### PR TITLE
Improve dhcp command

### DIFF
--- a/src/usr/dhcp.rs
+++ b/src/usr/dhcp.rs
@@ -68,20 +68,21 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     }
 
     if let Some(config) = dhcp_config {
+        //debug!("{:#?}", config);
         usr::net::main(&["net", "config", "ip", &config.address.to_string()]);
         usr::net::main(&["net", "config", "ip"]);
 
         if let Some(router) = config.router {
-            //iface.routes_mut().add_default_ipv4_route(router).unwrap();
             usr::net::main(&["net", "config", "gw", &router.to_string()]);
         } else {
-            //iface.routes_mut().remove_default_ipv4_route();
-            usr::net::main(&["net", "config", "gw", ""]);
+            usr::net::main(&["net", "config", "gw", "0.0.0.0"]);
         }
         usr::net::main(&["net", "config", "gw"]);
 
         let dns: Vec<_> = config.dns_servers.iter().filter_map(|s| *s).map(|s| s.to_string()).collect();
-        usr::net::main(&["net", "config", "dns", &dns.join(",")]);
+        if !dns.is_empty() {
+            usr::net::main(&["net", "config", "dns", &dns.join(",")]);
+        }
         usr::net::main(&["net", "config", "dns"]);
 
         return usr::shell::ExitCode::CommandSuccessful;

--- a/src/usr/net.rs
+++ b/src/usr/net.rs
@@ -215,14 +215,16 @@ pub fn set_config(attribute: &str, value: &str) {
             }
         }
         "gw" => {
-            if let Ok(ip) = Ipv4Address::from_str(value) {
-                if let Some(ref mut iface) = *sys::net::IFACE.lock() {
+            if let Some(ref mut iface) = *sys::net::IFACE.lock() {
+                if value == "0.0.0.0" {
+                    iface.routes_mut().remove_default_ipv4_route();
+                } else if let Ok(ip) = Ipv4Address::from_str(value) {
                     iface.routes_mut().add_default_ipv4_route(ip).unwrap();
                 } else {
-                    error!("Network error");
+                    error!("Could not parse address");
                 }
             } else {
-                error!("Could not parse address");
+                error!("Network error");
             }
         }
         "dns" => {


### PR DESCRIPTION
Avoid errors when a DHCP request return no default gateway or DNS servers.

Add `net config gw 0.0.0.0` to remove the default gateway.