### PR TITLE
Add PhysBuf for DMA

### DIFF
--- a/src/kernel/allocator.rs
+++ b/src/kernel/allocator.rs
@@ -3,10 +3,9 @@ use alloc::vec::Vec;
 use core::ops::{Index, IndexMut};
 use crate::kernel;
 use linked_list_allocator::LockedHeap;
-use x86_64::VirtAddr};
-use x86_64::mapper::MapToError;
-use x86_64::structures::paging;
-use x86_64::{ FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB };
+use x86_64::VirtAddr;
+use x86_64::structures::paging::mapper::MapToError;
+use x86_64::structures::paging::{ FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB };
 
 pub const HEAP_START: usize = 0x_4444_4444_0000;
 pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB

--- a/src/kernel/allocator.rs
+++ b/src/kernel/allocator.rs
@@ -1,10 +1,12 @@
+use alloc::slice::SliceIndex;
+use alloc::vec::Vec;
+use core::ops::{Index, IndexMut};
+use crate::kernel;
 use linked_list_allocator::LockedHeap;
-use x86_64::{
-    structures::paging::{
-        mapper::MapToError, FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB,
-    },
-    VirtAddr,
-};
+use x86_64::VirtAddr};
+use x86_64::mapper::MapToError;
+use x86_64::structures::paging;
+use x86_64::{ FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB };
 
 pub const HEAP_START: usize = 0x_4444_4444_0000;
 pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
@@ -32,4 +34,72 @@ pub fn init_heap(mapper: &mut impl Mapper<Size4KiB>, frame_allocator: &mut impl 
     }
 
     Ok(())
+}
+
+pub struct PhysBuf {
+    vec: Vec<u8>
+}
+
+impl PhysBuf {
+    pub fn new(len: usize) -> Self {
+        let mut vec: Vec<u8> = Vec::with_capacity(len);
+        vec.resize(len, 0);
+        Self::from(vec)
+    }
+
+    // Realloc vec until it uses a chunk of contiguous physical memory
+    fn from(vec: Vec<u8>) -> Self {
+        let buffer_len = vec.len() - 1;
+        let memory_len = phys_addr(&vec[buffer_len]) - phys_addr(&vec[0]);
+        if buffer_len == memory_len as usize {
+            Self { vec }
+        } else {
+            Self::from(vec.clone())
+        }
+    }
+
+    pub fn addr(&self) -> u64 {
+        phys_addr(&self.vec[0])
+    }
+}
+
+fn phys_addr(ptr: &u8) -> u64 {
+    let rx_ptr = ptr as *const u8;
+    let virt_addr = VirtAddr::new(rx_ptr as u64);
+    let phys_addr = kernel::mem::translate_addr(virt_addr).unwrap();
+    phys_addr.as_u64()
+}
+
+impl<I: SliceIndex<[u8]>> Index<I> for PhysBuf {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        Index::index(&**self, index)
+    }
+}
+
+impl<I: SliceIndex<[u8]>> IndexMut<I> for PhysBuf {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        IndexMut::index_mut(&mut **self, index)
+    }
+}
+
+impl core::ops::Deref for PhysBuf {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            alloc::slice::from_raw_parts(self.vec.as_ptr(), self.vec.len())
+        }
+    }
+}
+
+impl core::ops::DerefMut for PhysBuf {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe {
+            alloc::slice::from_raw_parts_mut(self.vec.as_mut_ptr(), self.vec.len())
+        }
+    }
 }

--- a/src/kernel/console.rs
+++ b/src/kernel/console.rs
@@ -44,7 +44,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => ({
-        let uptime = $crate::kernel::clock::clock_monotonic();
+        let uptime = $crate::kernel::clock::uptime();
         $crate::kernel::serial::print_fmt(format_args!("[{:.6}] ", uptime));
         $crate::kernel::serial::print_fmt(format_args!($($arg)*));
     });

