### PR TITLE
Add shell variables

### DIFF
--- a/doc/shell.md
+++ b/doc/shell.md
@@ -121,3 +121,25 @@ Which is more efficient than doing:
 
     > print hello -> write /tmp/hello
 
+## Variables
+
+- Name of the shell or the script: `$0`
+- Script arguments: `$1`, `$2`, `$3`, `$4`, ...
+- Process environment variable: `$HOME`, ...
+- Shell environment variable: `$foo`, ...
+
+Setting a variable in the shell environment is done with the following command:
+
+    > foo = "world"
+
+And accessing that variable is done with the `$` operator:
+
+    > print $foo
+    world
+
+    > print "hello $foo"
+    hello world
+
+The process environment is copied to the shell environment when a session is
+started. By convention a process env var should be in uppercase and a shell
+env var should be lowercase.

--- a/doc/syscalls.md
+++ b/doc/syscalls.md
@@ -62,10 +62,10 @@ pub fn delete(path: &str) -> isize
 pub fn stop(code: usize)
 ```
 
+The system will reboot with `0xcafe` and halt with `0xdead`.
+
 ## SLEEP (0xB)
 
 ```rust
 pub fn sleep(seconds: f64)
 ```
-
-The system will reboot with `0xcafe` and halt with `0xdead`.

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -266,5 +266,5 @@ fn test_regex() {
     assert_eq!(Regex::new("b.*?c").find("aaabbbcccddd"), Some((3, 7)));
     assert_eq!(Regex::new("a\\w*d").find("abcdabcd"), Some((0, 8)));
     assert_eq!(Regex::new("a\\w*?d").find("abcdabcd"), Some((0, 4)));
-    assert_eq!(Regex::new("\\$\\w+").find("test $test test"), Some((5, 9)));
+    assert_eq!(Regex::new("\\$\\w+").find("test $test test"), Some((5, 10)));
 }

--- a/src/api/regex.rs
+++ b/src/api/regex.rs
@@ -64,9 +64,11 @@ impl Regex {
     pub fn new(re: &str) -> Self {
         Self(re.to_string())
     }
+
     pub fn is_match(&self, text: &str) -> bool {
         self.find(text).is_some()
     }
+
     pub fn find(&self, text: &str) -> Option<(usize, usize)> {
         let text: Vec<char> = text.chars().collect(); // UTF-32
         let re: Vec<char> = self.0.chars().collect(); // UTF-32
@@ -264,4 +266,5 @@ fn test_regex() {
     assert_eq!(Regex::new("b.*?c").find("aaabbbcccddd"), Some((3, 7)));
     assert_eq!(Regex::new("a\\w*d").find("abcdabcd"), Some((0, 8)));
     assert_eq!(Regex::new("a\\w*?d").find("abcdabcd"), Some((0, 4)));
+    assert_eq!(Regex::new("\\$\\w+").find("test $test test"), Some((5, 9)));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,10 @@ fn main(boot_info: &'static BootInfo) -> ! {
     print!("\x1b[?25h"); // Enable cursor
     loop {
         if let Some(cmd) = option_env!("MOROS_CMD") {
-            let env = usr::shell::default_env();
+            let mut env = usr::shell::default_env();
             let prompt = usr::shell::prompt_string(true);
             println!("{}{}", prompt, cmd);
-            usr::shell::exec(cmd, &env);
+            usr::shell::exec(cmd, &mut env);
             sys::acpi::shutdown();
         } else {
             user_boot();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,10 @@ fn main(boot_info: &'static BootInfo) -> ! {
     print!("\x1b[?25h"); // Enable cursor
     loop {
         if let Some(cmd) = option_env!("MOROS_CMD") {
+            let env = usr::shell::default_env();
             let prompt = usr::shell::prompt_string(true);
             println!("{}{}", prompt, cmd);
-            usr::shell::exec(cmd);
+            usr::shell::exec(cmd, &env);
             sys::acpi::shutdown();
         } else {
             user_boot();

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -294,8 +294,8 @@ fn default_env() -> Rc<RefCell<Env>> {
     data.insert("system".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let cmd = string(&args[0])?;
-        let env = usr::shell::default_env();
-        let res = usr::shell::exec(&cmd, &env);
+        let mut env = usr::shell::default_env();
+        let res = usr::shell::exec(&cmd, &mut env);
         Ok(Exp::Num(res as u8 as f64))
     }));
     data.insert("print".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -294,7 +294,8 @@ fn default_env() -> Rc<RefCell<Env>> {
     data.insert("system".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let cmd = string(&args[0])?;
-        let res = usr::shell::exec(&cmd);
+        let env = usr::shell::default_env();
+        let res = usr::shell::exec(&cmd, &env);
         Ok(Exp::Num(res as u8 as f64))
     }));
     data.insert("print".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -391,7 +391,7 @@ fn test_shell() {
     sys::fs::format_mem();
     usr::install::copy_files(false);
 
-    let env = default_env();
+    let mut env = default_env();
 
     // Redirect standard output
     exec("print test1 => /test", &mut env);
@@ -408,6 +408,10 @@ fn test_shell() {
     // Redirect standard error explicitely
     exec("hex /nope 2=> /test", &mut env);
     assert!(api::fs::read_to_string("/test").unwrap().contains("File not found '/nope'"));
+
+    exec("b = 42", &mut env);
+    exec("print a $b $c d => /test", &mut env);
+    assert_eq!(api::fs::read_to_string("/test"), Ok("a 42 d\n".to_string()));
 
     sys::fs::dismount();
 }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -314,7 +314,7 @@ pub fn exec(cmd: &str, env: &BTreeMap<String, String>) -> ExitCode {
     res
 }
 
-pub fn run(env: &BTreeMap<String, String>) -> usr::shell::ExitCode {
+fn repl(env: &BTreeMap<String, String>) -> usr::shell::ExitCode {
     println!();
 
     let mut prompt = Prompt::new();
@@ -348,7 +348,7 @@ pub fn main(args: &[&str]) -> ExitCode {
     let mut env = default_env();
 
     if args.len() < 2 {
-        run(&env)
+        repl(&env)
     } else {
         let pathname = args[1];
 

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -348,15 +348,18 @@ pub fn main(args: &[&str]) -> ExitCode {
     let mut env = default_env();
 
     if args.len() < 2 {
+        env.insert("$0".to_string(), args[0].to_string());
+
         repl(&env)
     } else {
-        let pathname = args[1];
+        env.insert("$0".to_string(), args[1].to_string());
 
         // Add script arguments to the environment as `$1`, `$2`, `$3`, ...
         for (i, arg) in args[2..].iter().enumerate() {
             env.insert(format!("${}", i + 1), arg.to_string());
         }
 
+        let pathname = args[1];
         if let Ok(contents) = api::fs::read_to_string(pathname) {
             for line in contents.split('\n') {
                 if !line.is_empty() {

--- a/src/usr/time.rs
+++ b/src/usr/time.rs
@@ -6,9 +6,9 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     let csi_color = Style::color("LightBlue");
     let csi_reset = Style::reset();
     let cmd = args[1..].join(" ");
-    let env = usr::shell::default_env();
+    let mut env = usr::shell::default_env();
     let start = clock::realtime();
-    usr::shell::exec(&cmd, &env);
+    usr::shell::exec(&cmd, &mut env);
     let duration = clock::realtime() - start;
     println!("{}Executed '{}' in {:.6}s{}", csi_color, cmd, duration, csi_reset);
     usr::shell::ExitCode::CommandSuccessful

--- a/src/usr/time.rs
+++ b/src/usr/time.rs
@@ -6,8 +6,9 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
     let csi_color = Style::color("LightBlue");
     let csi_reset = Style::reset();
     let cmd = args[1..].join(" ");
+    let env = usr::shell::default_env();
     let start = clock::realtime();
-    usr::shell::exec(&cmd);
+    usr::shell::exec(&cmd, &env);
     let duration = clock::realtime() - start;
     println!("{}Executed '{}' in {:.6}s{}", csi_color, cmd, duration, csi_reset);
     usr::shell::ExitCode::CommandSuccessful


### PR DESCRIPTION
- Add access to the the pathname of the script or the shell via `$0`
- Add access to script arguments via `$1`, `$2`, `$3`, and so on
- Add access to environment variables like `$HOME`
- Allow setting a shell variable with `test = 42` to access it via `$test`