### PR TITLE
Improve lisp

### DIFF
--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -31,9 +31,21 @@ of strings to the language and reading from the filesystem.
 - `defun` (aliased to `defn`)
 - `mapcar` (aliased to `map`)
 - `print`
-- `read-file`
+- `read`
+- `read-bytes`
+- `bytes`
+- `str`
+- `cat`
+- `join`
 - `lines`
 - `parse`
+- `type`
+- `system`
+
+- Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`
+- Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
+- Comparisons: `>`, `<`, `>=`, `<=`, `=`
+- Boolean operations: `and`, `or`
 
 ## Usage
 

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -52,7 +52,7 @@
     ((null? a) a)
     (true (append (reverse (rest a)) (cons (first a) '())))))
 
-(defn read-line
+(defn read-line ()
   (str (reverse (rest (reverse (read-bytes "/dev/console" 256))))))
 
 (defn println (exp)

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -47,5 +47,10 @@
     ((null? a) b)
     (true (cons (first a) (append (rest a) b)))))
 
+(defn reverse (a)
+    (cond
+        ((null? a) a)
+        (true (append (reverse (rest a)) (cons (first a) '())))))
+
 (defn println (exp)
   (do (print exp) (print "\n")))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -30,17 +30,22 @@
 (defn null? (x)
   (eq? x null))
 
-(defn first (lst)
-  (car lst))
+(defn rest (a)
+  (cdr a))
 
-(defn rest (lst)
-  (cdr lst))
+(defn first (a)
+  (car a))
 
-(defn second (lst)
-  (first (rest lst)))
+(defn second (a)
+  (first (rest a)))
 
-(defn third (lst)
-  (second (rest lst)))
+(defn third (a)
+  (second (rest a)))
+
+(defn append (a b)
+ (cond
+    ((null? a) b)
+    (true (cons (first a) (append (rest a) b)))))
 
 (defn println (exp)
   (do (print exp) (print "\n")))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -43,19 +43,17 @@
   (second (rest a)))
 
 (defn append (a b)
- (cond
+  (cond
     ((null? a) b)
     (true (cons (first a) (append (rest a) b)))))
 
 (defn reverse (a)
-    (cond
-        ((null? a) a)
-        (true (append (reverse (rest a)) (cons (first a) '())))))
+  (cond
+    ((null? a) a)
+    (true (append (reverse (rest a)) (cons (first a) '())))))
 
-(defn read-line (s)
-    (do
-      (print s)
-      (str (reverse (rest (reverse (read-bytes "/dev/console" 256)))))))
+(defn read-line
+  (str (reverse (rest (reverse (read-bytes "/dev/console" 256))))))
 
 (defn println (exp)
   (do (print exp) (print "\n")))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -52,5 +52,10 @@
         ((null? a) a)
         (true (append (reverse (rest a)) (cons (first a) '())))))
 
+(defn read-line (s)
+    (do
+      (print s)
+      (str (reverse (rest (reverse (read-bytes "/dev/console" 256)))))))
+
 (defn println (exp)
   (do (print exp) (print "\n")))

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -305,15 +305,10 @@ fn default_env() -> Rc<RefCell<Env>> {
     data.insert("print".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         match args[0].clone() {
-            Exp::Str(s) => {
-                print!("{}", s);
-                Ok(Exp::Str(s))
-            }
-            exp => {
-                print!("{}", exp);
-                Ok(exp)
-            }
+            Exp::Str(s) => print!("{}", s),
+            exp => print!("{}", exp),
         }
+        Ok(Exp::List(Vec::new()))
     }));
     data.insert("read".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);


### PR DESCRIPTION
- [x] Add empty string `""`
- [x] Add `append` to core
- [x] Add `reverse` to core
- [x] Add `read-line` to core
- [x] Change `print` to return `()`
- [x] Add trigonometric functions (`acos`, `asin`, `atan`, `cos`, `sin`, `tan`)