### PR TITLE
Add new forms to lisp

### DIFF
--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -45,8 +45,15 @@ of strings to the language and reading from the filesystem.
 - String operations: `lines`, `join`
 - File IO: `read-file`, `read-file-bytes`, `write-file-bytes`, `append-file-bytes`
 
-## Standard Library
-- `/ini/lisp/core.lsp`
+## Core Library
+- `null`, `null?`, `eq?`
+- `atom?`, `string?`, `boolean?`, `symbol?`, `number?`, `list?`, `function?`, `lambda?`
+- `first`, `second`, `third`, `rest`
+- `append`, `reverse`
+- `read-line`, `read-char`
+- `print`, `println`
+- `write-file`, `append-file`
+- `uptime`
 
 ## Usage
 

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -34,6 +34,7 @@ of strings to the language and reading from the filesystem.
 - `string`
 - `encode-string` and `decode-string`
 - `encode-number` and `decode-number`
+- `regex-find`
 - `parse`
 - `system`
 - `load`
@@ -41,7 +42,7 @@ of strings to the language and reading from the filesystem.
 - Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
-- Boolean operations: `and`, `or`
+- Boolean operations: `not`, `and`, `or`
 - String operations: `lines`, `join`
 - File IO: `read-file`, `read-file-bytes`, `write-file-bytes`, `append-file-bytes`
 
@@ -54,6 +55,7 @@ of strings to the language and reading from the filesystem.
 - `print`, `println`
 - `write-file`, `append-file`
 - `uptime`
+- `regex-match?`
 
 ## Usage
 

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -54,7 +54,7 @@ of strings to the language and reading from the filesystem.
 - `read-line`, `read-char`
 - `print`, `println`
 - `write-file`, `append-file`
-- `uptime`
+- `uptime`, `realtime`
 - `regex-match?`
 
 ## Usage

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -33,7 +33,7 @@ of strings to the language and reading from the filesystem.
 - `type`
 - `string`
 - `encode-string` and `decode-string`
-- `encode-float` and `decode-float`
+- `encode-number` and `decode-number`
 - `parse`
 - `system`
 - `load`

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -42,7 +42,7 @@ of strings to the language and reading from the filesystem.
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Boolean operations: `and`, `or`
-- String operations: `lines`, `join`, `cat`
+- String operations: `lines`, `join`
 - File IO: `read-file`, `read-file-bytes`, `write-file-bytes`, `append-file-bytes`
 
 ## Standard Library

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -30,22 +30,23 @@ of strings to the language and reading from the filesystem.
 ## Additional Builtins
 - `defun` (aliased to `defn`)
 - `mapcar` (aliased to `map`)
-- `print`
-- `read`
-- `read-bytes`
-- `bytes`
-- `str`
-- `cat`
-- `join`
-- `lines`
-- `parse`
 - `type`
+- `string`
+- `encode-string` and `decode-string`
+- `encode-float` and `decode-float`
+- `parse`
 - `system`
+- `load`
 
 - Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Boolean operations: `and`, `or`
+- String operations: `lines`, `join`, `cat`
+- File IO: `read-file`, `read-file-bytes`, `write-file-bytes`, `append-file-bytes`
+
+## Standard Library
+- `/ini/lisp/core.lsp`
 
 ## Usage
 
@@ -61,21 +62,26 @@ MOROS Lisp v0.1.0
 > (quit)
 ```
 
-And it can execute a file. For example a file located in `/tmp/fibonacci.lsp`
+And it can execute a file. For example a file located in `/tmp/lisp/fibonacci.lsp`
 with the following content:
 
 ```lisp
+(load "/ini/lisp/core.lsp")
+
 (defn fib (n)
   (cond
     ((< n 2) n)
     (true (+ (fib (- n 1)) (fib (- n 2))))))
 
-(println (fib 10))
+(println
+  (cond
+    ((null? args) "Usage: fibonacci <num>")
+    (true (fib(parse (car args))))))
 ```
 
 Would produce the following output:
 
 ```
