### PR TITLE
Improve UTF-8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Improve UTF-8 support (#267)
+- Bump acpi from 4.0.0 to 4.1.0 (#265)
 - Add shell redirections (#262)
+- Bump linked_list_allocator from 0.9.0 to 0.9.1 (#256)
 - Add calc command (#263)
 - Add website (#261)
 - Fix VGA issues with real hardware (#258)
 - Add rust binaries support (#255)
 - Add dynamical disk information (#252)
+- Remove array-macro dependency (#253)
 - Add spawn syscall (#251)
+- Bump x86_64 from 0.14.5 to 0.14.6 (#247)
 - Add ELF loader (#248)
 - Add basic userspace (#228)
 - Bump acpi from 3.1.0 to 4.0.0 (#243)

--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -81,7 +81,9 @@ fn color_to_bg(name: &str) -> Option<usize> {
 
 pub fn is_printable(c: char) -> bool {
     if cfg!(feature = "video") {
-        c.is_ascii() && sys::vga::is_printable(c as u8)
+        // Check if the char can be converted to ASCII or Extended ASCII before
+        // asking the VGA driver if it's printable.
+        ((c as u32) < 0xFF) && sys::vga::is_printable(c as u8)
     } else {
         true // TODO
     }

--- a/src/api/io.rs
+++ b/src/api/io.rs
@@ -13,10 +13,11 @@ impl Stdin {
     }
 
     pub fn read_char(&self) -> Option<char> {
-        let mut buf = vec![0; 1];
+        let mut buf = vec![0; 4];
         if let Some(bytes) = syscall::read(0, &mut buf) {
             if bytes > 0 {
-                return Some(buf[0] as char);
+                buf.resize(bytes, 0);
+                return Some(String::from_utf8_lossy(&buf).to_string().remove(0));
             }
         }
         None

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -10,7 +10,7 @@ pub struct Prompt {
     pub history: History,
     offset: usize, // Offset line by the length of the prompt string
     cursor: usize,
-    line: Vec<char>,
+    line: Vec<char>, // UTF-32
 }
 
 impl Prompt {
@@ -45,7 +45,7 @@ impl Prompt {
                     self.update_completion();
                     self.update_history();
                     println!();
-                    return Some(self.line.clone().into_iter().collect());
+                    return Some(self.line.iter().collect());
                 },
                 c => {
                    for b in c.encode_utf8(&mut bytes).as_bytes() {
@@ -92,7 +92,7 @@ impl Prompt {
                 }
             },
             None => {
-                let s: String = self.line.clone().into_iter().collect();
+                let s: String = self.line.iter().collect();
                 self.completion.entries = (self.completion.completer)(&s);
                 if !self.completion.entries.is_empty() {
                     (0, 0)
@@ -135,11 +135,10 @@ impl Prompt {
             Some(i) => (self.history.entries[i].chars().count(), i + 1),
             None => return,
         };
-        let line: String = self.line.clone().into_iter().collect();
         let (pos, line) = if i < n {
-            (Some(i), &self.history.entries[i])
+            (Some(i), self.history.entries[i].clone())
         } else {
-            (None, &line)
+            (None, self.line.iter().collect())
         };
         let erase = '\x08'.to_string().repeat(bs);
         print!("{}{}", erase, line);

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -31,7 +31,6 @@ impl Prompt {
         self.line = Vec::with_capacity(80);
         let mut parser = Parser::new();
         while let Some(c) = io::stdin().read_char() {
-            let mut bytes = [0; 4];
             match c {
                 '\x03' => { // End of Text (^C)
                     println!();
@@ -48,7 +47,7 @@ impl Prompt {
                     return Some(self.line.iter().collect());
                 },
                 c => {
-                   for b in c.encode_utf8(&mut bytes).as_bytes() {
+                   for b in c.to_string().as_bytes() {
                         parser.advance(self, *b);
                     }
                 }
@@ -92,8 +91,8 @@ impl Prompt {
                 }
             },
             None => {
-                let s: String = self.line.iter().collect();
-                self.completion.entries = (self.completion.completer)(&s);
+                let line: String = self.line.iter().collect();
+                self.completion.entries = (self.completion.completer)(&line);
                 if !self.completion.entries.is_empty() {
                     (0, 0)
                 } else {
@@ -170,9 +169,9 @@ impl Prompt {
         if self.cursor < self.offset + self.line.len() {
             let i = self.cursor - self.offset;
             self.line.remove(i);
-            let s = &self.line[i..];
+            let s = &self.line[i..]; // UTF-32
             let n = s.len() + 1;
-            let s: String = s.into_iter().collect();
+            let s: String = s.into_iter().collect(); // UTF-8
             print!("{} \x1b[{}D", s, n);
         }
     }
@@ -183,9 +182,9 @@ impl Prompt {
         if self.cursor > self.offset {
             let i = self.cursor - self.offset - 1;
             self.line.remove(i);
-            let s = &self.line[i..];
+            let s = &self.line[i..]; // UTF-32
             let n = s.len() + 1;
-            let s: String = s.into_iter().collect();
+            let s: String = s.into_iter().collect(); // UTF-8
             print!("{}{} \x1b[{}D", '\x08', s, n);
             self.cursor -= 1;
         }
@@ -198,9 +197,9 @@ impl Prompt {
             let c = (c as u8) as char;
             let i = self.cursor - self.offset;
             self.line.insert(i, c);
-            let s = &self.line[i..];
+            let s = &self.line[i..]; // UTF-32
             let n = s.len();
-            let s: String = s.into_iter().collect();
+            let s: String = s.into_iter().collect(); // UTF-8
             print!("{} \x1b[{}D", s, n);
             self.cursor += 1;
         } else {

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -79,11 +79,11 @@ impl Regex {
         self.find(text).is_some()
     }
     pub fn find(&self, text: &str) -> Option<(usize, usize)> {
-        let vec_re: Vec<char> = self.0.chars().collect();
-        let vec_text: Vec<char> = text.chars().collect();
+        let text: Vec<char> = text.chars().collect(); // UTF-32
+        let re: Vec<char> = self.0.chars().collect(); // UTF-32
         let mut start = 0;
         let mut end = 0;
-        if is_match(&vec_re[..], &vec_text[..], &mut start, &mut end) {
+        if is_match(&re[..], &text[..], &mut start, &mut end) {
             Some((start, end))
         } else {
             None

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -24,7 +24,7 @@ impl Console {
 
 impl FileIO for Console {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
-        let mut s = if buf.len() == 1 {
+        let mut s = if buf.len() == 4 {
             read_char().to_string()
         } else {
             read_line()
@@ -105,7 +105,7 @@ pub fn key_handle(key: char) {
             if is_echo_enabled() {
                 let n = match c {
                     ETX_KEY | EOT_KEY | ESC_KEY => 2,
-                    _ => c.len_utf8(),
+                    _ => if (c as u32) < 0xFF { 1 } else { c.len_utf8() },
                 };
                 print_fmt(format_args!("{}", BS_KEY.to_string().repeat(n)));
             }

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -111,6 +111,7 @@ pub fn key_handle(key: char) {
             }
         }
     } else {
+        let key = if (key as u32) < 0xFF { (key as u8) as char } else { key };
         stdin.push(key);
         if is_echo_enabled() {
             match key {


### PR DESCRIPTION
MOROS started with only ASCII but it supports AZERTY keyboards that have accented keys that break the assumption that a character in a string takes only one byte. This PR change the console IO, the prompt, and the editor to work on character vectors (equivalent to UTF-32) instead of strings (UTF-8).

It is good enough for Latin languages but more work is needed to fully support UTF-8. We'll also need to read the unicode table at the end of PCF fonts and improve rendering.