### PR TITLE
Add a regular expression engine

### DIFF
--- a/doc/regex.md
+++ b/doc/regex.md
@@ -1,0 +1,21 @@
+# MOROS Regular Expression Engine
+
+MOROS include a simplified regular expression engine with the following syntax:
+
+- `\` escape the following character to its literal meaning
+- `^` matches the starting position within the string
+- `$` matches the ending position within the string
+- `*` matches the preceding element zero or more times
+- `+` matches the preceding element one or more times
+- `?` matches the preceding element zero or one time
+- `.` matches any single character
+- `\w` matches any alphanumeric character
+- `\W` matches any non-alphanumeric character
+- `\d` matches any numeric character
+- `\D` matches any non-numeric character
+- `\w` matches any whitespace character
+- `\W` matches any whitespace character
+
+The engine is UTF-8 aware, so for example the unicode character `é` will be
+matched by `\w` even if it's not present in the ASCII table and has a size
+of two bytes.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,3 +23,4 @@ pub mod prompt;
 pub mod regex;
 pub mod syscall;
 pub mod vga;
+// TODO: add mod wildcard

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,5 +20,6 @@ pub mod console;
 pub mod font;
 pub mod fs;
 pub mod prompt;
+pub mod regex;
 pub mod syscall;
 pub mod vga;

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -78,31 +78,34 @@ fn is_match_plus(c: char, re: &str, text: &str) -> bool {
 
 #[test_case]
 fn test_regex() {
-    assert_eq!(Regex::new("aaa").is_match("aaa"), true);
-    assert_eq!(Regex::new("aaa").is_match("bbb"), false);
-    assert_eq!(Regex::new("a.a").is_match("aaa"), true);
-    assert_eq!(Regex::new("a.a").is_match("aba"), true);
-    assert_eq!(Regex::new("a.a").is_match("abb"), false);
-
-    assert_eq!(Regex::new("a*").is_match("aaa"), true);
-    //assert_eq!(Regex::new("a*b").is_match("aab"), true); // FIXME
-    //assert_eq!(Regex::new("a*b*").is_match("aabb"), true); // FIXME
-    assert_eq!(Regex::new("a.*").is_match("abb"), true);
-    assert_eq!(Regex::new(".*").is_match("aaa"), true);
-    assert_eq!(Regex::new("a.*").is_match("a"), true);
-
-    assert_eq!(Regex::new("a.+").is_match("ab"), true);
-    assert_eq!(Regex::new("a.+").is_match("abb"), true);
-    assert_eq!(Regex::new("a.+").is_match("a"), false);
-    assert_eq!(Regex::new("a.+b").is_match("ab"), false);
-    assert_eq!(Regex::new("a.+b").is_match("abb"), true);
-    assert_eq!(Regex::new(".+").is_match("abb"), true);
-    assert_eq!(Regex::new(".+").is_match("b"), true);
-
-    assert_eq!(Regex::new("^a.*a$").is_match("aaa"), true);
-    assert_eq!(Regex::new("^#.*").is_match("#aaa"), true);
-    assert_eq!(Regex::new("^#.*").is_match("a#aaa"), false);
-    assert_eq!(Regex::new(".*;$").is_match("aaa;"), true);
-    assert_eq!(Regex::new(".*;$").is_match("aaa;a"), false);
-    assert_eq!(Regex::new("^.*$").is_match("aaa"), true);
+    let tests = [
+        ("aaa",    "aaa",   true),
+        ("aaa",    "bbb",   false),
+        ("a.a",    "aaa",   true),
+        ("a.a",    "aba",   true),
+        ("a.a",    "abb",   false),
+        ("a*",     "aaa",   true),
+    //  ("a*b",    "aab",   true), // FIXME
+    //  ("a*b*",   "aabb",  true), // FIXME
+        ("a.*",    "abb",   true),
+        (".*",     "aaa",   true),
+        ("a.*",    "a",     true),
+        ("a.+",    "ab",    true),
+        ("a.+",    "abb",   true),
+        ("a.+",    "a",     false),
+        ("a.+b",   "ab",    false),
+        ("a.+b",   "abb",   true),
+        (".+",     "abb",   true),
+        (".+",     "b",     true),
+        ("^a.*a$", "aaa",   true),
+        ("^#.*",   "#aaa",  true),
+        ("^#.*",   "a#aaa", false),
+        (".*;$",   "aaa;",  true),
+        (".*;$",   "aaa;a", false),
+        ("^.*$",   "aaa",   true),
+        ("^.*$",   "aaa",   true),
+    ];
+    for (re, text, is_match) in tests {
+        assert!(Regex::new(re).is_match(text) == is_match, "Regex::new(\"{}\").is_match(\"{}\") == {}", re, text, is_match);
+    }
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -38,6 +38,9 @@ fn is_match_here(re: &str, text: &str) -> bool {
     if re.chars().nth(1) == Some('*') {
         return is_match_star(re.chars().nth(0).unwrap(), &re[2..], text);
     }
+    if re.chars().nth(1) == Some('+') {
+        return is_match_plus(re.chars().nth(0).unwrap(), &re[2..], text);
+    }
     if re.chars().nth(0) == Some('$') && re.len() == 1 {
         return text.len() == 0;
     }
@@ -60,6 +63,19 @@ fn is_match_star(c: char, re: &str, text: &str) -> bool {
     false
 }
 
+fn is_match_plus(c: char, re: &str, text: &str) -> bool {
+    println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
+    let mut i = 0;
+    let n = text.len();
+    while i <= n && (text.chars().nth(i) == Some(c) || c == '.') {
+        if is_match_here(re, &text[i..]) && i > 0 {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 #[test_case]
 fn test_regex() {
     assert!(Regex::new("aaa").is_match("aaa"));
@@ -75,4 +91,12 @@ fn test_regex() {
     assert!(Regex::new(".*;$").is_match("aaa;"));
     assert!(!Regex::new(".*;$").is_match("aaa;a"));
     assert!(Regex::new("^.*$").is_match("aaa"));
+    assert!(Regex::new("a.*").is_match("a"));
+    assert!(Regex::new("a.+").is_match("ab"));
+    assert!(Regex::new("a.+").is_match("abb"));
+    assert!(!Regex::new("a.+").is_match("a"));
+    assert!(!Regex::new("a.+b").is_match("ab"));
+    assert!(Regex::new("a.+b").is_match("abb"));
+    assert!(Regex::new(".+").is_match("abb"));
+    assert!(Regex::new(".+").is_match("b"));
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -46,8 +46,10 @@ fn is_match_here(re: &[char], text: &[char]) -> bool {
     if re.len() == 0 {
         return true;
     }
-    if re[0] == '\\' {
-        return is_match_back(&re[1..], text);
+    match re[0] {
+        '\\' => return is_match_back(&re[1..], text),
+        '$' => return text.len() == 0,
+        _ => {},
     }
     if re.len() > 1 {
         match re[1] {
@@ -56,9 +58,6 @@ fn is_match_here(re: &[char], text: &[char]) -> bool {
             '?' => return is_match_ques(re[0], &re[2..], text),
             _ => {}
         }
-    }
-    if re[0] == '$' {
-        return text.len() == 0;
     }
     if text.len() != 0 && (re[0] == '.' || re[0] == text[0]) {
         return is_match_here(&re[1..], &text[1..]);

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -52,15 +52,21 @@ fn is_match_here(re: &str, text: &str) -> bool {
 
 fn is_match_star(c: char, re: &str, text: &str) -> bool {
     //println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
+
     let mut i = 0;
     let n = text.len();
-    while i <= n && (text.chars().nth(i) == Some(c) || c == '.') {
+    loop {
         if is_match_here(re, &text[i..]) {
             return true;
         }
+        if i == n {
+            return false;
+        }
         i += 1;
+        if !(text.chars().nth(i) == Some(c) || c == '.') {
+            return false;
+        }
     }
-    false
 }
 
 fn is_match_plus(c: char, re: &str, text: &str) -> bool {
@@ -85,8 +91,9 @@ fn test_regex() {
         ("a.a",    "aba",   true),
         ("a.a",    "abb",   false),
         ("a*",     "aaa",   true),
-    //  ("a*b",    "aab",   true), // FIXME
-    //  ("a*b*",   "aabb",  true), // FIXME
+        ("a*b",    "aab",   true),
+        ("a*b*",   "aabb",  true),
+        ("a*b*",   "bb",    true),
         ("a.*",    "abb",   true),
         (".*",     "aaa",   true),
         ("a.*",    "a",     true),

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -1,0 +1,72 @@
+use alloc::string::{String, ToString};
+
+// See "A Regular Expression Matcher" by Rob Pike and Brian Kernighan (2007)
+
+pub struct Regex(String);
+
+impl Regex {
+    pub fn new(re: &str) -> Self {
+        Self(re.to_string())
+    }
+    pub fn is_match(&self, text: &str) -> bool {
+        is_match(&self.0, text)
+    }
+}
+
+fn is_match(re: &str, text: &str) -> bool {
+    println!("debug: is_match('{}', '{}')", re, text);
+    if re.chars().nth(0) == Some('^') {
+        return is_match_here(&re[1..], text);
+    }
+    let mut i = 0;
+    let n = text.len();
+    while i < n {
+        if is_match_here(re, &text[i..]) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_match_here(re: &str, text: &str) -> bool {
+    println!("debug: is_match_here('{}', '{}')", re, text);
+    if re.len() == 0 {
+        return true;
+    }
+    if re.chars().nth(1) == Some('*') {
+        return is_match_star(re.chars().nth(0).unwrap(), &re[2..], text);
+    }
+    if re.chars().nth(0) == Some('$') && re.len() == 1 {
+        return text.len() == 1;
+    }
+    if text.len() != 0 && (re.chars().nth(0) == Some('.') || re.chars().nth(0) == text.chars().nth(0)) {
+        return is_match_here(&re[1..], &text[1..]);
+    }
+    false
+}
+
+fn is_match_star(c: char, re: &str, text: &str) -> bool {
+    println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
+    let mut i = 0;
+    let n = text.len();
+    while i < n && (text.chars().nth(i) == Some(c) || c == '.') {
+        if is_match_here(re, &text[i..]) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+#[test_case]
+fn test_regex() {
+    assert!(Regex::new("aaa").is_match("aaa"));
+    assert!(!Regex::new("aaa").is_match("bbb"));
+    assert!(Regex::new("a.a").is_match("aaa"));
+    assert!(Regex::new("a.a").is_match("aba"));
+    assert!(!Regex::new("a.a").is_match("abb"));
+    assert!(Regex::new("a.*").is_match("abb"));
+    assert!(Regex::new("^.*$").is_match("aaa"));
+    assert!(Regex::new("^a.*a$").is_match("aaa"));
+}

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -5,7 +5,6 @@ use core::ops::RangeBounds;
 
 const DEBUG: bool = false;
 
-#[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => ({
         if DEBUG {

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -276,6 +276,7 @@ fn test_regex() {
         assert!(Regex::new(re).is_match(text) == is_match, "Regex::new(\"{}\").is_match(\"{}\") == {}", re, text, is_match);
     }
 
+    assert_eq!(Regex::new(".*").find("abcd"), Some((0, 4)));
     assert_eq!(Regex::new("b.*c").find("aaabbbcccddd"), Some((3, 9)));
     assert_eq!(Regex::new("b.*?c").find("aaabbbcccddd"), Some((3, 7)));
     assert_eq!(Regex::new("a\\w*d").find("abcdabcd"), Some((0, 8)));

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -134,9 +134,9 @@ fn is_match_here(re: &[char], text: &[char], end: &mut usize) -> bool {
         let j = if lazy { i + 3 } else { i + 2 };
 
         match re[i + 1] {
-            '*' => return is_match_star(mc, &re[j..], text, end, lazy),
-            '+' => return is_match_plus(mc, &re[j..], text, end, lazy),
-            '?' => return is_match_ques(mc, &re[j..], text, end, lazy),
+            '*' => return is_match_star(lazy, mc, &re[j..], text, end),
+            '+' => return is_match_plus(lazy, mc, &re[j..], text, end),
+            '?' => return is_match_ques(lazy, mc, &re[j..], text, end),
             _ => {}
         }
     }
@@ -148,22 +148,22 @@ fn is_match_here(re: &[char], text: &[char], end: &mut usize) -> bool {
     false
 }
 
-fn is_match_star(mc: MetaChar, re: &[char], text: &[char], end: &mut usize, lazy: bool) -> bool {
+fn is_match_star(lazy: bool, mc: MetaChar, re: &[char], text: &[char], end: &mut usize) -> bool {
     debug!("debug: is_match_star({:?}, {:?}, {:?}", mc, re, text);
-    is_match_char(mc, re, text, .., end, lazy)
+    is_match_char(lazy, mc, re, text, .., end)
 }
 
-fn is_match_plus(mc: MetaChar, re: &[char], text: &[char], end: &mut usize, lazy: bool) -> bool {
+fn is_match_plus(lazy: bool, mc: MetaChar, re: &[char], text: &[char], end: &mut usize) -> bool {
     debug!("debug: is_match_plus({:?}, {:?}, {:?}", mc, re, text);
-    is_match_char(mc, re, text, 1.., end, lazy)
+    is_match_char(lazy, mc, re, text, 1.., end)
 }
 
-fn is_match_ques(mc: MetaChar, re: &[char], text: &[char], end: &mut usize, lazy: bool) -> bool {
+fn is_match_ques(lazy: bool, mc: MetaChar, re: &[char], text: &[char], end: &mut usize) -> bool {
     debug!("debug: is_match_ques({:?}, {:?}, {:?}", mc, re, text);
-    is_match_char(mc, re, text, ..2, end, lazy)
+    is_match_char(lazy, mc, re, text, ..2, end)
 }
 
-fn is_match_char<T: RangeBounds<usize>>(mc: MetaChar, re: &[char], text: &[char], range: T, end: &mut usize, lazy: bool) -> bool {
+fn is_match_char<T: RangeBounds<usize>>(lazy: bool, mc: MetaChar, re: &[char], text: &[char], range: T, end: &mut usize) -> bool {
     debug!("debug: is_match_char({:?}, {:?}, {:?}", mc, re, text);
     let mut i = 0;
     let n = text.len();

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -167,6 +167,7 @@ fn test_regex() {
         ("a\\\\\\\\.b", "a\\\\bb", true),
         ("a\\\\\\\\.b", "a\\\\.b", true),
 
+        ("a\\wb",       "aéb",     true),
         ("a\\wb",       "awb",     true),
         ("a\\wb",       "abb",     true),
         ("a\\wb",       "a1b",     true),

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 use core::convert::From;
 use core::ops::RangeBounds;
 
+// TODO: Remove this when tests are done
 const DEBUG: bool = false;
-
 macro_rules! debug {
     ($($arg:tt)*) => ({
         if DEBUG {

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -83,15 +83,14 @@ fn test_regex() {
     assert!(Regex::new("a.a").is_match("aaa"));
     assert!(Regex::new("a.a").is_match("aba"));
     assert!(!Regex::new("a.a").is_match("abb"));
+
+    assert!(Regex::new("a*").is_match("aaa"));
+    //assert!(Regex::new("a*b").is_match("aab")); // FIXME
+    //assert!(Regex::new("a*b*").is_match("aabb")); // FIXME
     assert!(Regex::new("a.*").is_match("abb"));
     assert!(Regex::new(".*").is_match("aaa"));
-    assert!(Regex::new("^a.*a$").is_match("aaa"));
-    assert!(Regex::new("^#.*").is_match("#aaa"));
-    assert!(!Regex::new("^#.*").is_match("a#aaa"));
-    assert!(Regex::new(".*;$").is_match("aaa;"));
-    assert!(!Regex::new(".*;$").is_match("aaa;a"));
-    assert!(Regex::new("^.*$").is_match("aaa"));
     assert!(Regex::new("a.*").is_match("a"));
+
     assert!(Regex::new("a.+").is_match("ab"));
     assert!(Regex::new("a.+").is_match("abb"));
     assert!(!Regex::new("a.+").is_match("a"));
@@ -99,4 +98,11 @@ fn test_regex() {
     assert!(Regex::new("a.+b").is_match("abb"));
     assert!(Regex::new(".+").is_match("abb"));
     assert!(Regex::new(".+").is_match("b"));
+
+    assert!(Regex::new("^a.*a$").is_match("aaa"));
+    assert!(Regex::new("^#.*").is_match("#aaa"));
+    assert!(!Regex::new("^#.*").is_match("a#aaa"));
+    assert!(Regex::new(".*;$").is_match("aaa;"));
+    assert!(!Regex::new(".*;$").is_match("aaa;a"));
+    assert!(Regex::new("^.*$").is_match("aaa"));
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -78,31 +78,31 @@ fn is_match_plus(c: char, re: &str, text: &str) -> bool {
 
 #[test_case]
 fn test_regex() {
-    assert!(Regex::new("aaa").is_match("aaa"));
-    assert!(!Regex::new("aaa").is_match("bbb"));
-    assert!(Regex::new("a.a").is_match("aaa"));
-    assert!(Regex::new("a.a").is_match("aba"));
-    assert!(!Regex::new("a.a").is_match("abb"));
+    assert_eq!(Regex::new("aaa").is_match("aaa"), true);
+    assert_eq!(Regex::new("aaa").is_match("bbb"), false);
+    assert_eq!(Regex::new("a.a").is_match("aaa"), true);
+    assert_eq!(Regex::new("a.a").is_match("aba"), true);
+    assert_eq!(Regex::new("a.a").is_match("abb"), false);
 
-    assert!(Regex::new("a*").is_match("aaa"));
-    //assert!(Regex::new("a*b").is_match("aab")); // FIXME
-    //assert!(Regex::new("a*b*").is_match("aabb")); // FIXME
-    assert!(Regex::new("a.*").is_match("abb"));
-    assert!(Regex::new(".*").is_match("aaa"));
-    assert!(Regex::new("a.*").is_match("a"));
+    assert_eq!(Regex::new("a*").is_match("aaa"), true);
+    //assert_eq!(Regex::new("a*b").is_match("aab"), true); // FIXME
+    //assert_eq!(Regex::new("a*b*").is_match("aabb"), true); // FIXME
+    assert_eq!(Regex::new("a.*").is_match("abb"), true);
+    assert_eq!(Regex::new(".*").is_match("aaa"), true);
+    assert_eq!(Regex::new("a.*").is_match("a"), true);
 
-    assert!(Regex::new("a.+").is_match("ab"));
-    assert!(Regex::new("a.+").is_match("abb"));
-    assert!(!Regex::new("a.+").is_match("a"));
-    assert!(!Regex::new("a.+b").is_match("ab"));
-    assert!(Regex::new("a.+b").is_match("abb"));
-    assert!(Regex::new(".+").is_match("abb"));
-    assert!(Regex::new(".+").is_match("b"));
+    assert_eq!(Regex::new("a.+").is_match("ab"), true);
+    assert_eq!(Regex::new("a.+").is_match("abb"), true);
+    assert_eq!(Regex::new("a.+").is_match("a"), false);
+    assert_eq!(Regex::new("a.+b").is_match("ab"), false);
+    assert_eq!(Regex::new("a.+b").is_match("abb"), true);
+    assert_eq!(Regex::new(".+").is_match("abb"), true);
+    assert_eq!(Regex::new(".+").is_match("b"), true);
 
-    assert!(Regex::new("^a.*a$").is_match("aaa"));
-    assert!(Regex::new("^#.*").is_match("#aaa"));
-    assert!(!Regex::new("^#.*").is_match("a#aaa"));
-    assert!(Regex::new(".*;$").is_match("aaa;"));
-    assert!(!Regex::new(".*;$").is_match("aaa;a"));
-    assert!(Regex::new("^.*$").is_match("aaa"));
+    assert_eq!(Regex::new("^a.*a$").is_match("aaa"), true);
+    assert_eq!(Regex::new("^#.*").is_match("#aaa"), true);
+    assert_eq!(Regex::new("^#.*").is_match("a#aaa"), false);
+    assert_eq!(Regex::new(".*;$").is_match("aaa;"), true);
+    assert_eq!(Regex::new(".*;$").is_match("aaa;a"), false);
+    assert_eq!(Regex::new("^.*$").is_match("aaa"), true);
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -70,16 +70,22 @@ fn is_match_star(c: char, re: &str, text: &str) -> bool {
 }
 
 fn is_match_plus(c: char, re: &str, text: &str) -> bool {
-    println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
+    //println!("debug: is_match_plus('{}', '{}', '{}')", c, re, text);
+
     let mut i = 0;
     let n = text.len();
-    while i <= n && (text.chars().nth(i) == Some(c) || c == '.') {
+    loop {
         if is_match_here(re, &text[i..]) && i > 0 {
             return true;
         }
+        if i == n {
+            return false;
+        }
         i += 1;
+        if !(text.chars().nth(i) == Some(c) || c == '.') {
+            return false;
+        }
     }
-    false
 }
 
 #[test_case]

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -13,12 +13,7 @@ impl Regex {
         Self(re.to_string())
     }
     pub fn is_match(&self, text: &str) -> bool {
-        //println!("debug: {:?}.is_match({:?})", self, text);
-        let vec_re: Vec<char> = self.0.chars().collect();
-        let vec_text: Vec<char> = text.chars().collect();
-        let mut start = 0;
-        let mut end = 0;
-        is_match(&vec_re[..], &vec_text[..], &mut start, &mut end)
+        self.find(text).is_some()
     }
     pub fn find(&self, text: &str) -> Option<(usize, usize)> {
         let vec_re: Vec<char> = self.0.chars().collect();

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -6,6 +6,7 @@ pub struct Regex(String);
 
 impl Regex {
     pub fn new(re: &str) -> Self {
+        //println!("debug: new('{}')", re);
         Self(re.to_string())
     }
     pub fn is_match(&self, text: &str) -> bool {
@@ -14,7 +15,7 @@ impl Regex {
 }
 
 fn is_match(re: &str, text: &str) -> bool {
-    println!("debug: is_match('{}', '{}')", re, text);
+    //println!("debug: is_match('{}', '{}')", re, text);
     if re.chars().nth(0) == Some('^') {
         return is_match_here(&re[1..], text);
     }
@@ -30,7 +31,7 @@ fn is_match(re: &str, text: &str) -> bool {
 }
 
 fn is_match_here(re: &str, text: &str) -> bool {
-    println!("debug: is_match_here('{}', '{}')", re, text);
+    //println!("debug: is_match_here('{}', '{}')", re, text);
     if re.len() == 0 {
         return true;
     }
@@ -38,7 +39,7 @@ fn is_match_here(re: &str, text: &str) -> bool {
         return is_match_star(re.chars().nth(0).unwrap(), &re[2..], text);
     }
     if re.chars().nth(0) == Some('$') && re.len() == 1 {
-        return text.len() == 1;
+        return text.len() == 0;
     }
     if text.len() != 0 && (re.chars().nth(0) == Some('.') || re.chars().nth(0) == text.chars().nth(0)) {
         return is_match_here(&re[1..], &text[1..]);
@@ -47,10 +48,10 @@ fn is_match_here(re: &str, text: &str) -> bool {
 }
 
 fn is_match_star(c: char, re: &str, text: &str) -> bool {
-    println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
+    //println!("debug: is_match_star('{}', '{}', '{}')", c, re, text);
     let mut i = 0;
     let n = text.len();
-    while i < n && (text.chars().nth(i) == Some(c) || c == '.') {
+    while i <= n && (text.chars().nth(i) == Some(c) || c == '.') {
         if is_match_here(re, &text[i..]) {
             return true;
         }
@@ -67,6 +68,11 @@ fn test_regex() {
     assert!(Regex::new("a.a").is_match("aba"));
     assert!(!Regex::new("a.a").is_match("abb"));
     assert!(Regex::new("a.*").is_match("abb"));
-    assert!(Regex::new("^.*$").is_match("aaa"));
+    assert!(Regex::new(".*").is_match("aaa"));
     assert!(Regex::new("^a.*a$").is_match("aaa"));
+    assert!(Regex::new("^#.*").is_match("#aaa"));
+    assert!(!Regex::new("^#.*").is_match("a#aaa"));
+    assert!(Regex::new(".*;$").is_match("aaa;"));
+    assert!(!Regex::new(".*;$").is_match("aaa;a"));
+    assert!(Regex::new("^.*$").is_match("aaa"));
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -67,7 +67,16 @@ fn is_match_here(re: &[char], text: &[char]) -> bool {
 
 fn is_match_back(re: &[char], text: &[char]) -> bool {
     //println!("debug: is_match_back({:?}, {:?}", re, text);
-    if re.len() > 0 && text.len() > 0 && re[0] == text[0] {
+    if re.len() > 0 && text.len() > 0 {
+        match re[0] {
+            'D' => if text[0].is_numeric()       { return false },
+            'S' => if text[0].is_whitespace()    { return false },
+            'W' => if text[0].is_alphanumeric()  { return false },
+            'd' => if !text[0].is_numeric()      { return false },
+            's' => if !text[0].is_whitespace()   { return false },
+            'w' => if !text[0].is_alphanumeric() { return false },
+            _   => if text[0] != re[0]           { return false },
+        }
         return is_match_here(&re[1..], &text[1..]);
     }
     false
@@ -157,6 +166,23 @@ fn test_regex() {
         ("a\\\\\\\\.b", "a\\.b",   false),
         ("a\\\\\\\\.b", "a\\\\bb", true),
         ("a\\\\\\\\.b", "a\\\\.b", true),
+
+        ("a\\wb",       "awb",     true),
+        ("a\\wb",       "abb",     true),
+        ("a\\wb",       "a1b",     true),
+        ("a\\wb",       "a.b",     false),
+        ("a\\Wb",       "aWb",     false),
+        ("a\\Wb",       "abb",     false),
+        ("a\\Wb",       "a1b",     false),
+        ("a\\Wb",       "a.b",     true),
+        ("a\\db",       "abb",     false),
+        ("a\\db",       "a1b",     true),
+        ("a\\Db",       "abb",     true),
+        ("a\\Db",       "a1b",     false),
+        ("a\\sb",       "abb",     false),
+        ("a\\sb",       "a b",     true),
+        ("a\\Sb",       "abb",     true),
+        ("a\\Sb",       "a b",     false),
     ];
     for (re, text, is_match) in tests {
         assert!(Regex::new(re).is_match(text) == is_match, "Regex::new(\"{}\").is_match(\"{}\") == {}", re, text, is_match);

--- a/src/sys/fs.rs
+++ b/src/sys/fs.rs
@@ -91,6 +91,10 @@ impl File {
         None
     }
 
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
     pub fn size(&self) -> usize {
         self.size as usize
     }

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -1,0 +1,60 @@
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use crate::{sys, usr};
+use crate::api::fs;
+use crate::api::regex::Regex;
+use crate::api::console::Style;
+
+// > find /tmp -name *.txt -line hello
+pub fn main(args: &[&str]) -> usr::shell::ExitCode {
+    let mut path: &str = &sys::process::dir();
+    let mut name = None;
+    let mut line = None;
+    let mut i = 1;
+    let n = args.len();
+    while i < n {
+        match args[i] {
+            "--name" | "-n" => {
+                if i + 1 < n {
+                    name = Some(args[i + 1]);
+                    i += 1;
+                } else {
+                    println!("Missing name");
+                    return usr::shell::ExitCode::CommandError;
+                }
+            },
+            "--line" | "-l" => {
+                if i + 1 < n {
+                    line = Some(args[i + 1]);
+                    i += 1;
+                } else {
+                    println!("Missing line");
+                    return usr::shell::ExitCode::CommandError;
+                }
+            },
+            _ => path = args[i],
+        }
+        i += 1;
+    }
+
+    if let Some(pattern) = line {
+        let re = Regex::new(pattern);
+        if let Ok(lines) = fs::read_to_string(path) {
+            let mut matches = Vec::new();
+            for (i, line) in lines.split('\n').enumerate() {
+                if re.is_match(line) {
+                    matches.push((i, line));
+                }
+            }
+            if !matches.is_empty() {
+                // TODO: Print filename if we are walking a dir
+                let width = matches[matches.len() - 1].0.to_string().len();
+                for (i, line) in matches {
+                    println!("{}{:>width$}:{} {}", Style::color("Yellow"), i, Style::reset(), line, width = width);
+                }
+            }
+        }
+    }
+
+    usr::shell::ExitCode::CommandSuccessful
+}

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -8,6 +8,20 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::iter::FromIterator;
 
+struct PrintingState {
+    is_first_match: bool,
+    is_recursive: bool,
+}
+
+impl PrintingState {
+    fn new() -> Self {
+        Self {
+            is_first_match: true,
+            is_recursive: false,
+        }
+    }
+}
+
 // > find /tmp -name *.txt -line hello
 pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     let mut path: &str = &sys::process::dir();
@@ -40,41 +54,74 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
         i += 1;
     }
 
-    let num = Style::color("Yellow");
-    let color = Style::color("LightRed");
-    let reset = Style::reset();
+    if name.is_some() {
+        todo!();
+    }
 
+    let mut state = PrintingState::new();
     if let Some(pattern) = line {
-        let re = Regex::new(pattern);
-        if let Ok(lines) = fs::read_to_string(path) {
-            let mut matches = Vec::new();
-            for (i, line) in lines.split('\n').enumerate() {
-                let line: Vec<char> = line.chars().collect();
-                let mut l = String::new();
-                let mut j = 0;
-                while let Some((a, b)) = re.find(&String::from_iter(&line[j..])) {
-                    let m = j + a;
-                    let n = j + b;
-                    let before = String::from_iter(&line[j..m]);
-                    let matched = String::from_iter(&line[m..n]);
-                    l = format!("{}{}{}{}{}", l, before, color, matched, reset);
-                    j = n;
-                }
-                if !l.is_empty() {
-                    let after = String::from_iter(&line[j..]);
-                    l.push_str(&after);
-                    matches.push((i + 1, l)); // 1-index line numbers
-                }
-            }
-            if !matches.is_empty() {
-                // TODO: Print filename if we are walking a dir
-                let width = matches[matches.len() - 1].0.to_string().len();
-                for (i, line) in matches {
-                    println!("{}{:>width$}:{} {}", num, i, reset, line, width = width);
-                }
-            }
-        }
+        print_matching_lines(path, pattern, &mut state);
     }
 
     usr::shell::ExitCode::CommandSuccessful
+}
+
+fn print_matching_lines(path: &str, pattern: &str, state: &mut PrintingState) {
+    if let Some(dir) = sys::fs::Dir::open(path) {
+        state.is_recursive = true;
+        for file in dir.read() {
+            let file_path = format!("{}/{}", path, file.name());
+            if file.is_dir() {
+                print_matching_lines(&file_path, pattern, state);
+            } else {
+                print_matching_lines_in_file(&file_path, pattern, state);
+            }
+        }
+    } else if sys::fs::File::open(path).is_some() {
+        print_matching_lines_in_file(&path, pattern, state);
+    }
+}
+
+fn print_matching_lines_in_file(path: &str, pattern: &str, state: &mut PrintingState) {
+    let name_color = Style::color("Cyan");
+    let line_color = Style::color("Yellow");
+    let match_color = Style::color("LightRed");
+    let reset = Style::reset();
+
+    let re = Regex::new(pattern);
+    if let Ok(lines) = fs::read_to_string(path) {
+        let mut matches = Vec::new();
+        for (i, line) in lines.split('\n').enumerate() {
+            let line: Vec<char> = line.chars().collect();
+            let mut l = String::new();
+            let mut j = 0;
+            while let Some((a, b)) = re.find(&String::from_iter(&line[j..])) {
+                let m = j + a;
+                let n = j + b;
+                let before = String::from_iter(&line[j..m]);
+                let matched = String::from_iter(&line[m..n]);
+                l = format!("{}{}{}{}{}", l, before, match_color, matched, reset);
+                j = n;
+            }
+            if !l.is_empty() {
+                let after = String::from_iter(&line[j..]);
+                l.push_str(&after);
+                matches.push((i + 1, l)); // 1-index line numbers
+            }
+        }
+        if !matches.is_empty() {
+            if state.is_recursive {
+                if state.is_first_match {
+                    state.is_first_match = false;
+                } else {
+                    println!();
+                }
+                println!("{}{}{}", name_color, path, reset);
+            }
+            let width = matches[matches.len() - 1].0.to_string().len();
+            for (i, line) in matches {
+                println!("{}{:>width$}:{} {}", line_color, i, reset, line, width = width);
+            }
+        }
+    }
 }

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -37,20 +37,28 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
         i += 1;
     }
 
+    let num = Style::color("Yellow");
+    let color = Style::color("Red");
+    let reset = Style::reset();
+
     if let Some(pattern) = line {
         let re = Regex::new(pattern);
         if let Ok(lines) = fs::read_to_string(path) {
             let mut matches = Vec::new();
             for (i, line) in lines.split('\n').enumerate() {
-                if re.is_match(line) {
-                    matches.push((i, line));
+                let mut l = line.to_string();
+                if let Some((a, b)) = re.find(line) { // TODO: look for more matches
+                    let b = b + color.to_string().len();
+                    l.insert_str(a, &color.to_string());
+                    l.insert_str(b, &reset.to_string());
+                    matches.push((i, l));
                 }
             }
             if !matches.is_empty() {
                 // TODO: Print filename if we are walking a dir
                 let width = matches[matches.len() - 1].0.to_string().len();
                 for (i, line) in matches {
-                    println!("{}{:>width$}:{} {}", Style::color("Yellow"), i, Style::reset(), line, width = width);
+                    println!("{}{:>width$}:{} {}", num, i, reset, line, width = width);
                 }
             }
         }

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -102,6 +102,13 @@ fn print_matching_lines_in_file(path: &str, pattern: &str, state: &mut PrintingS
                 let matched = String::from_iter(&line[m..n]);
                 l = format!("{}{}{}{}{}", l, before, match_color, matched, reset);
                 j = n;
+                if m == n || n >= line.len() {
+                    // Some patterns like "" or ".*?" would never move the
+                    // cursor on the line and some like ".*" would match the
+                    // whole line at once. In both cases we print the line,
+                    // and we color it in the latter case.
+                    break;
+                }
             }
             if !l.is_empty() {
                 let after = String::from_iter(&line[j..]);

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -41,7 +41,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     }
 
     let num = Style::color("Yellow");
-    let color = Style::color("Red");
+    let color = Style::color("LightRed");
     let reset = Style::reset();
 
     if let Some(pattern) = line {

--- a/src/usr/mod.rs
+++ b/src/usr/mod.rs
@@ -8,6 +8,7 @@ pub mod dhcp;
 pub mod disk;
 pub mod editor;
 pub mod env;
+pub mod find;
 pub mod geotime;
 pub mod halt;
 pub mod help;

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -132,7 +132,7 @@ pub fn exec(cmd: &str) -> ExitCode {
         "c" | "copy"           => usr::copy::main(&args),
         "d" | "del" | "delete" => usr::delete::main(&args),
         "e" | "edit"           => usr::editor::main(&args),
-        "f" | "find"           => ExitCode::CommandUnknown,
+        "f" | "find"           => usr::find::main(&args),
         "g" | "go" | "goto"    => change_dir(&args),
         "h" | "help"           => usr::help::main(&args),
         "i"                    => ExitCode::CommandUnknown,


### PR DESCRIPTION
Add a very basic regular expression engine based on https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html

- [x] Support `.` char
- [x] Support `*` char
- [x] Support `+` char
- [x] Support `?` char
- [x] Support `\` char
- [ ] Support `|` char
- [x] Support `\d` chars
- [x] Support `\D` chars
- [x] Support `\s` chars
- [x] Support `\S` chars
- [x] Support `\w` chars
- [x] Support `\W` chars
- [ ] Support `{a,b}` range
- [x] Support lazy `?` char

Also add a `find --line` command that works like `grep` on Unix to test it on files.