### PR TITLE
Handle RTC interrupts

### DIFF
--- a/src/kernel/clock.rs
+++ b/src/kernel/clock.rs
@@ -7,7 +7,7 @@ const DAYS_BEFORE_MONTH: [u64; 13] = [
 
 // NOTE: This clock is monotonic
 pub fn uptime() -> f64 {
-    1.0 / (1.193182 * 1000000.0 / 65536.0) * kernel::time::ticks() as f64
+    kernel::time::time_between_ticks() * kernel::time::ticks() as f64
 }
 
 // NOTE: This clock is not monotonic

--- a/src/kernel/clock.rs
+++ b/src/kernel/clock.rs
@@ -14,14 +14,17 @@ pub fn uptime() -> f64 {
 pub fn realtime() -> f64 {
     let rtc = CMOS::new().rtc(); // Assuming GMT
 
-    let t = 86400 * days_before_year(rtc.year as u64)
-          + 86400 * days_before_month(rtc.year as u64, rtc.month as u64)
-          + 86400 * (rtc.day - 1) as u64
-          +  3600 * rtc.hour as u64
-          +    60 * rtc.minute as u64
-          +         rtc.second as u64;
+    let timestamp = 86400 * days_before_year(rtc.year as u64)
+                  + 86400 * days_before_month(rtc.year as u64, rtc.month as u64)
+                  + 86400 * (rtc.day - 1) as u64
+                  +  3600 * rtc.hour as u64
+                  +    60 * rtc.minute as u64
+                  +         rtc.second as u64;
 
-    t as f64
+    let fract = kernel::time::time_between_ticks()
+              * (kernel::time::ticks() - kernel::time::last_rtc_update()) as f64;
+
+    (timestamp as f64) + fract
 }
 
 fn days_before_year(year: u64) -> u64 {

--- a/src/kernel/cmos.rs
+++ b/src/kernel/cmos.rs
@@ -89,11 +89,11 @@ impl CMOS {
         interrupts::without_interrupts(|| {
             self.disable_nmi();
             unsafe {
-                    self.addr.write(Register::A as u8);
-                    let prev = self.data.read();
-                    self.addr.write(Register::A as u8);
-                    self.data.write((prev & 0xF0) | rate);
-                }
+                self.addr.write(Register::A as u8);
+                let prev = self.data.read();
+                self.addr.write(Register::A as u8);
+                self.data.write((prev & 0xF0) | rate);
+            }
             self.enable_nmi();
             self.notify_end_of_interrupt();
         });

--- a/src/kernel/time.rs
+++ b/src/kernel/time.rs
@@ -1,10 +1,17 @@
-use crate::kernel;
 use lazy_static::lazy_static;
 use spin::Mutex;
 use crate::kernel::cmos::CMOS;
+use crate::kernel;
+use x86_64::instructions::interrupts;
+use x86_64::instructions::port::Port;
 
-const PIT_FREQUENCY: f64 = 3.579_545 / 3.0; // 1.193_181_666 Mhz
-const PIT_INTERVAL: f64 = 1.0 / (PIT_FREQUENCY * 1_000_000.0 / 65_536.0);
+// At boot the PIT starts with a frequency divider of 0 (equivalent to 65536)
+// which will result in about 54.926 ms between ticks.
+// During init we will change the divider to 1193 to have about 1.000 ms
+// between ticks to improve time measurements accuracy.
+const PIT_FREQUENCY: f64 = 3_579_545.0 / 3.0; // 1_193_181.666 Hz
+const PIT_DIVIDER: usize = 1193;
+const PIT_INTERVAL: f64 = (PIT_DIVIDER as f64) / PIT_FREQUENCY;
 
 lazy_static! {
     pub static ref PIT_TICKS: Mutex<usize> = Mutex::new(0);
@@ -35,9 +42,28 @@ pub fn halt() {
 }
 
 pub fn init() {
+    // PIT timmer
+    let divider = if PIT_DIVIDER < 65536 { PIT_DIVIDER } else { 0 };
+    set_pit_frequency_divider(divider as u16);
     kernel::idt::set_irq_handler(0, pit_interrupt_handler);
+
+    // RTC timmer
     kernel::idt::set_irq_handler(8, rtc_interrupt_handler);
     CMOS::new().enable_update_interrupt();
+}
+
+/// The frequency divider must be between 0 and 65535, with 0 acting as 65536
+fn set_pit_frequency_divider(divider: u16) {
+    interrupts::without_interrupts(|| {
+        let bytes = divider.to_le_bytes();
+        let mut cmd: Port<u8> = Port::new(0x43);
+        let mut data: Port<u8> = Port::new(0x40);
+        unsafe {
+            cmd.write(0x36);
+            data.write(bytes[0]);
+            data.write(bytes[1]);
+        }
+    });
 }
 
 pub fn pit_interrupt_handler() {

--- a/src/kernel/time.rs
+++ b/src/kernel/time.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use spin::Mutex;
 use crate::kernel::cmos::CMOS;
 
-const PIT_FREQUENCY: f64 = 1.193_182; // Mhz
+const PIT_FREQUENCY: f64 = 3.579_545 / 3.0; // 1.193_181_666 Mhz
 const PIT_INTERVAL: f64 = 1.0 / (PIT_FREQUENCY * 1_000_000.0 / 65_536.0);
 
 lazy_static! {

--- a/src/kernel/time.rs
+++ b/src/kernel/time.rs
@@ -1,12 +1,14 @@
 use crate::kernel;
 use lazy_static::lazy_static;
 use spin::Mutex;
+use crate::kernel::cmos::CMOS;
 
 const PIT_FREQUENCY: f64 = 1.193_182; // Mhz
 const PIT_INTERVAL: f64 = 1.0 / (PIT_FREQUENCY * 1_000_000.0 / 65_536.0);
 
 lazy_static! {
     pub static ref PIT_TICKS: Mutex<usize> = Mutex::new(0);
+    pub static ref LAST_RTC_UPDATE: Mutex<usize> = Mutex::new(0);
 }
 
 pub fn ticks() -> usize {
@@ -15,6 +17,10 @@ pub fn ticks() -> usize {
 
 pub fn time_between_ticks() -> f64 {
     PIT_INTERVAL
+}
+
+pub fn last_rtc_update() -> usize {
+    *LAST_RTC_UPDATE.lock()
 }
 
 pub fn sleep(duration: f64) {
@@ -30,9 +36,18 @@ pub fn halt() {
 
 pub fn init() {
     kernel::idt::set_irq_handler(0, pit_interrupt_handler);
+    kernel::idt::set_irq_handler(8, rtc_interrupt_handler);
+    CMOS::new().enable_update_interrupt();
 }
 
 pub fn pit_interrupt_handler() {
     let mut ticks = PIT_TICKS.lock();
     *ticks += 1;
+}
+
+pub fn rtc_interrupt_handler() {
+    let ticks = PIT_TICKS.lock();
+    let mut last_update = LAST_RTC_UPDATE.lock();
+    *last_update = *ticks;
+    CMOS::new().notify_end_of_interrupt();
 }


### PR DESCRIPTION
Keep track of last RTC update time and add fractional seconds to timestamps.