### PR TITLE
Truncate long lines in editor

### DIFF
--- a/src/kernel/console.rs
+++ b/src/kernel/console.rs
@@ -71,6 +71,8 @@ pub fn key_handle(key: DecodedKey) {
             }
         }
     } else {
+        // TODO: Replace non-ascii chars by ascii square symbol to keep length
+        // at 1 instead of being variable?
         stdin.push(c);
         if is_echo_enabled() {
             print!("{}", c);


### PR DESCRIPTION
An attempt was made to support soft wrapping but truncating lines was easier. Horizontal scrolling will be needed to edit long lines in place without adding and removing temporary newlines.