### PR TITLE
Add file append

### DIFF
--- a/doc/shell.md
+++ b/doc/shell.md
@@ -126,6 +126,10 @@ Which is more efficient than doing:
 
     > print hello -> write /tmp/hello
 
+NOTE: A redirection will append to a file without truncating it first as Unix
+does, so it is more equivalent to `>>` than `>` for now. This may change in
+the future with the addition of a `=>>` symbol.
+
 ## Variables
 
 - Name of the shell or the script: `$0`

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -173,7 +173,7 @@ pub fn reopen(path: &str, handle: usize) -> Result<usize, ()> {
         if info.is_device() {
             open_device(path)
         } else {
-            open_file(path)
+            append_file(path)
         }
     } else {
         create_file(path)

--- a/src/sys/fs/file.rs
+++ b/src/sys/fs/file.rs
@@ -84,7 +84,7 @@ impl File {
         let offset = match pos {
             SeekFrom::Start(i)   => i as i32,
             SeekFrom::Current(i) => i + self.offset as i32,
-            SeekFrom::End(i)     => i + self.size as i32 - 1,
+            SeekFrom::End(i)     => i + self.size as i32,
         };
         if offset < 0 || offset > self.size as i32 { // TODO: offset > size?
             return Err(())

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -29,11 +29,13 @@ pub const VERSION: u8 = 1;
 #[derive(Clone, Copy)]
 #[repr(u8)]
 pub enum OpenFlag {
-    Read   = 1,
-    Write  = 2,
-    Create = 4,
-    Dir    = 8,
-    Device = 16,
+    Read     = 1,
+    Write    = 2,
+    Append   = 4,
+    Create   = 8,
+    Truncate = 16,
+    Dir      = 32,
+    Device   = 64,
 }
 
 impl OpenFlag {
@@ -58,10 +60,15 @@ pub fn open(path: &str, flags: usize) -> Option<Resource> {
             res
         }.map(Resource::Device)
     } else {
-        let res = File::open(path);
+        let mut res = File::open(path);
         if res.is_none() && OpenFlag::Create.is_set(flags) {
             File::create(path)
         } else {
+            if OpenFlag::Append.is_set(flags) {
+                if let Some(ref mut file) = res {
+                    file.seek(SeekFrom::End(0)).ok();
+                }
+            }
             res
         }.map(Resource::File)
     }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -369,7 +369,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
             left_handle = 0;
         } else if Regex::new("^\\d*=+>$").is_match(args[i]) { // Redirect output stream(s)
             is_fat_arrow = true;
-            left_handle = 1; // TODO: parse file handle
+            left_handle = 1;
         } else if Regex::new("^\\d*-*>\\d*$").is_match(args[i]) { // Pipe output stream(s)
             is_thin_arrow = true;
             left_handle = 1;
@@ -379,6 +379,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
             continue;
         }
 
+        // Parse file handle
         let s = args[i].chars().take_while(|c| c.is_numeric()).collect::<String>();
         if let Ok(h) = s.parse() {
             left_handle = h;
@@ -576,20 +577,16 @@ fn test_shell() {
     usr::install::copy_files(false);
 
     // Redirect standard output
-    exec("print test1 => /test").ok();
-    assert_eq!(api::fs::read_to_string("/test"), Ok("test1\n".to_string()));
-
-    // Overwrite content of existing file
-    exec("print test2 => /test").ok();
-    assert_eq!(api::fs::read_to_string("/test"), Ok("test2\n".to_string()));
+    exec("print test1 => /tmp/test1").ok();
+    assert_eq!(api::fs::read_to_string("/tmp/test1"), Ok("test1\n".to_string()));
 
     // Redirect standard output explicitely
-    exec("print test3 1=> /test").ok();
-    assert_eq!(api::fs::read_to_string("/test"), Ok("test3\n".to_string()));
+    exec("print test2 1=> /tmp/test2").ok();
+    assert_eq!(api::fs::read_to_string("/tmp/test2"), Ok("test2\n".to_string()));
 
     // Redirect standard error explicitely
-    exec("hex /nope 2=> /test").ok();
-    assert!(api::fs::read_to_string("/test").unwrap().contains("File not found '/nope'"));
+    exec("hex /nope 2=> /tmp/test3").ok();
+    assert!(api::fs::read_to_string("/tmp/test3").unwrap().contains("File not found '/nope'"));
 
     let mut config = Config::new();
     exec_with_config("set b 42", &mut config).ok();

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -369,7 +369,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
             left_handle = 0;
         } else if Regex::new("^\\d*=+>$").is_match(args[i]) { // Redirect output stream(s)
             is_fat_arrow = true;
-            left_handle = 1;
+            left_handle = 1; // TODO: parse file handle
         } else if Regex::new("^\\d*-*>\\d*$").is_match(args[i]) { // Pipe output stream(s)
             is_thin_arrow = true;
             left_handle = 1;


### PR DESCRIPTION
Use file append in `=>` shell redirection, transforming the operation from the equivalent of `>` to `>>` in the Unix world. We might revisit that decision later by adding a `=>>` operation.

This will close https://github.com/vinc/moros/issues/377