### PR TITLE
Add userspace entry_point macro

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(test))]
 #[macro_export]
 macro_rules! entry_point {
     ($path:path) => {

--- a/src/bin/clear.rs
+++ b/src/bin/clear.rs
@@ -2,16 +2,11 @@
 #![no_main]
 
 use moros::api::syscall;
-use core::panic::PanicInfo;
+use moros::entry_point;
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
+entry_point!(main);
 
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start() {
+fn main(_args: &[&str]) -> usize {
     syscall::write(1, b"\x1b[2J\x1b[1;1H"); // Clear screen and move cursor to top
-    syscall::exit(0);
+    0
 }

--- a/src/bin/halt.rs
+++ b/src/bin/halt.rs
@@ -2,17 +2,11 @@
 #![no_main]
 
 use moros::api::syscall;
+use moros::entry_point;
 
-use core::panic::PanicInfo;
+entry_point!(main);
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
-
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start() {
+fn main(_args: &[&str]) -> usize {
     syscall::write(1, b"\x1b[93m"); // Yellow
     syscall::write(1, b"MOROS has reached its fate, the system is now halting.\n");
     syscall::write(1, b"\x1b[0m"); // Reset

--- a/src/bin/hello.rs
+++ b/src/bin/hello.rs
@@ -2,16 +2,11 @@
 #![no_main]
 
 use moros::api::syscall;
-use core::panic::PanicInfo;
+use moros::entry_point;
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
+entry_point!(main);
 
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start() {
+fn main(_args: &[&str]) -> usize {
     syscall::write(1, b"Hello, World!\n");
-    syscall::exit(0);
+    0
 }

--- a/src/bin/print.rs
+++ b/src/bin/print.rs
@@ -1,21 +1,10 @@
 #![no_std]
 #![no_main]
 
+use moros::entry_point;
 use moros::api::syscall;
-use core::panic::PanicInfo;
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
-
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start(args_ptr: u64, args_len: usize) {
-    let args = core::slice::from_raw_parts(args_ptr as *const _, args_len);
-    let code = main(args);
-    syscall::exit(code);
-}
+entry_point!(main);
 
 fn main(args: &[&str]) -> usize {
     let n = args.len();

--- a/src/bin/reboot.rs
+++ b/src/bin/reboot.rs
@@ -2,17 +2,11 @@
 #![no_main]
 
 use moros::api::syscall;
+use moros::entry_point;
 
-use core::panic::PanicInfo;
+entry_point!(main);
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
-
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start() {
+fn main(_args: &[&str]) -> usize {
     syscall::write(1, b"\x1b[93m"); // Yellow
     syscall::write(1, b"MOROS has reached its fate, the system is now rebooting.\n");
     syscall::write(1, b"\x1b[0m"); // Reset

--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -2,20 +2,9 @@
 #![no_main]
 
 use moros::api::syscall;
-use core::panic::PanicInfo;
+use moros::entry_point;
 
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    syscall::write(1, b"An exception occured!\n");
-    loop {}
-}
-
-#[no_mangle]
-pub unsafe extern "sysv64" fn _start(args_ptr: u64, args_len: usize) {
-    let args = core::slice::from_raw_parts(args_ptr as *const _, args_len);
-    let code = main(args);
-    syscall::exit(code);
-}
+entry_point!(main);
 
 fn main(args: &[&str]) -> usize {
     if args.len() == 2 {


### PR DESCRIPTION
Hide the boiler plate code needed to run a userspace program behind an `entry_point` macro.