### PR TITLE
Refactor line editing

### DIFF
--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -1,3 +1,4 @@
+use crate::sys;
 use core::fmt;
 
 pub struct Style {
@@ -81,3 +82,14 @@ fn color_to_bg(name: &str) -> Option<usize> {
     }
 }
 
+pub fn read_char() -> Option<char> {
+    Some(sys::console::get_char())
+}
+
+pub fn is_printable(c: char) -> bool {
+    if cfg!(feature = "video") {
+        c.is_ascii() && sys::vga::is_printable(c as u8)
+    } else {
+        true // TODO
+    }
+}

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -1,0 +1,51 @@
+use crate::sys;
+use alloc::string::{String, ToString};
+
+pub fn canonicalize(path: &str) -> Result<String, ()> {
+    match sys::process::env("HOME") {
+        Some(home) => {
+            if path.starts_with("~") {
+                Ok(path.replace("~", &home))
+            } else {
+                Ok(path.to_string())
+            }
+        },
+        None => {
+            Ok(path.to_string())
+        }
+    }
+}
+
+pub fn read_to_string(path: &str) -> Result<String, ()> {
+    let path = match canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return Err(()),
+    };
+    match sys::fs::File::open(&path) {
+        Some(mut file) => {
+            Ok(file.read_to_string())
+        },
+        None => {
+            Err(())
+        }
+    }
+}
+
+pub fn write(path: &str, buf: &[u8]) -> Result<(), ()> {
+    let path = match canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return Err(()),
+    };
+    let mut file = match sys::fs::File::open(&path) {
+        None => match sys::fs::File::create(&path) {
+            None => return Err(()),
+            Some(file) => file,
+        },
+        Some(file) => file,
+    };
+    // TODO: add File::write_all to split buf if needed
+    match file.write(buf) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(()),
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,5 +18,7 @@ macro_rules! println {
 
 pub mod console;
 pub mod font;
+pub mod fs;
+pub mod prompt;
 pub mod syscall;
 pub mod vga;

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -1,0 +1,171 @@
+use crate::api::fs;
+use crate::api::console;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+pub struct Prompt {
+    pub history: History,
+    offset: usize, // Offset cursor position by prompt length
+}
+
+impl Prompt {
+    pub fn new() -> Self {
+        Self {
+            history: History::new(),
+            offset: 0,
+        }
+    }
+
+    pub fn input(&mut self, prompt: &str) -> Option<String> {
+        print!("{}", prompt);
+        self.offset = strip_csi(prompt).len();
+        let mut cursor = self.offset;
+        let mut line = String::new();
+        let mut escape_sequence = false;
+        let mut control_sequence = false;
+        while let Some(c) = console::read_char() {
+            match c {
+                '\x03' => { // End of Text (^C)
+                    print!("\n");
+                    return None;
+                },
+                '\x04' => { // End of Transmission (^D)
+                    print!("\n");
+                    return None;
+                },
+                '\x1b' => {
+                    escape_sequence = true;
+                    continue;
+                },
+                '[' if escape_sequence => {
+                    control_sequence = true;
+                    continue;
+                },
+                'A' if control_sequence => { // Cursor Up
+                    // TODO: Navigate history up
+                },
+                'B' if control_sequence => { // Cursor Down
+                    // TODO: Navigate history down
+                },
+                'C' if control_sequence => { // Cursor Forward
+                    if cursor < self.offset + line.len() {
+                        print!("\x1b[1C");
+                        cursor += 1;
+                    }
+                },
+                'D' if control_sequence => { // Cursor Backward
+                    if cursor > self.offset {
+                        print!("\x1b[1D");
+                        cursor -= 1;
+                    }
+                },
+                '\n' => { // New Line
+                    print!("{}", c);
+                    return Some(line);
+                },
+                '\x08' => { // Backspace
+                    if cursor > self.offset {
+                        let i = cursor - self.offset - 1;
+                        line.remove(i);
+                        let s = &line[i..];
+                        print!("{}{} \x1b[{}D", c, s, s.len() + 1);
+                        cursor -= 1;
+                    }
+                },
+                /*
+                '\x7f' => { // Delete
+                    let i = cursor - self.offset;
+                    line.remove(i);
+                    let s = &line[i..];
+                    print!("{}{} \x1b[{}D", c, s, s.len() + 1);
+                },
+                */
+                _ => {
+                    if console::is_printable(c) {
+                        let i = cursor - self.offset;
+                        line.insert(i, c);
+                        let s = &line[i..];
+                        print!("{} \x1b[{}D", s, s.len());
+                        cursor += 1;
+                    }
+                },
+            } 
+            escape_sequence = false;
+            control_sequence = false;
+        }
+
+        None
+    }
+}
+
+pub struct History {
+    entries: Vec<String>,
+    limit: usize,
+}
+
+impl History {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            limit: 1000,
+        }
+    }
+
+    pub fn load(&mut self, path: &str) {
+        if let Ok(lines) = fs::read_to_string(path) {
+            self.entries = lines.split("\n").map(|s| s.to_string()).collect();
+        }
+    }
+
+    pub fn save(&mut self, path: &str) {
+        fs::write(path, self.entries.join("\n").as_bytes()).ok();
+    }
+
+    pub fn add(&mut self, entry: &str) {
+        // Remove duplicated entries
+        let mut i = 0;
+        while i < self.entries.len() {
+            if self.entries[i] == entry {
+                self.entries.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+
+        self.entries.push(entry.to_string());
+
+        // Remove oldest entries if limit is reached
+        while self.entries.len() > self.limit {
+            self.entries.remove(0);
+        }
+    }
+}
+
+fn strip_csi(s: &str) -> String {
+    let mut res = String::new();
+    let mut escape_sequence = false;
+    let mut control_sequence = false;
+    for c in s.chars() {
+        match c {
+            '\x1b' => {
+                escape_sequence = true;
+                continue;
+            },
+            '[' if escape_sequence => {
+                control_sequence = true;
+                continue;
+            },
+            'a'..='z' | 'A'..='Z' if control_sequence => {
+                escape_sequence = false;
+                control_sequence = false;
+            },
+            _ if control_sequence => {
+                continue;
+            },
+            _ => {
+                res.push(c);
+            },
+        }
+    }
+    res
+}

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -111,6 +111,18 @@ impl Perform for Prompt {
                     self.cursor -= 1;
                 }
             },
