### PR TITLE
Improve file reading

### DIFF
--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -98,11 +98,11 @@ pub fn read_exact(path: &str, buf: &mut [u8]) -> Result<(), ()> {
 }
 
 pub fn read_to_string(path: &str) -> Result<String, ()> {
-    let buf = read(path)?;
+    let buf = read_to_bytes(path)?;
     Ok(String::from_utf8_lossy(&buf).to_string())
 }
 
-pub fn read(path: &str) -> Result<Vec<u8>, ()> {
+pub fn read_to_bytes(path: &str) -> Result<Vec<u8>, ()> {
     if let Some(stat) = syscall::stat(&path) {
         let res = if stat.is_device() { open_device(&path) } else { open_file(&path) };
         if let Some(handle) = res {

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -154,7 +154,7 @@ fn test_file() {
     assert_eq!(write("/test", &input), Ok(input.len()));
 
     // Read file
-    assert_eq!(read("/test"), Ok(input.to_vec()));
+    assert_eq!(read_to_bytes("/test"), Ok(input.to_vec()));
 
     dismount();
 }

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -80,17 +80,13 @@ pub fn create_device(path: &str, kind: DeviceType) -> Option<usize> {
     None
 }
 
-pub fn read_exact(path: &str, buf: &mut [u8]) -> Result<(), ()> {
+pub fn read(path: &str, buf: &mut [u8]) -> Result<usize, ()> {
     if let Some(stat) = syscall::stat(&path) {
         let res = if stat.is_device() { open_device(&path) } else { open_file(&path) };
         if let Some(handle) = res {
             if let Some(bytes) = syscall::read(handle, buf) {
-                if buf.len() != bytes {
-                    return Err(());
-                }
-
                 syscall::close(handle);
-                return Ok(());
+                return Ok(bytes);
             }
         }
     }

--- a/src/api/process.rs
+++ b/src/api/process.rs
@@ -1,12 +1,9 @@
 use crate::api::syscall;
-use crate::api::fs;
 
 pub fn spawn(path: &str) -> Result<(), ()> {
-    if let Ok(path) = fs::canonicalize(path) {
-        if syscall::stat(&path).is_some() {
-            syscall::spawn(&path);
-            return Ok(());
-        }
+    if syscall::stat(&path).is_some() {
+        syscall::spawn(&path);
+        return Ok(());
     }
     Err(())
 }

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -8,6 +8,8 @@ mod file;
 mod read_dir;
 mod super_block;
 
+use crate::sys;
+
 pub use bitmap_block::BITMAP_SIZE;
 pub use device::{Device, DeviceType};
 pub use dir::Dir;
@@ -19,6 +21,8 @@ pub use crate::sys::ata::BLOCK_SIZE;
 
 use dir_entry::DirEntry;
 use super_block::SuperBlock;
+
+use alloc::string::{String, ToString};
 
 pub const VERSION: u8 = 1;
 
@@ -95,6 +99,21 @@ impl FileIO for Resource {
             Resource::Dir(io) => io.write(buf),
             Resource::File(io) => io.write(buf),
             Resource::Device(io) => io.write(buf),
+        }
+    }
+}
+
+pub fn canonicalize(path: &str) -> Result<String, ()> {
+    match sys::process::env("HOME") {
+        Some(home) => {
+            if path.starts_with('~') {
+                Ok(path.replace('~', &home))
+            } else {
+                Ok(path.to_string())
+            }
+        },
+        None => {
+            Ok(path.to_string())
         }
     }
 }

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -22,7 +22,11 @@ pub fn realtime() -> f64 {
 }
 
 pub fn stat(path: &str, stat: &mut FileStat) -> isize {
-    if let Some(res) = sys::fs::stat(path) {
+    let path = match sys::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return -1,
+    };
+    if let Some(res) = sys::fs::stat(&path) {
         *stat = res;
         0
     } else {
@@ -31,7 +35,11 @@ pub fn stat(path: &str, stat: &mut FileStat) -> isize {
 }
 
 pub fn open(path: &str, flags: usize) -> isize {
-    if let Some(resource) = sys::fs::open(path, flags) {
+    let path = match sys::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return -1,
+    };
+    if let Some(resource) = sys::fs::open(&path, flags) {
         if let Ok(handle) = sys::process::create_file_handle(resource) {
             return handle as isize;
         }
@@ -72,7 +80,11 @@ pub fn close(handle: usize) {
 }
 
 pub fn spawn(path: &str) -> isize {
-    if let Some(mut file) = sys::fs::File::open(path) {
+    let path = match sys::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return -1,
+    };
+    if let Some(mut file) = sys::fs::File::open(&path) {
         let mut buf = vec![0; file.size()];
         if let Ok(bytes) = file.read(&mut buf) {
             buf.resize(bytes, 0);

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -15,7 +15,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
         return usr::shell::ExitCode::CommandError;
     }
 
-    if let Ok(contents) = fs::read(source) {
+    if let Ok(contents) = fs::read_to_bytes(source) {
         if fs::write(dest, &contents).is_ok() {
             usr::shell::ExitCode::CommandSuccessful
         } else {

--- a/src/usr/elf.rs
+++ b/src/usr/elf.rs
@@ -12,7 +12,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     let reset = Style::reset();
 
     let pathname = args[1];
-    if let Ok(buf) = fs::read(pathname) {
+    if let Ok(buf) = fs::read_to_bytes(pathname) {
         let bin = buf.as_slice();
         if let Ok(obj) = object::File::parse(bin) {
             println!("ELF entry address: {:#x}", obj.entry());

--- a/src/usr/hex.rs
+++ b/src/usr/hex.rs
@@ -8,7 +8,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
         return usr::shell::ExitCode::CommandError;
     }
     let pathname = args[1];
-    if let Ok(buf) = fs::read(pathname) { // TODO: read chunks
+    if let Ok(buf) = fs::read_to_bytes(pathname) { // TODO: read chunks
         print_hex(&buf);
         usr::shell::ExitCode::CommandSuccessful
     } else {

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -265,6 +265,10 @@ fn default_env<'a>() -> Env<'a> {
         buf.resize(bytes, 0);
         Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
     }));
+    data.insert("bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+        ensure_length_eq!(args, 1);
+        let s = string(&args[0])?;
+        let buf = s.as_bytes();
         Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
     }));
     data.insert("str".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -250,6 +250,14 @@ fn default_env<'a>() -> Env<'a> {
             }
         }
     }));
+    data.insert("read-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+        ensure_length_eq!(args, 2);
+        let path = string(&args[0])?;
+        let len = float(&args[1])?;
+        let mut buf = vec![0; len as usize];
+        fs::read_exact(&path, &mut buf).or(Err(Err::Reason("Could not read file".to_string())))?;
+        Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
+    }));
     data.insert("read".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let path = string(&args[0])?;

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -458,6 +458,14 @@ fn eval_mapcar_args(args: &[Exp], env: &mut Env) -> Result<Exp, Err> {
     }
 }
 
+fn eval_progn_args(args: &[Exp], env: &mut Env) -> Result<Exp, Err> {
+    let mut res = Ok(Exp::List(vec![]));
+    for arg in args {
+        res = Ok(eval(&arg, env)?);
+    }
+    res
+}
+
 fn eval_load_args(args: &[Exp], env: &mut Env) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     let path = string(&args[0])?;
@@ -492,6 +500,7 @@ fn eval_built_in_form(exp: &Exp, args: &[Exp], env: &mut Env) -> Option<Result<E
 
                 "defun" | "defn" => Some(eval_defun_args(args, env)),
                 "mapcar" | "map" => Some(eval_mapcar_args(args, env)),
+                "progn" | "do"   => Some(eval_progn_args(args, env)),
                 "load"           => Some(eval_load_args(args, env)),
                 _                => None,
             }

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -261,7 +261,10 @@ fn default_env<'a>() -> Env<'a> {
         let path = string(&args[0])?;
         let len = float(&args[1])?;
         let mut buf = vec![0; len as usize];
-        fs::read_exact(&path, &mut buf).or(Err(Err::Reason("Could not read file".to_string())))?;
+        let bytes = fs::read(&path, &mut buf).or(Err(Err::Reason("Could not read file".to_string())))?;
+        buf.resize(bytes, 0);
+        Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
+    }));
         Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
     }));
     data.insert("str".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {

--- a/src/usr/read.rs
+++ b/src/usr/read.rs
@@ -76,7 +76,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
                     usr::list::main(args)
                 } else if stat.is_device() {
                     loop {
-                        if let Ok(bytes) = fs::read(pathname) {
+                        if let Ok(bytes) = fs::read_to_bytes(pathname) {
                             print!("{}", bytes[0] as char);
                         }
                         if sys::console::end_of_text() {

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -10,7 +10,7 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     match args[1] {
         "set" => {
             if args.len() == 4 && args[2] == "font" {
-                if let Ok(buf) = fs::read(args[3]) {
+                if let Ok(buf) = fs::read_to_bytes(args[3]) {
                     if let Ok(font) = api::font::from_bytes(&buf) {
                         sys::vga::set_font(&font);
                     } else {


### PR DESCRIPTION
- [x] Rename `api::fs::read(path)` to `api::fs::read_to_bytes(path)`
- [x] Add `api::fs::read(path, buf)`
- [x] Move `api::fs::canonicalize(path)` to kernel internal in `sys::fs`
- [x] Add `(read-bytes <path> <len>)` to read `len` bytes from a file in lisp
- [x] Add `(bytes <str>)` to transform a string into a list of bytes in lisp
- [x] Add `(str <bytes>)` to transform a list of bytes into a string in lisp
- [x] Add `progn` (aliased to `do`) to evaluate a sequence of expression in lisp