### PR TITLE
Upgrade linked list allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
 dependencies = [
  "spinning_top",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
+checksum = "636c3bc929db632724303109c88d5d559a2a60f62243bb041387f03fa081d94a"
 dependencies = [
  "spinning_top",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ float-cmp = "0.9.0"
 hmac = { version = "0.12.1", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libm = "0.2.2"
-linked_list_allocator = "0.10.0"
+linked_list_allocator = "0.10.1"
 littlewing = { version = "0.7.0", default-features = false }
 nom = { version = "7.1.1", default-features = false, features = ["alloc"] }
 object = { version = "0.29.0", default-features = false, features = ["read"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ float-cmp = "0.9.0"
 hmac = { version = "0.12.1", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libm = "0.2.2"
-linked_list_allocator = "0.9.1"
+linked_list_allocator = "0.10.0"
 littlewing = { version = "0.7.0", default-features = false }
 nom = { version = "7.1.1", default-features = false, features = ["alloc"] }
 object = { version = "0.29.0", default-features = false, features = ["read"] }

--- a/src/sys/allocator.rs
+++ b/src/sys/allocator.rs
@@ -20,9 +20,9 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 pub fn init_heap(mapper: &mut impl Mapper<Size4KiB>, frame_allocator: &mut impl FrameAllocator<Size4KiB>) -> Result<(), MapToError<Size4KiB>> {
     // Use half of the memory for the heap, caped to 16 MB because the allocator is too slow
     let heap_size = cmp::min(sys::mem::memory_size() / 2, 16 << 20);
+    let heap_start = VirtAddr::new(HEAP_START as u64);
 
     let pages = {
-        let heap_start = VirtAddr::new(HEAP_START as u64);
         let heap_end = heap_start + heap_size - 1u64;
         let heap_start_page = Page::containing_address(heap_start);
         let heap_end_page = Page::containing_address(heap_end);
@@ -38,7 +38,7 @@ pub fn init_heap(mapper: &mut impl Mapper<Size4KiB>, frame_allocator: &mut impl 
     }
 
     unsafe {
-        ALLOCATOR.lock().init(HEAP_START, heap_size as usize);
+        ALLOCATOR.lock().init(heap_start.as_mut_ptr(), heap_size as usize);
     }
 
     Ok(())


### PR DESCRIPTION
The constructor of the allocator in version 0.10.0 takes a pointer instead of the address of `HEAP_START`

See https://github.com/rust-osdev/linked-list-allocator/blob/main/Changelog.md#0100--2022-06-27
And https://github.com/rust-osdev/linked-list-allocator/pull/62

But this breaks the boot of MOROS during the first initialization of a string from what I can see in gdb:

```
...
#31 0x0000000000253c7f in moros::panic (info=0x10000201368) at src/main.rs:44
#32 0x00000000006252f3 in core::panicking::panic_fmt (fmt=...) at src/panicking.rs:142
#33 0x000000000062516a in core::panicking::panic (expr=...) at src/panicking.rs:48
#34 0x00000000004f0b7a in linked_list_allocator::hole::Cursor::try_insert_after (self=0x100002015e8, node=...) at src/hole.rs:439
#35 0x00000000004f0fea in linked_list_allocator::hole::deallocate (list=0x67aba0 <moros::sys::allocator::ALLOCATOR+32>, addr=0x444444440328, size=192)
    at src/hole.rs:536
#36 0x00000000004f03fd in linked_list_allocator::hole::HoleList::deallocate (self=0x67aba0 <moros::sys::allocator::ALLOCATOR+32>, ptr=..., layout=...)
    at src/hole.rs:353
#37 0x00000000004eec66 in linked_list_allocator::Heap::deallocate (self=0x67ab88 <moros::sys::allocator::ALLOCATOR+8>, ptr=..., layout=...)
    at src/lib.rs:182
#38 0x00000000004eee38 in linked_list_allocator::{impl#4}::dealloc (self=0x67ab80 <moros::sys::allocator::ALLOCATOR>, ptr=0x444444440328, layout=...)
    at src/lib.rs:302
#39 0x000000000034a04c in moros::sys::allocator::_::__rg_dealloc (arg0=0x444444440328, arg1=192, arg2=8) at src/sys/allocator.rs:18
#40 0x00000000005e1f2a in alloc::alloc::dealloc (ptr=0x444444440328, layout=...)
...
#49 0x0000000000259a65 in alloc::string::{impl#40}::to_string<time::format::deferred_format::DeferredFormat> (self=0x10000201b10)
    at /home/v/.rustup/toolchains/nightly-2022-06-21-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs:2489
#50 0x00000000003cb865 in time::offset_date_time::OffsetDateTime::format<&str> (self=..., format=...)
    at /home/v/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.2.27/src/offset_date_time.rs:862
#51 0x000000000029406c in moros::sys::clock::init () at src/sys/clock.rs:108
#52 0x00000000003f8bba in moros::init (boot_info=0x10000000000) at src/lib.rs:39
#53 0x0000000000253514 in moros::main (boot_info=0x10000000000) at src/main.rs:13
#54 0x0000000000253d0a in moros::__impl_start (boot_info=0x10000000000)