### PR TITLE
Remove array-macro dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-macro"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a08c8f180019011a1d94e5eebcbfaa548736815f636fadc10955f1b622b4c71"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,7 +242,6 @@ version = "0.6.0"
 dependencies = [
  "acpi",
  "aml",
- "array-macro",
  "base64",
  "bit_field",
  "bootloader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ pcnet = []
 [dependencies]
 acpi = "4.0.0"
 aml = "0.16.0"
-array-macro = "2.1.0"
 base64 = { version = "0.13.0", default-features = false }
 bit_field = "0.10.0"
 bootloader = { version = "0.9.19", features = ["map_physical_memory"] }

--- a/src/sys/net/pcnet.rs
+++ b/src/sys/net/pcnet.rs
@@ -5,7 +5,6 @@ use crate::sys::net::Stats;
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use array_macro::array;
 use bit_field::BitField;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use smoltcp::Result;
@@ -155,8 +154,8 @@ impl PCNET {
             stats: Stats::new(),
             ports: Ports::new(io_base),
             eth_addr: None,
-            rx_buffers: array![PhysBuf::new(MTU); RX_BUFFERS_COUNT],
-            tx_buffers: array![PhysBuf::new(MTU); TX_BUFFERS_COUNT],
+            rx_buffers: [(); RX_BUFFERS_COUNT].map(|_| PhysBuf::new(MTU)),
+            tx_buffers: [(); TX_BUFFERS_COUNT].map(|_| PhysBuf::new(MTU)),
             rx_des: PhysBuf::new(RX_BUFFERS_COUNT * DE_LEN),
             tx_des: PhysBuf::new(TX_BUFFERS_COUNT * DE_LEN),
             rx_id: Arc::new(AtomicUsize::new(0)),

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -3,7 +3,6 @@ use crate::sys::allocator::PhysBuf;
 use crate::sys::net::Stats;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use array_macro::array;
 use core::convert::TryInto;
 use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy;
@@ -157,7 +156,7 @@ impl RTL8139 {
             rx_buffer: PhysBuf::new(RX_BUFFER_LEN + MTU),
 
             rx_offset: 0,
-            tx_buffers: array![PhysBuf::new(TX_BUFFER_LEN); TX_BUFFERS_COUNT],
+            tx_buffers: [(); TX_BUFFERS_COUNT].map(|_| PhysBuf::new(TX_BUFFER_LEN)),
 
             // Before a transmission begin the id is incremented,
             // so the first transimission will start at 0.


### PR DESCRIPTION
Hello, I'm a maintainer of `array-macro` crate.

Code that was using `array_macro::array!` used it incorrectly causing a subtle issue. In 2.0.0 the behaviour of `array` macro did change to clone values to match the behavior of standard library's [`vec! macro`](https://doc.rust-lang.org/stable/std/macro.vec.html).

In the code that used this macro it was used for objects of `PhysBuf` type.

```rust
#[derive(Clone)]
pub struct PhysBuf {
    buf: Arc<Mutex<Vec<u8>>>,
}
```

For `Arc` objects cloning doesn't create a new object, rather it shares a reference causing a subtle issue where all elements of `rx_buffers` shared the exact same buffer, which I don't think you have intended.

Standard library now contains `array::map` which can replace `array_macro::array!` in most situations. It may be a good idea to use that, considering amount of people that look at standard library's code is greater than number of people that look at `array_macro` (which is just me).