### PR TITLE
Add new date command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add new `date` and `env` commands (#112)
 - Add ACPI shutdown (#111)
 - Improve text editor (#109)
 - Add pcnet driver (#82)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
 name = "cpuio"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +235,7 @@ dependencies = [
  "sha2",
  "smoltcp",
  "spin 0.7.0",
+ "time",
  "uart_16550",
  "volatile",
  "vte",
@@ -265,6 +272,12 @@ checksum = "af2a5497fb8e59bf8015f67b7dff238d75ef445e03f23edac24ac3a8f09be952"
 dependencies = [
  "cpuio",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -385,10 +398,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "standback"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+
+[[package]]
+name = "syn"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "time"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
+dependencies = [
+ "const_fn",
+ "standback",
+ "time-macros",
+ "version_check",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
+]
 
 [[package]]
 name = "typenum"
@@ -417,6 +485,12 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "volatile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ uart_16550 = "0.2.7"
 volatile = "0.2.6"
 vte = "0.8.0"
 x86_64 = "0.12.2"
+time = { version = "0.2.22", default-features = false }

--- a/src/kernel/process.rs
+++ b/src/kernel/process.rs
@@ -37,6 +37,10 @@ pub fn env(key: &str) -> Option<String> {
     }
 }
 
+pub fn envs() -> BTreeMap<String, String> {
+    PROCESS.lock().env.clone()
+}
+
 pub fn dir() -> String {
     PROCESS.lock().dir.clone()
 }

--- a/src/user/date.rs
+++ b/src/user/date.rs
@@ -1,10 +1,13 @@
 use crate::{kernel, print, user};
-use time::OffsetDateTime;
+use time::{OffsetDateTime, Duration};
 
 pub fn main(args: &[&str]) -> user::shell::ExitCode {
     let timestamp = kernel::clock::realtime();
+    let nanos = libm::floor(1e9 * (timestamp - libm::floor(timestamp))) as i64;
+    let date = OffsetDateTime::from_unix_timestamp(timestamp as i64)
+             + Duration::nanoseconds(nanos);
+
     let format = if args.len() > 1 { args[1] } else { "%FT%T" };
-    let date = OffsetDateTime::from_unix_timestamp(timestamp as i64);
     match time::util::validate_format_string(format) {
         Ok(()) => {
             print!("{}\n", date.format(format));

--- a/src/user/date.rs
+++ b/src/user/date.rs
@@ -7,7 +7,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
     let date = OffsetDateTime::from_unix_timestamp(timestamp as i64)
              + Duration::nanoseconds(nanos);
 
-    let format = if args.len() > 1 { args[1] } else { "%FT%T" };
+    let format = if args.len() > 1 { args[1] } else { "%FT%H:%M:%S" };
     match time::util::validate_format_string(format) {
         Ok(()) => {
             print!("{}\n", date.format(format));

--- a/src/user/date.rs
+++ b/src/user/date.rs
@@ -1,11 +1,11 @@
 use crate::{kernel, print, user};
-use time::{OffsetDateTime, Duration};
+use time::{OffsetDateTime, Duration, UtcOffset};
 
 pub fn main(args: &[&str]) -> user::shell::ExitCode {
-    let timestamp = kernel::clock::realtime();
-    let nanos = libm::floor(1e9 * (timestamp - libm::floor(timestamp))) as i64;
-    let date = OffsetDateTime::from_unix_timestamp(timestamp as i64)
-             + Duration::nanoseconds(nanos);
+    let seconds = kernel::clock::realtime(); // Since Unix Epoch
+    let nanoseconds = libm::floor(1e9 * (seconds - libm::floor(seconds))) as i64;
+    let date = OffsetDateTime::from_unix_timestamp(seconds as i64).to_offset(offset())
+             + Duration::nanoseconds(nanoseconds);
 
     let format = if args.len() > 1 { args[1] } else { "%FT%H:%M:%S" };
     match time::util::validate_format_string(format) {
@@ -18,4 +18,13 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
             user::shell::ExitCode::CommandError
         }
     }
+}
+
+fn offset() -> UtcOffset {
+    if let Some(tz) = kernel::process::env("TZ") {
+        if let Ok(offset) = tz.parse::<i32>() {
+            return UtcOffset::seconds(offset);
+        }
+    }
+    UtcOffset::seconds(0)
 }

--- a/src/user/date.rs
+++ b/src/user/date.rs
@@ -1,46 +1,18 @@
-use crate::kernel::cmos::CMOS;
 use crate::{kernel, print, user};
-
-pub fn print_time_in_seconds(time: f64) {
-    if time < 1.0e3 {
-        print!("{:.3} seconds\n", time);
-    } else if time < 1.0e6 {
-        print!("{:.3} kiloseconds\n", time / 1.0e3);
-    } else if time < 1.0e9 {
-        print!("{:.3} megaseconds\n", time / 1.0e6);
-    } else {
-        print!("{:.3} gigaseconds\n", time / 1.0e9);
-    }
-}
-
-pub fn print_time_in_days(time: f64) {
-    if time < 0.01 {
-        print!("{:.2} dimidays\n", time * 10_000.0);
-    } else if time < 1.0 {
-        print!("{:.2} centidays\n", time * 100.0);
-    } else {
-        print!("{:.2} days\n", time);
-    }
-}
+use time::OffsetDateTime;
 
 pub fn main(args: &[&str]) -> user::shell::ExitCode {
-    if args.len() == 2 && args[1] == "--raw" {
-        print!("{:.6}\n", kernel::clock::realtime());
-    } else if args.len() == 2 && args[1] == "--metric" {
-        print_time_in_seconds(kernel::clock::realtime());
-    } else if args.len() == 2 && args[1] == "--iso-8601" {
-        let rtc = CMOS::new().rtc();
-        print!(
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}\n",
-            rtc.year, rtc.month, rtc.day,
-            rtc.hour, rtc.minute, rtc.second
-        );
-    } else {
-        let rtc = CMOS::new().rtc();
-        let seconds_since_midnight = rtc.hour as f64 * 3600.0
-                                   + rtc.minute as f64 * 60.0
-                                   + rtc.second as f64;
-        print_time_in_days(seconds_since_midnight / 86400.0);
+    let timestamp = kernel::clock::realtime();
+    let format = if args.len() > 1 { args[1] } else { "%FT%T" };
+    let date = OffsetDateTime::from_unix_timestamp(timestamp as i64);
+    match time::util::validate_format_string(format) {
+        Ok(()) => {
+            print!("{}\n", date.format(format));
+            user::shell::ExitCode::CommandSuccessful
+        }
+        Err(e) => {
+            print!("Error: {}\n", e);
+            user::shell::ExitCode::CommandError
+        }
     }
-    user::shell::ExitCode::CommandSuccessful
 }

--- a/src/user/env.rs
+++ b/src/user/env.rs
@@ -1,0 +1,22 @@
+use crate::{kernel, print, user};
+
+pub fn main(args: &[&str]) -> user::shell::ExitCode {
+    if args.len() == 1 {
+        for (key, val) in kernel::process::envs() {
+            print!("{}={}\n", key, val);
+        }
+    } else {
+        for arg in args[1..].iter() {
+            if let Some(i) = arg.find('=') {
+                let (key, mut val) = arg.split_at(i);
+                val = &val[1..];
+                kernel::process::set_env(key, val);
+                print!("{}={}\n", key, val);
+            } else {
+                print!("Error: could not parse '{}'\n", arg);
+                return user::shell::ExitCode::CommandError;
+            }
+        }
+    }
+    user::shell::ExitCode::CommandSuccessful
+}

--- a/src/user/help.rs
+++ b/src/user/help.rs
@@ -11,6 +11,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
 
 fn help_command(cmd: &str) -> user::shell::ExitCode {
     match cmd {
+        "date" => help_date(),
         "edit" => help_edit(),
         _      => help_unknown(cmd),
     }
@@ -76,6 +77,56 @@ fn help_edit() -> user::shell::ExitCode {
         let csi_color = Style::color("LightGreen");
         let csi_reset = Style::reset();
         print!("  {}{}{}    {}\n", csi_color, shortcut, csi_reset, usage);
+    }
+    user::shell::ExitCode::CommandSuccessful
+}
+
+fn help_date() -> user::shell::ExitCode {
+    let csi_color = Style::color("Yellow");
+    let csi_reset = Style::reset();
+    print!("The date command's formatting behavior is based on strftime in C\n");
+    print!("\n");
+    print!("{}Specifiers:{}\n", csi_color, csi_reset);
+    print!("\n");
+
+    let specifiers = [
+        ("%a", "Abbreviated weekday name", "Thu"),
+        ("%A", "Full weekday name", "Thursday"),
+        ("%b", "Abbreviated month name", "Aug"),
+        ("%B", "Full month name", "August"),
+        ("%c", "Date and time representation, equivalent to %a %b %-d %-H:%M:%S %-Y", "Thu Aug 23 14:55:02 2001"),
+        ("%C", "Year divided by 100 and truncated to integer (00-99)", "20"),
+        ("%d", "Day of the month, zero-padded (01-31)", "23"),
+        ("%D", "Short MM/DD/YY date, equivalent to %-m/%d/%y", "8/23/01"),
+        ("%F", "Short YYYY-MM-DD date, equivalent to %-Y-%m-%d", "2001-08-23"),
+        ("%g", "Week-based year, last two digits (00-99)", "01"),
+        ("%G", "Week-based year", "2001"),
+        ("%H", "Hour in 24h format (00-23)", "14"),
+        ("%I", "Hour in 12h format (01-12)", "02"),
+        ("%j", "Day of the year (001-366)", "235"),
+        ("%m", "Month as a decimal number (01-12)", "08"),
+        ("%M", "Minute (00-59)", "55"),
+        ("%N", "Subsecond nanoseconds. Always 9 digits", "012345678"),
+        ("%p", "am or pm designation", "pm"),
+        ("%P", "AM or PM designation", "PM"),
+        ("%r", "12-hour clock time, equivalent to %-I:%M:%S %p", "2:55:02 pm"),
+        ("%R", "24-hour HH:MM time, equivalent to %-H:%M", "14:55"),
+        ("%S", "Second (00-59)", "02"),
+        ("%T", "24-hour clock time with seconds, equivalent to %-H:%M:%S", "14:55:02"),
+        ("%u", "ISO 8601 weekday as number with Monday as 1 (1-7)", "4"),
+        ("%U", "Week number with the first Sunday as the start of week one (00-53)", "33"),
+        ("%V", "ISO 8601 week number (01-53)", "34"),
+        ("%w", "Weekday as a decimal number with Sunday as 0 (0-6)", "4"),
+        ("%W", "Week number with the first Monday as the start of week one (00-53)", "34"),
+        ("%y", "Year, last two digits (00-99)", "01"),
+        ("%Y", "Full year, including + if ≥10,000", "2001"),
+        ("%z", "ISO 8601 offset from UTC in timezone (+HHMM)", "+0100"),
+        ("%%", "Literal %", "%"),
+    ];
+    for (specifier, usage, _exemple) in &specifiers {
+        let csi_color = Style::color("LightGreen");
+        let csi_reset = Style::reset();
+        print!("  {}{}{}    {}\n", csi_color, specifier, csi_reset, usage);
     }
     user::shell::ExitCode::CommandSuccessful
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -7,6 +7,7 @@ pub mod delete;
 pub mod dhcp;
 pub mod disk;
 pub mod editor;
+pub mod env;
 pub mod geotime;
 pub mod halt;
 pub mod help;

--- a/src/user/read.rs
+++ b/src/user/read.rs
@@ -1,4 +1,5 @@
 use crate::{kernel, print, user};
+use crate::kernel::cmos::CMOS;
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
@@ -11,13 +12,21 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
 
     match pathname {
         "/dev/rtc" => {
-            user::date::main(&["date", "--iso-8601"])
+            let rtc = CMOS::new().rtc();
+            print!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}\n",
+                rtc.year, rtc.month, rtc.day,
+                rtc.hour, rtc.minute, rtc.second
+            );
+            user::shell::ExitCode::CommandSuccessful
         },
         "/dev/clk/realtime" => {
-            user::date::main(&["date", "--raw"])
+            print!("{:.6}\n", kernel::clock::realtime());
+            user::shell::ExitCode::CommandSuccessful
         },
         "/dev/clk/uptime" => {
-            user::uptime::main(&["uptime", "--raw"])
+            print!("{:.6}\n", kernel::clock::uptime());
+            user::shell::ExitCode::CommandSuccessful
         },
         _ => {
             if pathname.starts_with("/net/") {

--- a/src/user/shell.rs
+++ b/src/user/shell.rs
@@ -407,6 +407,7 @@ impl Shell {
             "sleep"                => user::sleep::main(&args),
             "clear"                => user::clear::main(&args),
             "base64"               => user::base64::main(&args),
+            "date"                 => user::date::main(&args),
             "halt"                 => user::halt::main(&args),
             "hex"                  => user::hex::main(&args), // TODO: Rename to `dump`
             "net"                  => user::net::main(&args),

--- a/src/user/shell.rs
+++ b/src/user/shell.rs
@@ -408,6 +408,7 @@ impl Shell {
             "clear"                => user::clear::main(&args),
             "base64"               => user::base64::main(&args),
             "date"                 => user::date::main(&args),
+            "env"                  => user::env::main(&args),
             "halt"                 => user::halt::main(&args),
             "hex"                  => user::hex::main(&args), // TODO: Rename to `dump`
             "net"                  => user::net::main(&args),

--- a/src/user/uptime.rs
+++ b/src/user/uptime.rs
@@ -1,13 +1,6 @@
 use crate::{kernel, print, user};
 
-pub fn main(args: &[&str]) -> user::shell::ExitCode {
-    let time = kernel::clock::uptime();
-    if args.len() == 2 && args[1] == "--raw" {
-        print!("{:.6}\n", time);
-    } else if args.len() == 2 && args[1] == "--metric" {
-        user::date::print_time_in_seconds(time);
-    } else {
-        user::date::print_time_in_days(time / 86400.0);
-    }
+pub fn main(_args: &[&str]) -> user::shell::ExitCode {
+    print!("{:.6}\n", kernel::clock::uptime());
     user::shell::ExitCode::CommandSuccessful
 }


### PR DESCRIPTION
Back when MOROS was using `cargo-xbuild` we couldn't compile the `time` crate (https://github.com/time-rs/time/issues/268) but now that it doesn't use it anymore (https://github.com/vinc/moros/pull/83) we can compile it.

So we can now have a new `date` command that accepts formatting (https://time-rs.github.io/time/time/index.html#formatting).

```
> date
2020-11-08T23:47:02

> date "%A, %B %d, %Y"
Sunday, November 08, 2020
```