### PR TITLE
Add shell globbing

### DIFF
--- a/doc/shell.md
+++ b/doc/shell.md
@@ -143,3 +143,15 @@ And accessing that variable is done with the `$` operator:
 The process environment is copied to the shell environment when a session is
 started. By convention a process env var should be in uppercase and a shell
 env var should be lowercase.
+
+## Globbing
+
+MOROS Shell support filename expansion or globbing for `*` and `?` wildcard
+characters, where a pattern given in an argument of a command will be replaced
+by files matching the pattern.
+
+- `*` means zero or more chars except `/`
+- `?` means any char except `/`
+
+For example `/tmp/*.txt` will match any files with the `txt` extension inside
+`/tmp`, and `a?c.txt` will match a file named `abc.txt`.

--- a/src/usr/delete.rs
+++ b/src/usr/delete.rs
@@ -3,34 +3,35 @@ use crate::api::syscall;
 use crate::api::fs;
 
 pub fn main(args: &[&str]) -> usr::shell::ExitCode {
-    if args.len() != 2 {
+    if args.len() < 2 {
         return usr::shell::ExitCode::CommandError;
     }
 
-    let mut pathname = args[1];
+    for arg in &args[1..] {
+        let mut pathname = arg.clone();
 
-    // The commands `delete /usr/alice/` and `delete /usr/alice` are equivalent,
-    // but `delete /` should not be modified.
-    if pathname.len() > 1 {
-        pathname = pathname.trim_end_matches('/');
-    }
+        // The commands `delete /usr/alice/` and `delete /usr/alice` are equivalent,
+        // but `delete /` should not be modified.
+        if pathname.len() > 1 {
+            pathname = pathname.trim_end_matches('/');
+        }
 
-    if !fs::exists(pathname) {
-        error!("File not found '{}'", pathname);
-        return usr::shell::ExitCode::CommandError;
-    }
+        if !fs::exists(pathname) {
+            error!("File not found '{}'", pathname);
+            return usr::shell::ExitCode::CommandError;
+        }
 
-    if let Some(info) = syscall::info(pathname) {
-        if info.is_dir() && info.size() > 0 {
-            error!("Directory '{}' not empty", pathname);
+        if let Some(info) = syscall::info(pathname) {
+            if info.is_dir() && info.size() > 0 {
+                error!("Directory '{}' not empty", pathname);
+                return usr::shell::ExitCode::CommandError;
+            }
+        }
+
+        if fs::delete(pathname).is_err() {
+            error!("Could not delete file '{}'", pathname);
             return usr::shell::ExitCode::CommandError;
         }
     }
-
-    if fs::delete(pathname).is_ok() {
-        usr::shell::ExitCode::CommandSuccessful
-    } else {
-        error!("Could not delete file '{}'", pathname);
-        usr::shell::ExitCode::CommandError
-    }
+    usr::shell::ExitCode::CommandSuccessful
 }

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -61,8 +61,9 @@ pub fn main(args: &[&str]) -> usr::shell::ExitCode {
         path = path.trim_end_matches('/');
     }
 
-    if name.is_some() {
-        todo!();
+    if name.is_some() { // TODO
+        error!("`--name` is not implemented");
+        return usr::shell::ExitCode::CommandError;
     }
 
     let mut state = PrintingState::new();
@@ -153,7 +154,7 @@ fn help() -> usr::shell::ExitCode {
     println!("{}Usage:{} find {}<options> <path>{1}", csi_title, csi_reset, csi_option);
     println!();
     println!("{}Options:{}", csi_title, csi_reset);
-    println!("  {0}-n{1},{0} --name <pattern>{1}    Find file name matching {0}<pattern>{1}", csi_option, csi_reset);
-    println!("  {0}-l{1},{0} --line <pattern>{1}    Find lines matching {0}<pattern>{1}", csi_option, csi_reset);
+    println!("  {0}-n{1},{0} --name \"<pattern>\"{1}    Find file name matching {0}<pattern>{1}", csi_option, csi_reset);
+    println!("  {0}-l{1},{0} --line \"<pattern>\"{1}    Find lines matching {0}<pattern>{1}", csi_option, csi_reset);
     usr::shell::ExitCode::CommandSuccessful
 }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -119,13 +119,13 @@ fn glob_to_regex(pattern: &str) -> String {
     )
 }
 
-fn glob(path: &str) -> Vec<String> {
+fn glob(arg: &str) -> Vec<String> {
     let mut matches = Vec::new();
-    if is_globbing(path) {
-        let (dir, pattern) = if path.contains("/") {
-            (fs::dirname(&path).to_string(), fs::filename(&path).to_string())
+    if is_globbing(arg) {
+        let (dir, pattern) = if arg.contains("/") {
+            (fs::dirname(&arg).to_string(), fs::filename(&arg).to_string())
         } else {
-            (sys::process::dir().clone(), path.to_string())
+            (sys::process::dir().clone(), arg.to_string())
         };
 
         let re = Regex::new(&glob_to_regex(&pattern));
@@ -139,7 +139,7 @@ fn glob(path: &str) -> Vec<String> {
             }
         }
     } else {
-        matches.push(path.to_string());
+        matches.push(arg.to_string());
     }
     matches
 }


### PR DESCRIPTION
Add support to the shell of filename expansion or globbing for `*` and `?` wildcard characters, where a pattern given in an argument of a command will be replaced by files matching the pattern.

- `*` means zero or more chars except `/`
- `?` means any char except `/`

For example `/tmp/*.txt` will match any files with the `txt` extension inside `/tmp`, and `a?c.txt` will match a file named `abc.txt`.