### PR TITLE
Use ChaCha20 RNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,9 @@ dependencies = [
  "pbkdf2",
  "pc-keyboard",
  "pic8259_simple",
+ "rand",
+ "rand_chacha",
+ "rand_core",
  "raw-cpuid",
  "sha2",
  "smoltcp",
@@ -273,6 +276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +303,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ linked_list_allocator = "0.8.4"
 pbkdf2 = { version = "0.3.0", default-features = false }
 pc-keyboard = "0.5.1"
 pic8259_simple = "0.2.0"
+rand = { version = "0.7.3", default-features = false }
+rand_chacha = { version = "0.2.2", default-features = false }
+rand_core = { version = "0.5.1", default-features = false }
 raw-cpuid = "8.1.0"
 sha2 = { version = "0.8.2", default-features = false }
 smoltcp = { version = "0.6.0", default-features = false, features = ["alloc", "ethernet", "socket-tcp", "socket-udp", "proto-ipv4", "proto-dhcpv4"] }

--- a/src/kernel/random.rs
+++ b/src/kernel/random.rs
@@ -1,22 +1,28 @@
+use rand_chacha::ChaChaRng;
+use rand_core::{RngCore, SeedableRng};
 use x86_64::instructions::random::RdRand;
 
-pub fn rand64() -> Option<u64> {
-    match RdRand::new() {
-        Some(rand) => rand.get_u64(),
-        None => None,
+pub fn get_u64() -> u64 {
+    let mut seed = [0u8; 32];
+    if let Some(rdrand) = RdRand::new() {
+        for i in 0..4 {
+            if let Some(rand) = rdrand.get_u64() {
+                let bytes = rand.to_be_bytes();
+                for j in 0..8 {
+                    seed[8 * i + j] = bytes[j];
+                }
+            }
+        }
     }
+
+    let mut chacha = ChaChaRng::from_seed(seed);
+    chacha.next_u64()
 }
 
-pub fn rand32() -> Option<u32> {
-    match RdRand::new() {
-        Some(rand) => rand.get_u32(),
-        None => None,
-    }
+pub fn get_u32() -> u32 {
+    get_u64() as u32
 }
 
-pub fn rand16() -> Option<u16> {
-    match RdRand::new() {
-        Some(rand) => rand.get_u16(),
-        None => None,
-    }
+pub fn get_u16() -> u16 {
+    get_u64() as u16
 }

--- a/src/user/host.rs
+++ b/src/user/host.rs
@@ -58,7 +58,7 @@ impl Message {
     pub fn query(qname: &str, qtype: QueryType, qclass: QueryClass) -> Self {
         let mut datagram = Vec::new();
 
-        let id = kernel::random::rand16().expect("random id");
+        let id = kernel::random::get_u16();
         for b in id.to_be_bytes().iter() {
             datagram.push(*b); // Transaction ID
         }
@@ -124,7 +124,7 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
     let dns_port = 53;
     let server = IpEndpoint::new(dns_address, dns_port);
 
-    let local_port = 49152 + kernel::random::rand16().expect("random port") % 16384;
+    let local_port = 49152 + kernel::random::get_u16() % 16384;
     let client = IpEndpoint::new(IpAddress::Unspecified, local_port);
 
     let qname = name;

--- a/src/user/http.rs
+++ b/src/user/http.rs
@@ -129,7 +129,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
 
                 state = match state {
                     State::Connect if !socket.is_active() => {
-                        let local_port = 49152 + kernel::random::rand16().expect("random port") % 16384;
+                        let local_port = 49152 + kernel::random::get_u16() % 16384;
                         if is_verbose {
                             print!("* Connecting to {}:{}\n", address, url.port);
                         }

--- a/src/user/read.rs
+++ b/src/user/read.rs
@@ -28,6 +28,15 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
             print!("{:.6}\n", kernel::clock::uptime());
             user::shell::ExitCode::CommandSuccessful
         },
+        "/dev/random" => {
+            loop {
+                // Generate ASCII graphic chars
+                let i = (kernel::random::get_u32() % (0x72 - 0x20)) + 0x20;
+                if let Some(c) = core::char::from_u32(i) {
+                    print!("{}", c);
+                }
+            }
+        },
         _ => {
             if pathname.starts_with("/net/") {
                 // Examples:

--- a/src/user/shell.rs
+++ b/src/user/shell.rs
@@ -14,11 +14,12 @@ const AUTOCOMPLETE_COMMANDS: [&str; 29] = [
 ];
 
 // TODO: Scan /dev
-const AUTOCOMPLETE_DEVICES: [&str; 5] = [
+const AUTOCOMPLETE_DEVICES: [&str; 6] = [
     "/dev/ata",
     "/dev/clk",
     "/dev/clk/uptime",
     "/dev/clk/realtime",
+    "/dev/random",
     "/dev/rtc",
 ];
 

--- a/src/user/tcp.rs
+++ b/src/user/tcp.rs
@@ -90,7 +90,7 @@ pub fn main(args: &[&str]) -> user::shell::ExitCode {
 
                 state = match state {
                     State::Connect if !socket.is_active() => {
-                        let local_port = 49152 + kernel::random::rand16().expect("random port") % 16384;
+                        let local_port = 49152 + kernel::random::get_u16() % 16384;
                         print!("Connecting to {}:{}\n", address, port);
                         if socket.connect((address, port), local_port).is_err() {
                             print!("Could not connect to {}:{}\n", address, port);

--- a/src/user/user.rs
+++ b/src/user/user.rs
@@ -147,7 +147,7 @@ pub fn hash(password: &str) -> String {
 
     // Generating salt
     for i in 0..2 {
-        let num = kernel::random::rand64().unwrap();
+        let num = kernel::random::get_u64();
         let buf = num.to_be_bytes();
         let n = buf.len();
         for j in 0..n {


### PR DESCRIPTION
Revisit https://github.com/vinc/moros/pull/2 now that we can build the rand crates.

This PR uses ChaCha20 RNG as a source of randomness in the OS and the RDRAND instruction will seed it if available.