### PR TITLE
Enable asm_sym feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]
 #![feature(asm)]
+#![feature(asm_sym)]
 #![feature(naked_functions)]
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]


### PR DESCRIPTION
Fix `error[E0658]: sym operands for inline assembly are unstable` compilation error.

See https://github.com/rust-lang/rust/issues/72016