### PR TITLE
Switch HTTP server to HTTP 1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ else
 	opts += -cpu max
 endif
 
+ifeq ($(pcap),true)
+	opts += -object filter-dump,id=f1,netdev=e0,file=/tmp/qemu.pcap
+endif
+
 ifeq ($(output),serial)
 	opts += -display none -chardev stdio,id=s0,signal=off -serial chardev:s0
 endif

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -98,7 +98,7 @@ impl Response {
     pub fn end(&mut self) {
         self.size = self.body.len();
         self.headers.insert("Content-Length".to_string(), self.size.to_string());
-        self.headers.insert("Connection".to_string(), "close".to_string());
+        self.headers.insert("Connection".to_string(), "keep-alive".to_string());
         self.headers.insert("Content-Type".to_string(), if self.mime.starts_with("text/") {
             format!("{}; charset=utf-8", self.mime)
         } else {

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -127,7 +127,7 @@ impl Response {
             500 => "Internal Server Error",
             _   => "Unknown Error",
         };
-        format!("HTTP/1.0 {} {}", self.code, msg)
+        format!("HTTP/1.1 {} {}", self.code, msg)
     }
 }
 


### PR DESCRIPTION
- [x] Respond with `HTTP/1.1` instead of `HTTP/1.0`
- [x] Respond with `Connection: keep-alive` instead of `Connection: close`
- [x] Add packet capture to QEMU

https://www.rfc-editor.org/rfc/rfc2616#page-44