+            '~' => {
+                for param in params.iter() {
+                    if param[0] == 3 { // Delete
+                        if self.cursor < self.offset + self.line.len() {
+                            let i = self.cursor - self.offset;
+                            self.line.remove(i);
+                            let s = &self.line[i..];
+                            print!("{} \x1b[{}D", s, s.len() + 1);
+                        }
+                    }
+                }
+            },
             _ => {},
         }
     }

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -72,14 +72,14 @@ impl Prompt {
                         cursor -= 1;
                     }
                 },
-                /*
                 '\x7f' => { // Delete
-                    let i = cursor - self.offset;
-                    line.remove(i);
-                    let s = &line[i..];
-                    print!("{}{} \x1b[{}D", c, s, s.len() + 1);
+                    if cursor < self.offset + line.len() {
+                        let i = cursor - self.offset;
+                        line.remove(i);
+                        let s = &line[i..];
+                        print!("{} \x1b[{}D", s, s.len() + 1);
+                    }
                 },
-                */
                 _ => {
                     if console::is_printable(c) {
                         let i = cursor - self.offset;

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -177,6 +177,7 @@ pub fn drain() {
     })
 }
 
+// TODO: Rename to `read_char()`
 pub fn get_char() -> char {
     sys::console::disable_echo();
     sys::console::enable_raw();
@@ -198,6 +199,7 @@ pub fn get_char() -> char {
     }
 }
 
+// TODO: Rename to `read_line()`
 pub fn get_line() -> String {
     loop {
         sys::time::halt();

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -12,6 +12,22 @@ lazy_static! {
     pub static ref RAW: Mutex<bool> = Mutex::new(false);
 }
 
+pub fn cols() -> usize {
+    if cfg!(feature = "video") {
+        sys::vga::cols()
+    } else {
+        80
+    }
+}
+
+pub fn rows() -> usize {
+    if cfg!(feature = "video") {
+        sys::vga::rows()
+    } else {
+        25
+    }
+}
+
 pub fn has_cursor() -> bool {
     cfg!(feature = "video")
 }
@@ -23,6 +39,18 @@ pub fn clear_row_after(x: usize) {
         sys::serial::print_fmt(format_args!("\r")); // Move cursor to begining of line
         sys::serial::print_fmt(format_args!("\x1b[{}C", x)); // Move cursor forward to position
         sys::serial::print_fmt(format_args!("\x1b[K")); // Clear line after position
+    }
+}
+
+pub fn clear_row() {
+    clear_row_after(0);
+}
+
+pub fn clear_screen() {
+    if cfg!(feature = "video") {
+        sys::vga::clear_screen();
+    } else {
+        sys::serial::print_fmt(format_args!("\x1b[2J"));
     }
 }
 
@@ -52,6 +80,14 @@ pub fn cursor_position() -> (usize, usize) {
             }
         }
         (x.parse().unwrap_or(1), y.parse().unwrap_or(1))
+    }
+}
+
+pub fn set_cursor_position(x: usize, y: usize) {
+    if cfg!(feature = "video") {
+        sys::vga::set_cursor_position(x, y);
+    } else {
+        sys::serial::print_fmt(format_args!("\x1b[{};{}H", y + 1, x + 1));
     }
 }
 