-> lisp /tmp/fibonacci.lsp
-55
+> lisp /tmp/lisp/fibonacci.lsp 20
+6755
 ```

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -70,6 +70,9 @@
 (defn uptime ()
   (decode-number (read-file-bytes "/dev/clk/uptime" 8)))
 
+(defn realtime ()
+  (decode-number (read-file-bytes "realtime" 8)))
+
 (defn write-file (path str)
   (write-file-bytes path (encode-string str)))
 

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -65,4 +65,4 @@
   (do (print exp) (print "\n")))
 
 (defn uptime ()
-  (decode-float (read-file-bytes "/dev/clk/uptime" 8)))
+  (decode-number (read-file-bytes "/dev/clk/uptime" 8)))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -75,3 +75,6 @@
 
 (defn append-file (path str)
   (append-file-bytes path (encode-string str)))
+
+(defn regex-match? (pattern str)
+  (not (null? (regex-find pattern str))))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -30,6 +30,9 @@
 (defn null? (x)
   (eq? x null))
 
+(defn not (x)
+  (eq? x false))
+
 (defn rest (a)
   (cdr a))
 

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -53,13 +53,16 @@
     (true (append (reverse (rest a)) (cons (first a) '())))))
 
 (defn read-line ()
-  (decode-string (reverse (rest (reverse (read-bytes "/dev/console" 256))))))
+  (decode-string (reverse (rest (reverse (read-file-bytes "/dev/console" 256))))))
+
+(defn read-char ()
+  (decode-string (read-file-bytes "/dev/console" 4)))
 
 (defn print (exp)
-  (do (append-bytes "/dev/console" (encode-string (string exp))) '()))
+  (do (append-file-bytes "/dev/console" (encode-string (string exp))) '()))
 
 (defn println (exp)
   (do (print exp) (print "\n")))
 
 (defn uptime ()
-  (decode-float (read-bytes "/dev/clk/uptime" 8)))
+  (decode-float (read-file-bytes "/dev/clk/uptime" 8)))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -66,3 +66,9 @@
 
 (defn uptime ()
   (decode-number (read-file-bytes "/dev/clk/uptime" 8)))
+
+(defn write-file (path str)
+  (write-file-bytes path (encode-string str)))
+
+(defn append-file (path str)
+  (append-file-bytes path (encode-string str)))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -57,3 +57,6 @@
 
 (defn println (exp)
   (do (print exp) (print "\n")))
+
+(defn uptime ()
+  (decode-float (read-bytes "/dev/clk/uptime" 8)))

--- a/dsk/ini/lisp/core.lsp
+++ b/dsk/ini/lisp/core.lsp
@@ -53,7 +53,10 @@
     (true (append (reverse (rest a)) (cons (first a) '())))))
 
 (defn read-line ()
-  (str (reverse (rest (reverse (read-bytes "/dev/console" 256))))))
+  (decode-string (reverse (rest (reverse (read-bytes "/dev/console" 256))))))
+
+(defn print (exp)
+  (do (append-bytes "/dev/console" (encode-string (string exp))) '()))
 
 (defn println (exp)
   (do (print exp) (print "\n")))

--- a/dsk/tmp/lisp/factorial.lsp
+++ b/dsk/tmp/lisp/factorial.lsp
@@ -9,7 +9,6 @@
   (fact-acc n 1))
 
 (println
-  (fact
-    (cond
-      ((null? args) 10)
-      (true (parse (car args))))))
+  (cond
+    ((null? args) "Usage: factorial <num>")
+    (true (fact (parse (car args))))))

--- a/dsk/tmp/lisp/fibonacci.lsp
+++ b/dsk/tmp/lisp/fibonacci.lsp
@@ -6,7 +6,6 @@
     (true (+ (fib (- n 1)) (fib (- n 2))))))
 
 (println
-  (fib
-    (cond
-      ((null? args) 10)
-      (true (parse (car args))))))
+  (cond
+    ((null? args) "Usage: fibonacci <num>")
+    (true (fib (parse (car args))))))

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -764,7 +764,7 @@ fn repl(env: &mut Rc<RefCell<Env>>) -> Result<(), ExitCode> {
     let csi_reset = Style::reset();
     let prompt_string = format!("{}>{} ", csi_color, csi_reset);
 
-    println!("MOROS Lisp v0.2.0\n");
+    println!("MOROS Lisp v0.3.0\n");
 
     let mut prompt = Prompt::new();
     let history_file = "~/.lisp-history";

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -348,6 +348,18 @@ fn default_env() -> Rc<RefCell<Env>> {
         buf.resize(bytes, 0);
         Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
     }));
+    data.insert("write-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+        ensure_length_eq!(args, 2);
+        let path = string(&args[0])?;
+        match &args[1] {
+            Exp::List(list) => {
+                let buf = list_of_bytes(list)?;
+                let bytes = fs::write(&path, &buf).or(Err(Err::Reason("Could not write file".to_string())))?;
+                Ok(Exp::Num(bytes as f64))
+            }
+            _ => Err(Err::Reason("Expected second arg to be a list".to_string()))
+        }
+    }));
     data.insert("bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let s = string(&args[0])?;

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -325,13 +325,13 @@ fn default_env() -> Rc<RefCell<Env>> {
             Err(code) => Ok(Exp::Num(code as u8 as f64)),
         }
     }));
-    data.insert("read".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("read-file".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let path = string(&args[0])?;
         let contents = fs::read_to_string(&path).or(Err(Err::Reason("Could not read file".to_string())))?;
         Ok(Exp::Str(contents))
     }));
-    data.insert("read-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("read-file-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 2);
         let path = string(&args[0])?;
         let len = float(&args[1])?;
@@ -340,7 +340,7 @@ fn default_env() -> Rc<RefCell<Env>> {
         buf.resize(bytes, 0);
         Ok(Exp::List(buf.iter().map(|b| Exp::Num(*b as f64)).collect()))
     }));
-    data.insert("write-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("write-file-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 2);
         let path = string(&args[0])?;
         match &args[1] {
@@ -352,7 +352,7 @@ fn default_env() -> Rc<RefCell<Env>> {
             _ => Err(Err::Reason("Expected second arg to be a list".to_string()))
         }
     }));
-    data.insert("append-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("append-file-bytes".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 2);
         let path = string(&args[0])?;
         match &args[1] {

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -388,7 +388,7 @@ fn default_env() -> Rc<RefCell<Env>> {
             _ => Err(Err::Reason("Expected arg to be a list".to_string()))
         }
     }));
-    data.insert("decode-float".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("decode-number".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         match &args[0] {
             Exp::List(list) => {
@@ -399,7 +399,7 @@ fn default_env() -> Rc<RefCell<Env>> {
             _ => Err(Err::Reason("Expected arg to be a list".to_string()))
         }
     }));
-    data.insert("encode-float".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+    data.insert("encode-number".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let f = float(&args[0])?;
         Ok(Exp::List(f.to_be_bytes().iter().map(|b| Exp::Num(*b as f64)).collect()))
@@ -957,8 +957,8 @@ fn test_lisp() {
     assert_eq!(eval!("(or false true)"), "true");
     assert_eq!(eval!("(or false false)"), "false");
 
-    // float
-    assert_eq!(eval!("(decode-float (encode-float 42))"), "42");
+    // number
+    assert_eq!(eval!("(decode-number (encode-number 42))"), "42");
 
     // string
     assert_eq!(eval!("(parse \"9.75\")"), "9.75");

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -428,6 +428,9 @@ fn default_env() -> Rc<RefCell<Env>> {
         };
         Ok(Exp::Str(exp.to_string()))
     }));
+    data.insert("list".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
+        Ok(Exp::List(args.to_vec()))
+    }));
 
     // Setup autocompletion
     let mut forms: Vec<String> = data.keys().map(|k| k.to_string()).collect();
@@ -978,4 +981,10 @@ fn test_lisp() {
 
     eval!("(defn apply2 (f arg1 arg2) (f arg1 arg2))");
     assert_eq!(eval!("(apply2 + 1 2)"), "3");
+
+    // list
+    assert_eq!(eval!("(list)"), "()");
+    assert_eq!(eval!("(list 1)"), "(1)");
+    assert_eq!(eval!("(list 1 2)"), "(1 2)");
+    assert_eq!(eval!("(list 1 2 (+ 1 2))"), "(1 2 3)");
 }


### PR DESCRIPTION
- [x] Add `list` form
- [x] Add `string` form
- [x] Rename `bytes` to `encode-string`
- [x] Add `decode-string` form
- [x] Add `encode-number` and `decode-number` forms
- [x] Rename `read` and `read-bytes` to `read-file` and `read-file-bytes`
- [x] Add `write-file-bytes` and `append-file-bytes` forms
- [x] Add `write-file` and `append-file` simplified forms
- [x] Add `read-char` form
- [x] Add `uptime` form
- [x] Add `regex-find` and `regex-match?` forms
- [x] Add `not` form