### PR TITLE
Remove volatile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ dependencies = [
  "spin 0.9.2",
  "time",
  "uart_16550",
- "volatile 0.2.7",
  "vte",
  "x86_64",
 ]
@@ -505,12 +504,6 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "volatile"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b06ad3ed06fef1713569d547cdbdb439eafed76341820fb0e0344f29a41945"
-
-[[package]]
-name = "volatile"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c2dbd44eb8b53973357e6e207e370f0c1059990df850aca1eca8947cf464f0"
@@ -544,5 +537,5 @@ checksum = "d95947de37ad0d2d9a4a4dd22e0d042e034e5cbd7ab53edbca0d8035e0a6a64d"
 dependencies = [
  "bit_field 0.9.0",
  "bitflags",
- "volatile 0.4.4",
+ "volatile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ smoltcp = { version = "0.7.5", default-features = false, features = ["alloc", "e
 spin = "0.9.2"
 time = { version = "0.2.27", default-features = false }
 uart_16550 = "0.2.15"
-volatile = "0.2.6"
 vte = "0.10.1"
 x86_64 = "0.14.4"
 

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -150,7 +150,7 @@ impl Writer {
             for y in 1..BUFFER_HEIGHT {
                 for x in 0..BUFFER_WIDTH {
                     unsafe {
-                        let c  = core::ptr::read_volatile(&mut self.buffer.chars[y][x]);
+                        let c = core::ptr::read_volatile(&mut self.buffer.chars[y][x]);
                         core::ptr::write_volatile(&mut self.buffer.chars[y - 1][x], c);
                     }
                 }

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -150,7 +150,7 @@ impl Writer {
             for y in 1..BUFFER_HEIGHT {
                 for x in 0..BUFFER_WIDTH {
                     unsafe {
-                        let c = core::ptr::read_volatile(&mut self.buffer.chars[y][x]);
+                        let c = core::ptr::read_volatile(&self.buffer.chars[y][x]);
                         core::ptr::write_volatile(&mut self.buffer.chars[y - 1][x], c);
                     }
                 }


### PR DESCRIPTION
The API of this crate changed in v0.4 and I found it easier to switch to `core::ptr::write_volatile` and `core::ptr::read_volatile` for now, but we'll look at it again in the future.

See https://github.com/rust-osdev/volatile/pull/13 and https://github.com/rust-osdev/volatile/pull/22