### PR TITLE
Build only moros image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(img):
 image: $(img)
 	touch src/lib.rs
 	env | grep MOROS
-	cargo bootimage --no-default-features --features $(output) --release
+	cargo bootimage --no-default-features --features $(output) --release --bin moros
 	dd conv=notrunc if=$(bin) of=$(img)
 
 opts = -m 32 -cpu max -nic model=$(nic) -hda $(img) -soundhw pcspk


### PR DESCRIPTION
Add `--bin moros` to `cargo bootimage` to avoid building images for userland binaries