### PR TITLE
Fix args ptr alignment

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-04-15"
+channel = "nightly-2022-06-21"
 components = ["rust-src", "llvm-tools-preview"]


### PR DESCRIPTION
The pointer to the command line arguments passed to a process wasn't aligned in some situations, causing a Segment Not Present exception in debug mode. This PR rewrite this part of the code to make it slightly simpler and align the pointer.