### PR TITLE
Use CSI for key events

### DIFF
--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -145,9 +145,6 @@ impl Editor {
                     csi = true;
                     continue;
                 },
-                _ => {},
-            }
-            match c {
                 '\0' => {
                     continue;
                 }

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -131,9 +131,22 @@ impl Editor {
         sys::vga::set_cursor_position(0, 0);
         sys::vga::set_writer_position(0, 0);
 
+        let mut escape = false;
+        let mut csi = false;
         loop {
             let (mut x, mut y) = sys::vga::cursor_position();
             let c = sys::console::get_char();
+            match c {
+                '\x1B' => { // ESC
+                    escape = true;
+                    continue;
+                },
+                '[' if escape => {
+                    csi = true;
+                    continue;
+                },
+                _ => {},
+            }
             match c {
                 '\0' => {
                     continue;
@@ -163,7 +176,7 @@ impl Editor {
                     self.dx = 0;
                     self.print_screen();
                 },
-                '↑' => { // Arrow up
+                'A' if csi => { // Arrow up
                     if y > 0 {
                         y -= 1
                     } else {
@@ -174,7 +187,7 @@ impl Editor {
                     }
                     x = self.next_pos(x, y);
                 },
-                '↓' => { // Arrow down
+                'B' if csi => { // Arrow down
                     let is_eof = self.dy + y == self.lines.len() - 1;
                     let is_bottom = y == self.height() - 1;
                     if y < cmp::min(self.height(), self.lines.len() - 1) {
@@ -189,19 +202,7 @@ impl Editor {
                         x = self.next_pos(x, y);
                     }
                 },
-                '←' => { // Arrow left
-                    if x + self.dx == 0 {
-                        continue;
-                    } else if x == 0 {
-                        x = self.dx - 1;
-                        self.dx -= self.width();
-                        self.print_screen();
-                        x = self.next_pos(x, y);
-                    } else {
-                        x -= 1;
-                    }
-                },
-                '→' => { // Arrow right
+                'C' if csi => { // Arrow right
                     let line = &self.lines[self.dy + y];
                     if line.len() == 0 || x + self.dx >= line.len() {
                         continue
@@ -211,6 +212,18 @@ impl Editor {
                         self.print_screen();
                     } else {
                         x += 1;
+                    }
+                },
+                'D' if csi => { // Arrow left
+                    if x + self.dx == 0 {
+                        continue;
+                    } else if x == 0 {
+                        x = self.dx - 1;
+                        self.dx -= self.width();
+                        self.print_screen();
+                        x = self.next_pos(x, y);
+                    } else {
+                        x -= 1;
                     }
                 },
                 '\x14' => { // Ctrl T -> Go to top of file
@@ -321,6 +334,8 @@ impl Editor {
                     }
                 },
             }
+            escape = false;
+            csi = false;
             sys::vga::set_cursor_position(x, y);
             sys::vga::set_writer_position(x, y);
         }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -73,9 +73,6 @@ impl Shell {
                     csi = true;
                     continue;
                 },
-                _ => {},
-            }
-            match c {
                 '\0' => {
                     continue;
                 }


### PR DESCRIPTION
Initially some unicode chars where used for the arrow keys, but switching from ASCII to Extended ASCII introduced a visual bug for login and other programs reading an input line.

Dealing with unicode as bytes is error prone. This PR replace the unicode chars for arrow keys with their classic CSI equivalent. Userspace programs need to be updated because getting the char sequence for an arrow key require 3 calls to `console::get_char` instead of one, but this solution is more portable. It also mean the we will be able to be more interactive in serial mode.

https://en.wikipedia.org/wiki/ANSI_escape_code