### PR TITLE
Replace ChaCha RNG by HC-128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,8 +264,7 @@ dependencies = [
  "pc-keyboard",
  "pic8259",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_hc 0.3.1",
  "raw-cpuid",
  "sha2",
  "smoltcp",
@@ -376,9 +375,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "rand_chacha 0.2.2",
+ "rand_chacha",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -401,16 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ pbkdf2 = { version = "0.11.0", default-features = false }
 pc-keyboard = "0.5.1"
 pic8259 = "0.10.2"
 rand = { version = "0.8.5", default-features = false }
-rand_chacha = { version = "0.3.1", default-features = false }
-rand_core = { version = "0.6.3", default-features = false }
+rand_hc = "0.3.1"
 raw-cpuid = "10.3.0"
 sha2 = { version = "0.10.2", default-features = false, features = ["force-soft"] }
 smoltcp = { version = "0.8.0", default-features = false, features = ["alloc", "medium-ethernet", "socket-tcp", "socket-udp", "socket-dhcpv4", "proto-ipv4", "proto-dhcpv4"] }


### PR DESCRIPTION
The `rand_chacha` crate restricted us to release mode only because of a LLVM error described here: https://github.com/vinc/moros/pull/120

When reading this https://github.com/rust-osdev/bootloader/pull/229#issuecomment-1094289805 I discovered that I could replace it with the `rand_hc` crate to simplify the code and allow compilation of the debug mode.

See https://en.wikipedia.org/wiki/Salsa20#ChaCha_variant and https://en.wikipedia.org/wiki/HC-256