--- a/src/sys/fs.rs
+++ b/src/sys/fs.rs
@@ -300,7 +300,7 @@ impl Block {
 const BITMAP_SIZE: u32 = 512 - 4; // TODO: Bitmap should use the full block
 const MAX_BLOCKS: u32 = 2 * 2048;
 
-const DISK_OFFSET: u32 = (1 << 20) / 512;
+const DISK_OFFSET: u32 = 4 << 10; // Leave space for kernel binary
 const SUPERBLOCK_ADDR: u32 = DISK_OFFSET;
 const BITMAP_ADDR_OFFSET: u32 = DISK_OFFSET + 2;
 const DATA_ADDR_OFFSET: u32 = BITMAP_ADDR_OFFSET + MAX_BLOCKS / 8;

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -305,9 +305,9 @@ impl Perform for Writer {
 
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let mut state_machine = PARSER.lock();
+        let mut parser = PARSER.lock();
         for byte in s.bytes() {
-            state_machine.advance(self, byte);
+            parser.advance(self, byte);
         }
         let (x, y) = self.writer_position();
         self.set_cursor_position(x, y);

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -305,11 +305,11 @@ pub fn clear_row_after(x: usize) {
     set_writer_position(x, y);
 }
 
-pub fn screen_width() -> usize {
+pub fn cols() -> usize {
     BUFFER_WIDTH
 }
 
-pub fn screen_height() -> usize {
+pub fn rows() -> usize {
     BUFFER_HEIGHT
 }
 

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -89,6 +89,7 @@ fn copy_file(pathname: &str, buf: &[u8]) {
         } else {
             file.write(buf).unwrap();
         }
+        // TODO: add File::write_all to split buf if needed
         println!("Copied '{}'", pathname);
     }
 }

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -498,7 +498,7 @@ fn lisp_completer(line: &str) -> Vec<String> {
             let f = &last_word[1..];
             for form in COMPLETER_FORMS {
                 if form.starts_with(f) {
-                    entries.push(form[f.len()..].to_string());
+                    entries.push(form[f.len()..].into());
                 }
             }
         }
@@ -508,14 +508,18 @@ fn lisp_completer(line: &str) -> Vec<String> {
 
 fn repl(env: &mut Env) -> usr::shell::ExitCode {
     print!("MOROS Lisp v0.1.0\n\n");
+
     let csi_color = Style::color("Cyan");
     let csi_error = Style::color("Red");
     let csi_reset = Style::reset();
+    let prompt_string = format!("{}>{} ", csi_color, csi_reset);
+
     let mut prompt = Prompt::new();
     let history_file = "~/.lisp-history";
     prompt.history.load(history_file);
     prompt.completion.set(&lisp_completer);
-    while let Some(exp) = prompt.input(&format!("{}>{} ", csi_color, csi_reset)) {
+
+    while let Some(exp) = prompt.input(&prompt_string) {
         if exp == "(exit)" {
             break;
         }

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -485,6 +485,27 @@ fn strip_comments(s: &str) -> String {
     s.split("#").next().unwrap().into()
 }
 
+
+const COMPLETER_FORMS: [&str; 11] = [
+    "quote", "atom?", "eq?", "first", "rest", "cons", "cond", "def", "fn",
+    "defn", "print",
+];
+
+fn lisp_completer(line: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+    if let Some(last_word) = line.split_whitespace().next_back() {
+        if last_word.starts_with("(") {
+            let f = &last_word[1..];
+            for form in COMPLETER_FORMS {
+                if form.starts_with(f) {
+                    entries.push(form[f.len()..].to_string());
+                }
+            }
+        }
+    }
+    entries
+}
+
 fn repl(env: &mut Env) -> usr::shell::ExitCode {
     print!("MOROS Lisp v0.1.0\n\n");
     let csi_color = Style::color("Cyan");
@@ -493,6 +514,7 @@ fn repl(env: &mut Env) -> usr::shell::ExitCode {
     let mut prompt = Prompt::new();
     let history_file = "~/.lisp-history";
     prompt.history.load(history_file);
+    prompt.completion.set(&lisp_completer);
     while let Some(exp) = prompt.input(&format!("{}>{} ", csi_color, csi_reset)) {
         if exp == "(exit)" {
             break;

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -491,19 +491,24 @@ fn repl(env: &mut Env) -> usr::shell::ExitCode {
     let csi_error = Style::color("Red");
     let csi_reset = Style::reset();
     let mut prompt = Prompt::new();
-    //let history_file = "~/.lisp-history";
-    //prompt.history.load(history_file);
+    let history_file = "~/.lisp-history";
+    prompt.history.load(history_file);
     while let Some(exp) = prompt.input(&format!("{}>{} ", csi_color, csi_reset)) {
         if exp == "(exit)" {
             break;
         }
         match parse_eval(&exp, env) {
-            Ok(res) => print!("{}\n\n", res),
+            Ok(res) => {
+                print!("{}\n\n", res);
+            }
             Err(e) => match e {
                 Err::Reason(msg) => print!("{}Error: {}{}\n\n", csi_error, msg, csi_reset),
             },
         }
-        //prompt.history.save(history_file);
+        if exp.len() > 0 {
+            prompt.history.add(&exp);
+            prompt.history.save(history_file);
+        }
     }
     usr::shell::ExitCode::CommandSuccessful
 }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -1,4 +1,5 @@
 use crate::{sys, usr};
+use crate::api::console;
 use crate::api::console::Style;
 use alloc::format;
 use alloc::vec;
@@ -217,7 +218,7 @@ impl Shell {
                 c => {
                     self.update_history();
                     self.update_autocomplete();
-                    if c.is_ascii() && sys::vga::is_printable(c as u8) {
+                    if console::is_printable(c) {
                         if sys::console::has_cursor() {
                             let cmd = self.cmd.clone();
                             let (before_cursor, after_cursor) = cmd.split_at(x - self.prompt.len());

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -1,27 +1,16 @@
+use crate::api::prompt::Prompt;
 use crate::{sys, usr};
-use crate::api::console;
 use crate::api::console::Style;
 use alloc::format;
-use alloc::vec;
 use alloc::vec::Vec;
 use alloc::string::String;
 
 // TODO: Scan /bin
-const AUTOCOMPLETE_COMMANDS: [&str; 29] = [
-    "base64", "clear", "colors", "copy", "delete", "dhcp", "disk", "edit",
-    "geotime", "goto", "halt", "help", "hex", "host", "http", "install", "ip",
-    "list", "move", "net", "print", "quit", "read", "route", "shell", "sleep",
-    "tcp", "user", "write",
-];
-
-// TODO: Scan /dev
-const AUTOCOMPLETE_DEVICES: [&str; 6] = [
-    "/dev/ata",
-    "/dev/clk",
-    "/dev/clk/uptime",
-    "/dev/clk/realtime",
-    "/dev/random",
-    "/dev/rtc",
+const AUTOCOMPLETE_COMMANDS: [&str; 35] = [
+    "base64", "clear", "colors", "copy", "date", "delete", "dhcp", "disk", "edit", "env", "exit",
+    "geotime", "goto", "halt", "help", "hex", "host", "http", "httpd", "install", "ip", "lisp",
+    "list", "memory", "move", "net", "print", "read", "route", "shell", "sleep", "tcp", "user",
+    "vga", "write"
 ];
 
 #[repr(u8)]
@@ -33,463 +22,206 @@ pub enum ExitCode {
     ShellExit         = 255,
 }
 
-pub struct Shell {
-    cmd: String,
-    prompt: String,
-    history: Vec<String>,
-    history_index: usize,
-    autocomplete: Vec<String>,
-    autocomplete_index: usize,
-    errored: bool,
+fn shell_completer(line: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+
+    let args = split_args(&line);
+    let i = args.len() - 1;
+    if args.len() == 1 { // Autocomplete command
+        for &cmd in &AUTOCOMPLETE_COMMANDS {
+            if cmd.starts_with(args[i]) {
+                entries.push(cmd[args[i].len()..].into());
+            }
+        }
+    } else { // Autocomplete path
+        let pathname = sys::fs::realpath(args[i]);
+        let dirname = sys::fs::dirname(&pathname);
+        let filename = sys::fs::filename(&pathname);
+        let sep = if dirname.ends_with("/") { "" } else { "/" };
+        if let Some(dir) = sys::fs::Dir::open(dirname) {
+            for entry in dir.read() {
+                let name = entry.name();
+                if name.starts_with(filename) {
+                    let end = if entry.is_dir() { "/" } else { "" };
+                    let path = format!("{}{}{}{}", dirname, sep, name, end);
+                    entries.push(path[pathname.len()..].into());
+                }
+            }
+        }
+    }
+    entries
 }
 
-impl Shell {
-    pub fn new() -> Self {
-        Shell {
-            cmd: String::new(),
-            prompt: String::from("> "),
-            history: Vec::new(),
-            history_index: 0,
-            autocomplete: Vec::new(),
-            autocomplete_index: 0,
-            errored: false,
-        }
-    }
+pub fn prompt_string(success: bool) -> String {
+    let csi_color = Style::color("Magenta");
+    let csi_error = Style::color("Red");
+    let csi_reset = Style::reset();
+    format!("{}>{} ", if success { csi_color } else { csi_error }, csi_reset)
+}
 
-    pub fn run(&mut self) -> usr::shell::ExitCode {
-        self.load_history();
-        print!("\n");
-        self.print_prompt();
-        let mut escape = false;
-        let mut csi = false;
-        loop {
-            let (x, y) = sys::vga::cursor_position();
-            let c = sys::console::get_char();
-            match c {
-                '\x1B' => { // ESC
-                    escape = true;
-                    continue;
-                },
-                '[' if escape => {
-                    csi = true;
-                    continue;
-                },
-                '\0' => {
-                    continue;
-                }
-                '\x04' => { // Ctrl D => End of Transmission
-                    if self.cmd.is_empty() {
-                        sys::vga::clear_screen();
-                        return ExitCode::CommandSuccessful;
-                    }
-                },
-                '\x03' => { // Ctrl C => End of Text
-                    self.cmd.clear();
-                    self.errored = false;
-                    print!("\n\n");
-                    self.print_prompt();
-                },
-                '\n' => { // Newline
-                    self.update_history();
-                    self.update_autocomplete();
-                    print!("\n");
-                    if self.cmd.len() > 0 {
-                        // Add or move command to history at the end
-                        let cmd = self.cmd.clone();
-                        if let Some(pos) = self.history.iter().position(|s| *s == *cmd) {
-                            self.history.remove(pos);
-                        }
-                        self.history.push(cmd);
-                        self.history_index = self.history.len();
+pub fn split_args(cmd: &str) -> Vec<&str> {
+    let mut args: Vec<&str> = Vec::new();
+    let mut i = 0;
+    let mut n = cmd.len();
+    let mut is_quote = false;
 
-                        let line = self.cmd.clone();
-                        match self.exec(&line) {
-                            ExitCode::CommandSuccessful => {
-                                self.errored = false;
-                                self.save_history();
-                            },
-                            ExitCode::ShellExit => {
-                                sys::vga::clear_screen();
-                                return ExitCode::CommandSuccessful
-                            },
-                            _ => {
-                                self.errored = true;
-                            },
-                        }
-                        sys::console::drain();
-                        self.cmd.clear();
-                    } else {
-                        self.errored = false;
-                    }
-                    print!("\n");
-                    self.print_prompt();
-                },
-                '\t' => { // Tab
-                    self.update_history();
-                    self.print_autocomplete();
-                },
-                'A' if csi => { // Arrow up
-                    self.update_autocomplete();
-                    if self.history.len() > 0 {
-                        if self.history_index > 0 {
-                            self.history_index -= 1;
-                        }
-                        let cmd = &self.history[self.history_index];
-                        let n = self.prompt.len();
-                        sys::console::clear_row_after(n + cmd.len());
-                        sys::vga::set_writer_position(n, y);
-                        print!("{}", cmd);
-                    }
-                },
-                'B' if csi => { // Arrow down
-                    self.update_autocomplete();
-                    if self.history_index < self.history.len() {
-                        self.history_index += 1;
-                        let cmd = if self.history_index < self.history.len() {
-                            &self.history[self.history_index]
-                        } else {
-                            &self.cmd
-                        };
-                        let n = self.prompt.len();
-                        sys::console::clear_row_after(n + cmd.len());
-                        sys::vga::set_writer_position(n, y);
-                        print!("{}", cmd);
-                    }
-                },
-                'C' if csi => { // Arrow right
-                    self.update_history();
-                    self.update_autocomplete();
-                    if x < self.prompt.len() + self.cmd.len() {
-                        sys::vga::set_cursor_position(x + 1, y);
-                        sys::vga::set_writer_position(x + 1, y);
-                    }
-                },
-                'D' if csi => { // Arrow left
-                    self.update_history();
-                    self.update_autocomplete();
-                    if x > self.prompt.len() {
-                        sys::vga::set_cursor_position(x - 1, y);
-                        sys::vga::set_writer_position(x - 1, y);
-                    }
-                },
-                '\x08' => { // Backspace
-                    self.update_history();
-                    self.update_autocomplete();
-                    if self.cmd.len() > 0 {
-                        if sys::console::has_cursor() {
-                            if x > self.prompt.len() {
-                                let cmd = self.cmd.clone();
-                                let (before_cursor, mut after_cursor) = cmd.split_at(x - 1 - self.prompt.len());
-                                if after_cursor.len() > 0 {
-                                    after_cursor = &after_cursor[1..];
-                                }
-                                self.cmd.clear();
-                                self.cmd.push_str(before_cursor);
-                                self.cmd.push_str(after_cursor);
-                                print!("{}{} ", c, after_cursor);
-                                sys::vga::set_cursor_position(x - 1, y);
-                                sys::vga::set_writer_position(x - 1, y);
-                            }
-                        } else {
-                            self.cmd.pop();
-                            print!("{}", c);
-                        }
-                    }
-                },
-                '\x7f' => { // Delete
-                    self.update_history();
-                    self.update_autocomplete();
-                    if self.cmd.len() > 0 {
-                        if sys::console::has_cursor() {
-                            let cmd = self.cmd.clone();
-                            let (before_cursor, mut after_cursor) = cmd.split_at(x - self.prompt.len());
-                            if after_cursor.len() > 0 {
-                                after_cursor = &after_cursor[1..];
-                            }
-                            self.cmd.clear();
-                            self.cmd.push_str(before_cursor);
-                            self.cmd.push_str(after_cursor);
-                            print!("{} ", after_cursor);
-                            sys::vga::set_cursor_position(x, y);
-                            sys::vga::set_writer_position(x, y);
-                        }
-                    }
-                },
-                c => {
-                    self.update_history();
-                    self.update_autocomplete();
-                    if console::is_printable(c) {
-                        if sys::console::has_cursor() {
-                            let cmd = self.cmd.clone();
-                            let (before_cursor, after_cursor) = cmd.split_at(x - self.prompt.len());
-                            self.cmd.clear();
-                            self.cmd.push_str(before_cursor);
-                            self.cmd.push(c);
-                            self.cmd.push_str(after_cursor);
-                            print!("{}{}", c, after_cursor);
-                            sys::vga::set_cursor_position(x + 1, y);
-                            sys::vga::set_writer_position(x + 1, y);
-                        } else {
-                            self.cmd.push(c);
-                            print!("{}", c);
-                        }
-                    }
-                },
+    for (j, c) in cmd.char_indices() {
+        if c == '#' && !is_quote {
+            n = j; // Discard comments
+            break;
+        } else if c == ' ' && !is_quote {
+            if i != j {
+                args.push(&cmd[i..j]);
             }
-            escape = false;
-            csi = false;
-        }
-    }
-
-    // Called when a key other than up or down is pressed while in history
-    // mode. The history index point to a command that will be selected and
-    // the index will be reset to the length of the history vector to signify
-    // that the editor is no longer in history mode.
-    pub fn update_history(&mut self) {
-        if self.history_index != self.history.len() {
-            self.cmd = self.history[self.history_index].clone();
-            self.history_index = self.history.len();
-        }
-    }
-
-    pub fn load_history(&mut self) {
-        if let Some(home) = sys::process::env("HOME") {
-            let pathname = format!("{}/.shell_history", home);
-
-            if let Some(mut file) = sys::fs::File::open(&pathname) {
-                let contents = file.read_to_string();
-                for line in contents.split('\n') {
-                    let cmd = line.trim();
-                    if cmd.len() > 0 {
-                        self.history.push(cmd.into());
-                    }
-                }
+            i = j + 1;
+        } else if c == '"' {
+            is_quote = !is_quote;
+            if !is_quote {
+                args.push(&cmd[i..j]);
             }
-            self.history_index = self.history.len();
+            i = j + 1;
         }
     }
 
-    pub fn save_history(&mut self) {
-        if let Some(home) = sys::process::env("HOME") {
-            let pathname = format!("{}/.shell_history", home);
+    if i < n {
+        if is_quote {
+            n -= 1;
+        }
+        args.push(&cmd[i..n]);
+    }
 
-            let mut contents = String::new();
-            for cmd in &self.history {
-                contents.push_str(&format!("{}\n", cmd));
+    if n == 0 || cmd.chars().last().unwrap() == ' ' {
+        args.push("");
+    }
+
+    args
+}
+
+fn change_dir(args: &[&str]) -> ExitCode {
+    match args.len() {
+        1 => {
+            print!("{}\n", sys::process::dir());
+            ExitCode::CommandSuccessful
+        },
+        2 => {
+            let mut pathname = sys::fs::realpath(args[1]);
+            if pathname.len() > 1 {
+                pathname = pathname.trim_end_matches('/').into();
             }
-
-            let mut file = match sys::fs::File::open(&pathname) {
-                Some(file) => file,
-                None => sys::fs::File::create(&pathname).unwrap(),
-            };
-
-            file.write(&contents.as_bytes()).unwrap();
-        }
-    }
-
-    pub fn print_autocomplete(&mut self) {
-        let mut args = self.parse(&self.cmd);
-        let i = args.len() - 1;
-        if self.autocomplete_index == 0 {
-            if args.len() == 1 { // Autocomplete cmd
-                self.autocomplete = vec![args[i].into()];
-                for &cmd in &AUTOCOMPLETE_COMMANDS {
-                    if cmd.starts_with(args[i]) {
-                        self.autocomplete.push(cmd.into());
-                    }
-                }
-            } else { // Autocomplete path
-                let pathname = sys::fs::realpath(args[i]);
-                let dirname = sys::fs::dirname(&pathname);
-                let filename = sys::fs::filename(&pathname);
-                self.autocomplete = vec![args[i].into()];
-                let sep = if dirname.ends_with("/") { "" } else { "/" };
-                if pathname.starts_with("/dev") {
-                    for dev in &AUTOCOMPLETE_DEVICES {
-                        let d = sys::fs::dirname(dev);
-                        let f = sys::fs::filename(dev);
-                        if d == dirname && f.starts_with(filename) {
-                            self.autocomplete.push(format!("{}{}{}", d, sep, f));
-                        }
-                    }
-                } else if let Some(dir) = sys::fs::Dir::open(dirname) {
-                    for entry in dir.read() {
-                        let name = entry.name();
-                        if name.starts_with(filename) {
-                            let end = if entry.is_dir() { "/" } else { "" };
-                            self.autocomplete.push(format!("{}{}{}{}", dirname, sep, name, end));
-                        }
-                    }
-                }
-            }
-        }
-
-        self.autocomplete_index = (self.autocomplete_index + 1) % self.autocomplete.len();
-        args[i] = &self.autocomplete[self.autocomplete_index];
-
-        let cmd = args.join(" ");
-        let n = self.prompt.len();
-        let (_, y) = sys::console::cursor_position();
-        sys::console::clear_row_after(n + cmd.len());
-        sys::console::set_writer_position(n, y);
-        print!("{}", cmd);
-    }
-
-    // Called when a key other than tab is pressed while in autocomplete mode.
-    // The autocomplete index point to an argument that will be added to the
-    // command and the index will be reset to signify that the editor is no
-    // longer in autocomplete mode.
-    pub fn update_autocomplete(&mut self) {
-        if self.autocomplete_index != 0 {
-            let mut args = self.parse(&self.cmd);
-            let i = args.len() - 1;
-            args[i] = &self.autocomplete[self.autocomplete_index];
-            self.cmd = args.join(" ");
-            self.autocomplete_index = 0;
-            self.autocomplete = vec!["".into()];
-        }
-    }
-
-    pub fn parse<'a>(&self, cmd: &'a str) -> Vec<&'a str> {
-        //let args: Vec<&str> = cmd.split_whitespace().collect();
-        let mut args: Vec<&str> = Vec::new();
-        let mut i = 0;
-        let mut n = cmd.len();
-        let mut is_quote = false;
-
-        for (j, c) in cmd.char_indices() {
-            if c == '#' && !is_quote {
-                n = j; // Discard comments
-                break;
-            } else if c == ' ' && !is_quote {
-                if i != j {
-                    args.push(&cmd[i..j]);
-                }
-                i = j + 1;
-            } else if c == '"' {
-                is_quote = !is_quote;
-                if !is_quote {
-                    args.push(&cmd[i..j]);
-                }
-                i = j + 1;
-            }
-        }
-
-        if i < n {
-            if is_quote {
-                n -= 1;
-            }
-            args.push(&cmd[i..n]);
-        }
-
-        if n == 0 || cmd.chars().last().unwrap() == ' ' {
-            args.push("");
-        }
-
-        args
-    }
-
-    pub fn exec(&self, cmd: &str) -> ExitCode {
-        let args = self.parse(cmd);
-
-        match args[0] {
-            ""                     => ExitCode::CommandSuccessful,
-            "a" | "alias"          => ExitCode::CommandUnknown,
-            "b"                    => ExitCode::CommandUnknown,
-            "c" | "copy"           => usr::copy::main(&args),
-            "d" | "del" | "delete" => usr::delete::main(&args),
-            "e" | "edit"           => usr::editor::main(&args),
-            "f" | "find"           => ExitCode::CommandUnknown,
-            "g" | "go" | "goto"    => self.change_dir(&args),
-            "h" | "help"           => usr::help::main(&args),
-            "i"                    => ExitCode::CommandUnknown,
-            "j" | "jump"           => ExitCode::CommandUnknown,
-            "k" | "kill"           => ExitCode::CommandUnknown,
-            "l" | "list"           => usr::list::main(&args),
-            "m" | "move"           => usr::r#move::main(&args),
-            "n"                    => ExitCode::CommandUnknown,
-            "o"                    => ExitCode::CommandUnknown,
-            "p" | "print"          => usr::print::main(&args),
-            "q" | "quit" | "exit"  => ExitCode::ShellExit,
-            "r" | "read"           => usr::read::main(&args),
-            "s"                    => ExitCode::CommandUnknown,
-            "t"                    => ExitCode::CommandUnknown,
-            "u"                    => ExitCode::CommandUnknown,
-            "v"                    => ExitCode::CommandUnknown,
-            "w" | "write"          => usr::write::main(&args),
-            "x"                    => ExitCode::CommandUnknown,
-            "y"                    => ExitCode::CommandUnknown,
-            "z"                    => ExitCode::CommandUnknown,
-            "vga"                  => usr::vga::main(&args),
-            "shell"                => usr::shell::main(&args),
-            "sleep"                => usr::sleep::main(&args),
-            "clear"                => usr::clear::main(&args),
-            "base64"               => usr::base64::main(&args),
-            "date"                 => usr::date::main(&args),
-            "env"                  => usr::env::main(&args),
-            "halt"                 => usr::halt::main(&args),
-            "hex"                  => usr::hex::main(&args),
-            "net"                  => usr::net::main(&args),
-            "route"                => usr::route::main(&args),
-            "dhcp"                 => usr::dhcp::main(&args),
-            "http"                 => usr::http::main(&args),
-            "httpd"                => usr::httpd::main(&args),
-            "tcp"                  => usr::tcp::main(&args),
-            "host"                 => usr::host::main(&args),
-            "install"              => usr::install::main(&args),
-            "ip"                   => usr::ip::main(&args),
-            "geotime"              => usr::geotime::main(&args),
-            "colors"               => usr::colors::main(&args),
-            "disk"                 => usr::disk::main(&args),
-            "user"                 => usr::user::main(&args),
-            "mem" | "memory"       => usr::mem::main(&args),
-            "lisp"                 => usr::lisp::main(&args),
-            _                      => ExitCode::CommandUnknown,
-        }
-    }
-
-    fn print_prompt(&self) {
-        let color = if self.errored { "Red" } else { "Magenta" };
-        let csi_color = Style::color(color);
-        let csi_reset = Style::reset();
-        print!("{}{}{}", csi_color, self.prompt, csi_reset);
-    }
-
-    fn change_dir(&self, args: &[&str]) -> ExitCode {
-        match args.len() {
-            1 => {
-                print!("{}\n", sys::process::dir());
+            if sys::fs::Dir::open(&pathname).is_some() {
+                sys::process::set_dir(&pathname);
                 ExitCode::CommandSuccessful
-            },
-            2 => {
-                let pathname = sys::fs::realpath(args[1]);
-                if sys::fs::Dir::open(&pathname).is_some() {
-                    sys::process::set_dir(&pathname);
-                    ExitCode::CommandSuccessful
-                } else {
-                    print!("File not found '{}'\n", pathname);
-                    ExitCode::CommandError
-                }
-            },
-            _ => {
+            } else {
+                print!("File not found '{}'\n", pathname);
                 ExitCode::CommandError
             }
+        },
+        _ => {
+            ExitCode::CommandError
         }
     }
+}
+
+pub fn exec(cmd: &str) -> ExitCode {
+    let args = split_args(cmd);
+
+    match args[0] {
+        ""                     => ExitCode::CommandSuccessful,
+        "a" | "alias"          => ExitCode::CommandUnknown,
+        "b"                    => ExitCode::CommandUnknown,
+        "c" | "copy"           => usr::copy::main(&args),
+        "d" | "del" | "delete" => usr::delete::main(&args),
+        "e" | "edit"           => usr::editor::main(&args),
+        "f" | "find"           => ExitCode::CommandUnknown,
+        "g" | "go" | "goto"    => change_dir(&args),
+        "h" | "help"           => usr::help::main(&args),
+        "i"                    => ExitCode::CommandUnknown,
+        "j" | "jump"           => ExitCode::CommandUnknown,
+        "k" | "kill"           => ExitCode::CommandUnknown,
+        "l" | "list"           => usr::list::main(&args),
+        "m" | "move"           => usr::r#move::main(&args),
+        "n"                    => ExitCode::CommandUnknown,
+        "o"                    => ExitCode::CommandUnknown,
+        "p" | "print"          => usr::print::main(&args),
+        "q" | "quit" | "exit"  => ExitCode::ShellExit,
+        "r" | "read"           => usr::read::main(&args),
+        "s"                    => ExitCode::CommandUnknown,
+        "t"                    => ExitCode::CommandUnknown,
+        "u"                    => ExitCode::CommandUnknown,
+        "v"                    => ExitCode::CommandUnknown,
+        "w" | "write"          => usr::write::main(&args),
+        "x"                    => ExitCode::CommandUnknown,
+        "y"                    => ExitCode::CommandUnknown,
+        "z"                    => ExitCode::CommandUnknown,
+        "vga"                  => usr::vga::main(&args),
+        "shell"                => usr::shell::main(&args),
+        "sleep"                => usr::sleep::main(&args),
+        "clear"                => usr::clear::main(&args),
+        "base64"               => usr::base64::main(&args),
+        "date"                 => usr::date::main(&args),
+        "env"                  => usr::env::main(&args),
+        "halt"                 => usr::halt::main(&args),
+        "hex"                  => usr::hex::main(&args),
+        "net"                  => usr::net::main(&args),
+        "route"                => usr::route::main(&args),
+        "dhcp"                 => usr::dhcp::main(&args),
+        "http"                 => usr::http::main(&args),
+        "httpd"                => usr::httpd::main(&args),
+        "tcp"                  => usr::tcp::main(&args),
+        "host"                 => usr::host::main(&args),
+        "install"              => usr::install::main(&args),
+        "ip"                   => usr::ip::main(&args),
+        "geotime"              => usr::geotime::main(&args),
+        "colors"               => usr::colors::main(&args),
+        "disk"                 => usr::disk::main(&args),
+        "user"                 => usr::user::main(&args),
+        "mem" | "memory"       => usr::mem::main(&args),
+        "lisp"                 => usr::lisp::main(&args),
+        _                      => ExitCode::CommandUnknown,
+    }
+}
+
+pub fn run() -> usr::shell::ExitCode {
+    println!();
+
+    let mut prompt = Prompt::new();
+    let history_file = "~/.shell-history";
+    prompt.history.load(history_file);
+    prompt.completion.set(&shell_completer);
+
+    let mut success = true;
+    while let Some(cmd) = prompt.input(&prompt_string(success)) {
+        match exec(&cmd) {
+            ExitCode::CommandSuccessful => {
+                success = true;
+                prompt.history.add(&cmd);
+                prompt.history.save(history_file);
+            },
+            ExitCode::ShellExit => {
+                sys::vga::clear_screen();
+                return ExitCode::CommandSuccessful;
+            },
+            _ => {
+                success = false;
+            },
+        }
+        println!();
+    }
+
+    ExitCode::CommandError
 }
 
 pub fn main(args: &[&str]) -> ExitCode {
-    let mut shell = Shell::new();
     match args.len() {
         1 => {
-            return shell.run();
+            return run();
         },
         2 => {
             let pathname = args[1];
             if let Some(mut file) = sys::fs::File::open(pathname) {
                 for line in file.read_to_string().split("\n") {
                     if line.len() > 0 {
-                        shell.exec(line);
+                        exec(line);
                     }
                 }
                 ExitCode::CommandSuccessful

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -198,8 +198,7 @@ pub fn run() -> usr::shell::ExitCode {
                 prompt.history.save(history_file);
             },
             ExitCode::ShellExit => {
-                sys::vga::clear_screen();
-                return ExitCode::CommandSuccessful;
+                break;
             },
             _ => {
                 success = false;
@@ -207,8 +206,8 @@ pub fn run() -> usr::shell::ExitCode {
         }
         println!();
     }
-
-    ExitCode::CommandError
+    sys::vga::clear_screen();
+    ExitCode::CommandSuccessful
 }
 
 pub fn main(args: &[&str]) -> ExitCode {


### PR DESCRIPTION
Add `Prompt` to generalize line editing for the shell and the lisp interpreter. It will also be used in the login screen. Inspired by [Linenoise](https://github.com/antirez/linenoise), a bit like [RustyLine](https://github.com/kkawakam/rustyline) but without `std`.

More code will also be moved from the Kernel to the API, and communication with the VGA driver through the console will now be done with [ANSI Escape Sequence](https://en.wikipedia.org/wiki/ANSI_escape_code) instead of calling functions of the VGA module. This will simplify switching to a real userspace.

- [x] Add `Prompt`
- [x] Add `History` to `Prompt`
- [x] Add `Completion` to `Prompt`
- [x] Use `Prompt` for the `lisp` command
- [x] Use `Prompt` for the `shell` command
- [ ] Use `Prompt` for the `login` command