--- a/src/kernel/time.rs
+++ b/src/kernel/time.rs
@@ -13,7 +13,6 @@ pub fn ticks() -> usize {
 pub fn sleep(duration: f64) {
     let interval = 1.0 / (1.193182 * 1000000.0 / 65536.0);
     let start = kernel::clock::uptime();
-    halt();
     while kernel::clock::uptime() - start < duration - interval {
         halt();
     }

--- a/src/user/dhcp.rs
+++ b/src/user/dhcp.rs
@@ -39,7 +39,13 @@ pub fn main(_args: &[&str]) -> user::shell::ExitCode {
             }
 
             let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
-            iface.poll(&mut sockets, timestamp).map(|_| ()).unwrap_or_else(|e| print!("Error: {:?}\n", e));
+            match iface.poll(&mut sockets, timestamp) {
+                Err(smoltcp::Error::Unrecognized) => {}
+                Err(e) => {
+                    print!("Network Error: {}\n", e);
+                }
+                Ok(_) => {}
+            }
             let config = dhcp.poll(&mut iface, &mut sockets, timestamp).unwrap_or_else(|e| {
                 print!("DHCP: {:?}\n", e);
                 None

--- a/src/user/dhcp.rs
+++ b/src/user/dhcp.rs
@@ -21,7 +21,7 @@ pub fn main(_args: &[&str]) -> user::shell::ExitCode {
             vec![0; 600]
         );
 
-        let timestamp = Instant::from_millis((kernel::clock::uptime() * 1000.0) as i64);
+        let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
         let mut dhcp = Dhcpv4Client::new(&mut sockets, dhcp_rx_buffer, dhcp_tx_buffer, timestamp);
 
         let mut prev_cidr = match iface.ip_addrs().first() {
@@ -30,14 +30,15 @@ pub fn main(_args: &[&str]) -> user::shell::ExitCode {
         };
 
         print!("DHCP Discover transmitted\n");
+        let timeout = 60.0;
         let time = kernel::clock::uptime();
         loop {
-            if kernel::clock::uptime() - time > 60.0 {
+            if kernel::clock::uptime() - time > timeout {
                 print!("Timeout reached\n");
                 return user::shell::ExitCode::CommandError;
             }
 
-            let timestamp = Instant::from_millis((kernel::clock::uptime() * 1000.0) as i64);
+            let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
             iface.poll(&mut sockets, timestamp).map(|_| ()).unwrap_or_else(|e| print!("Error: {:?}\n", e));
             let config = dhcp.poll(&mut iface, &mut sockets, timestamp).unwrap_or_else(|e| {
                 print!("DHCP: {:?}\n", e);
@@ -81,10 +82,10 @@ pub fn main(_args: &[&str]) -> user::shell::ExitCode {
                 return user::shell::ExitCode::CommandSuccessful;
             }
 
-            let mut timeout = dhcp.next_poll(timestamp);
-            iface.poll_delay(&sockets, timestamp).map(|sockets_timeout| timeout = sockets_timeout);
-            let wait_duration: Duration = timeout.into();
-            kernel::time::sleep(wait_duration.as_secs_f64());
+            let mut duration = dhcp.next_poll(timestamp);
+            iface.poll_delay(&sockets, timestamp).map(|sockets_timeout| duration = sockets_timeout);
+            let wait_duration: Duration = duration.into();
+            kernel::time::sleep(libm::fmin(wait_duration.as_secs_f64(), timeout));
         }
     }
 

--- a/src/user/host.rs
+++ b/src/user/host.rs
@@ -163,10 +163,11 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
 
             let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
             match iface.poll(&mut sockets, timestamp) {
-                Ok(_) => {},
-                Err(_) => {
-                    //print!("poll error: {}\n", e);
+                Err(smoltcp::Error::Unrecognized) => {}
+                Err(e) => {
+                    print!("Network Error: {}\n", e);
                 }
+                Ok(_) => {}
             }
 
             {

--- a/src/user/host.rs
+++ b/src/user/host.rs
@@ -154,17 +154,18 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
             _ => {}
         }
 
+        let timeout = 5.0;
         let time = kernel::clock::uptime();
         loop {
-            if kernel::clock::uptime() - time > 5.0 {
+            if kernel::clock::uptime() - time > timeout {
                 return Err(ResponseCode::NetworkError);
             }
 
-            let timestamp = Instant::from_millis((kernel::clock::uptime() * 1000.0) as i64);
+            let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
             match iface.poll(&mut sockets, timestamp) {
                 Ok(_) => {},
                 Err(e) => {
-                    print!("poll error: {}\n", e);
+                    //print!("poll error: {}\n", e);
                 }
             }
 
@@ -207,7 +208,7 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
 
             if let Some(wait_duration) = iface.poll_delay(&sockets, timestamp) {
                 let wait_duration: Duration = wait_duration.into();
-                kernel::time::sleep(wait_duration.as_secs_f64());
+                kernel::time::sleep(libm::fmin(wait_duration.as_secs_f64(), timeout));
             }
         }
     } else {

--- a/src/user/host.rs
+++ b/src/user/host.rs
@@ -164,7 +164,7 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
             let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
             match iface.poll(&mut sockets, timestamp) {
                 Ok(_) => {},
-                Err(e) => {
+                Err(_) => {
                     //print!("poll error: {}\n", e);
                 }
             }

--- a/src/user/http.rs
+++ b/src/user/http.rs
@@ -159,8 +159,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
                     }
                     State::Response if socket.can_recv() => {
                         socket.recv(|data| {
-                            let contents = str::from_utf8(data).unwrap_or("invalid UTF-8");
-                            let mut is_header = true;
+                            let contents = String::from_utf8_lossy(data);
                             for line in contents.lines() {
                                 if line.len() == 0 {
                                     is_header = false;

--- a/src/user/http.rs
+++ b/src/user/http.rs
@@ -39,20 +39,33 @@ impl URL {
 }
 
 pub fn main(args: &[&str]) -> user::shell::ExitCode {
+    // Parse command line options
     let mut is_verbose = false;
-    let args: Vec<_> = args.into_iter().filter(|arg| {
-        let arg = arg.to_string();
+    let mut args: Vec<String> = args.iter().map(ToOwned::to_owned).map(ToOwned::to_owned).filter(|arg| {
         if arg == "--verbose" {
             is_verbose = true;
         }
         !arg.starts_with("--")
     }).collect();
+
+    // Split <server> and <path>
+    if args.len() == 2 {
+        if let Some(i) = args[1].find('/') {
+            let arg = args[1].clone();
+            let (server, path) = arg.split_at(i);
+            args[1] = server.to_string();
+            args.push(path.to_string());
+        } else {
+            args.push("/".to_string());
+        }
+    }
+
     if args.len() != 3 {
         print!("Usage: http <server> <path>\n");
         return user::shell::ExitCode::CommandError;
     }
 
-    let url = "http://".to_owned() + args[1] + args[2];
+    let url = "http://".to_owned() + &args[1] + &args[2];
     let url = URL::parse(&url).expect("invalid URL format");
 
     let address = if url.host.ends_with(char::is_numeric) {
@@ -170,7 +183,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
                         break;
                     }
                     _ => state
-                }
+                };
             }
 
             if let Some(wait_duration) = iface.poll_delay(&sockets, timestamp) {

--- a/src/user/http.rs
+++ b/src/user/http.rs
@@ -102,11 +102,11 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
 
             let timestamp = Instant::from_millis((kernel::clock::realtime() * 1000.0) as i64);
             match iface.poll(&mut sockets, timestamp) {
-                Ok(_) => {},
+                Err(smoltcp::Error::Unrecognized) => {}
                 Err(e) => {
-                    print!("Interface polling error: {}\n", e);
-                    return user::shell::ExitCode::CommandError;
+                    print!("Network Error: {}\n", e);
                 }
+                Ok(_) => {}
             }
 
             {

--- a/src/user/http.rs
+++ b/src/user/http.rs
@@ -105,6 +105,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
             _ => {}
         }
 
+        let mut is_header = true;
         let timeout = 5.0;
         let time = kernel::clock::uptime();
         loop {


### PR DESCRIPTION
When we allocate on the heap, the next three frames after the first allocated frame are used to create new page tables, and are therefor unavailable.

If we allocate a buffer larger that the space available in the first frame, it will then use the fifth frame, but if we use the buffer for DMA the frames used for the page tables will be overwritten.

https://docs.rs/x86_64/0.8.3/x86_64/structures/paging/mapper/trait.Mapper.html#tymethod.map_to
https://docs.rs/x86_64/0.8.3/src/x86_64/structures/paging/mapper/mapped_page_table.rs.html#92