### PR TITLE
Remove deprecation warnings

### DIFF
--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -1,7 +1,9 @@
 use lazy_static::lazy_static;
+use x86_64::VirtAddr;
+use x86_64::instructions::segmentation::{CS, Segment};
+use x86_64::instructions::tables::load_tss;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
 use x86_64::structures::tss::TaskStateSegment;
-use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
@@ -38,12 +40,9 @@ struct Selectors {
 }
 
 pub fn init() {
-    use x86_64::instructions::segmentation::set_cs;
-    use x86_64::instructions::tables::load_tss;
-
     GDT.0.load();
     unsafe {
-        set_cs(GDT.1.code_selector);
+        CS::set_reg(GDT.1.code_selector);
         load_tss(GDT.1.tss_selector);
     }
 }


### PR DESCRIPTION
This PR fixes the following deprecation warning from the latest version of the `x86_64` crate:
```
warning: use of deprecated function `x86_64::instructions::segmentation::set_cs`: use `CS::set_reg()` instead
```

See https://github.com/rust-osdev/x86_64/pull/258