### PR TITLE
Fix autocomplete bug

### DIFF
--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -100,7 +100,7 @@ impl Prompt {
                 }
             },
         };
-        let erase = '\x08'.to_string().repeat(bs);
+        let erase = "\x08".repeat(bs);
         let complete = &self.completion.entries[pos];
         print!("{}{}", erase, complete);
         self.completion.pos = Some(pos);
@@ -194,7 +194,6 @@ impl Prompt {
         self.update_completion();
         self.update_history();
         if console::is_printable(c) {
-            let c = (c as u8) as char;
             let i = self.cursor - self.offset;
             self.line.insert(i, c);
             let s = &self.line[i..]; // UTF-32
@@ -202,7 +201,6 @@ impl Prompt {
             let s: String = s.into_iter().collect(); // UTF-8
             print!("{} \x1b[{}D", s, n);
             self.cursor += 1;
-        } else {
         }
     }
 }

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -66,9 +66,9 @@ impl Prompt {
 
     fn update_completion(&mut self) {
         if let Some(i) = self.completion.pos {
-            let mut complete: Vec<char> = self.completion.entries[i].chars().collect();
-            self.line.append(&mut complete);
-            self.cursor += complete.len();
+            let complete = self.completion.entries[i].chars();
+            self.cursor += complete.clone().count();
+            self.line.extend(complete);
             self.completion.pos = None;
             self.completion.entries = Vec::new();
         }

--- a/src/sys/net/pcnet.rs
+++ b/src/sys/net/pcnet.rs
@@ -330,8 +330,7 @@ impl<'a> Device<'a> for PCNET {
             ]) as usize;
 
             let n = if end_of_packet { packet_size } else { self.rx_buffers[rx_id].len() };
-            let mut buffer = self.rx_buffers[rx_id][0..n].to_vec();
-            packet.append(&mut buffer);
+            packet.extend(&self.rx_buffers[rx_id][0..n]);
 
             self.rx_des[rx_id * DE_LEN + 7].set_bit(DE_OWN, true); // Give back ownership
             rx_id = (rx_id + 1) % RX_BUFFERS_COUNT;

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -120,13 +120,13 @@ impl Editor {
 
         let mut row: Vec<char> = format!("{:cols$}", line, cols = self.dx).chars().collect();
         let n = self.dx + self.cols();
-        let mut after: Vec<char> = if row.len() > n {
+        let after = if row.len() > n {
             row.truncate(n - 1);
             truncated_line_indicator()
         } else {
             " ".repeat(n - row.len())
-        }.chars().collect();
-        row.append(&mut after);
+        };
+        row.extend(after.chars());
         row[self.dx..].iter().collect()
     }
 


### PR DESCRIPTION
Using `append` instead of `extend` move the elements instead of cloning them, producing a bug in the autocomplete code.