### PR TITLE
Update shell redirections

### DIFF
--- a/doc/shell.md
+++ b/doc/shell.md
@@ -132,10 +132,8 @@ NOTE: The following file handles are available when a process is created:
 - `stderr(2)`
 - `stdnull(3)`
 
-<!--
-NOTE: A redirection with a fat arrow will append to a file without truncating
-it first. This could change in the future with with the addition of `=>>`.
--->
+A redirection with a single arrow head will truncate its destination while
+multiple heads like `=>>` will append to it.
 
 NOTE: Arrows can be longer, and also shorter in the case of fat arrows:
 
@@ -154,6 +152,9 @@ NOTE: Arrows can be longer, and also shorter in the case of fat arrows:
     > write bar.txt <= foo.txt
     > write bar.txt < foo.txt
 
+    > read foo.txt ==>> bar.txt
+    > read foo.txt =>> bar.txt
+    > read foo.txt >> bar.txt
 
 ## Variables
 

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -1,9 +1,11 @@
 # MOROS Shell
 
-## Config
+
+## Configuration
 
 The shell will read `/ini/shell.sh` during initialization to setup its
 configuration.
+
 
 ## Commands
 
@@ -69,66 +71,89 @@ current directory.
 
 When executed without arguments, this command will print the current directory.
 
-## Combiners (TODO)
 
-The `&` and `|` symbols are used only for combiners so there's no needs to
-double them.
+## Combiners (TODO)
 
 **And combiner:**
 
-    > r a.txt & r b.txt
+    > read foo.txt and read bar.txt
 
 **Or combiners:**
 
-    > r a.txt | r b.txt
+    > read foo.txt or read bar.txt
 
-## Pipes (TODO)
 
-The pipe symbol `|` from UNIX is replaced by a thin arrow `->`, shortened to
-`>`, and the redirection symbol `>` from UNIX is replaced by a fat arrow `=>`
-(see below).
+## Pipes and redirections (WIP)
 
-Piping the standard output of a program to the `write` command to emulate a
-redirection for example would be `-> write` or `> w` in short.
+A thin arrow `->` can be used for piping the output from one command to the
+input of another command (TODO):
 
-An additional standard stream stdnull(3) is added to simplify writing to `/dev/null`.
+    > read foo.txt -> write bar.txt
 
-Examples:
+A fat arrow `=>` can be used for redirecting directly to a file:
 
-Read file A and redirect stdout(1) to stdin(0) of write file B:
+    > read foo.txt => bar.txt
 
-    > r a.txt > w b.txt
-    > r a.txt 1>0 w b.txt # with explicit streams
-    > r a.txt -> w b.txt # with thin arrow
+In the following example the standard output is redirected to the null device
+file while the standard error is kept:
 
-Read file A and redirect stderr(2) to stdin(0) of write file B:
+    > time read foo.txt => /dev/null
 
-    > r a.txt 2> w b.txt
-    > r a.txt 2>0 w b.txt
+The standard output is implied as the source of a redirection, but it is
+possible to explicitly redirect a file handle to another (TODO):
 
-Suppress errors by redirecting stderr(2) to stdnull(3):
+    > time read foo.txt [1]=>[3]
 
-    > r a.txt 2>3 w b.txt
+Or to redirect a file handle to a file:
 
-Redirect stdout(1) to stdin(0) and stderr(2) to stdnull(3):
+    > time read foo.txt [1]=> bar.txt
 
-    > r a.txt > 2>3 w b.txt
-    > r a.txt 1>0 2>3 w b.txt
+Or to pipe a file handle to another command:
 
-## Redirections
+    > time read foo.txt [1]-> write bar.txt
 
-Redirecting standard IO streams can be done with a fat arrow, for example the
-output of the print command can be written to a file like so:
+It is possible to chain multiple redirections:
 
-    > print hello => /tmp/hello
+    > time read foo.txt [1]=> bar.txt [2]=> time.txt
 
-Which is more efficient than doing:
+When the arrow point to the other direction the source and destination are
+swapped and the standard input is implied (TODO):
 
-    > print hello -> write /tmp/hello
+    > write <= req.txt => /net/http/moros.cc
 
-NOTE: A redirection will append to a file without truncating it first as Unix
-does, so it is more equivalent to `>>` than `>` for now. This may change in
-the future with the addition of a `=>>` symbol.
+Redirections should be declared before piping (TODO):
+
+    > write <= req.txt => /net/http/moros.cc -> find --line href -> sort
+
+NOTE: The following file handles are available when a process is created:
+
+- `stdin(0)`
+- `stdout(1)`
+- `stderr(2)`
+- `stdnull(3)`
+
+<!--
+NOTE: A redirection with a fat arrow will append to a file without truncating
+it first. This could change in the future with with the addition of `=>>`.
+-->
+
+NOTE: Arrows can be longer, and also shorter in the case of fat arrows:
+
+    > read foo.txt --> write bar.txt
+    > read foo.txt -> write bar.txt
+
+<!--
+    > read foo.txt | write bar.txt
+-->
+
+    > read foo.txt ==> bar.txt
+    > read foo.txt => bar.txt
+    > read foo.txt > bar.txt
+
+    > write bar.txt <== foo.txt
+    > write bar.txt <= foo.txt
+    > write bar.txt < foo.txt
+
 
 ## Variables
 
@@ -171,6 +196,7 @@ by files matching the pattern.
 
 For example `/tmp/*.txt` will match any files with the `txt` extension inside
 `/tmp`, and `a?c.txt` will match a file named `abc.txt`.
+
 
 ## Tilde Expansion
 

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -168,12 +168,14 @@ pub fn append(path: &str, buf: &[u8]) -> Result<usize, ()> {
     Err(())
 }
 
-pub fn reopen(path: &str, handle: usize) -> Result<usize, ()> {
+pub fn reopen(path: &str, handle: usize, append_mode: bool) -> Result<usize, ()> {
     let res = if let Some(info) = syscall::info(path) {
         if info.is_device() {
             open_device(path)
-        } else {
+        } else if append_mode {
             append_file(path)
+        } else {
+            open_file(path)
         }
     } else {
         create_file(path)

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -38,10 +38,10 @@ impl ProcessData {
         let dir = dir.to_string();
         let user = user.map(String::from);
         let mut file_handles = [(); MAX_FILE_HANDLES].map(|_| None);
-        file_handles[0] = Some(Box::new(Resource::Device(Device::Console(Console::new()))));
-        file_handles[1] = Some(Box::new(Resource::Device(Device::Console(Console::new()))));
-        file_handles[2] = Some(Box::new(Resource::Device(Device::Console(Console::new()))));
-        file_handles[3] = Some(Box::new(Resource::Device(Device::Null)));
+        file_handles[0] = Some(Box::new(Resource::Device(Device::Console(Console::new())))); // stdin
+        file_handles[1] = Some(Box::new(Resource::Device(Device::Console(Console::new())))); // stdout
+        file_handles[2] = Some(Box::new(Resource::Device(Device::Console(Console::new())))); // stderr
+        file_handles[3] = Some(Box::new(Resource::Device(Device::Null))); // stdnull
         Self { env, dir, user, file_handles }
     }
 }

--- a/src/usr/time.rs
+++ b/src/usr/time.rs
@@ -10,6 +10,6 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let start = clock::realtime();
     let res = usr::shell::exec(&cmd);
     let duration = clock::realtime() - start;
-    println!("{}Executed '{}' in {:.6}s{}", csi_color, cmd, duration, csi_reset);
+    eprintln!("{}Executed '{}' in {:.6}s{}", csi_color, cmd, duration, csi_reset);
     res
 }


### PR DESCRIPTION
> "Those who don't understand Unix are condemned to reinvent it, poorly."

I've been reading the doc I wrote about file handle redirections in the shell and they were associated with the thin arrow `->` (pipes) instead of the fat arrow `=>` (redirections).

While I was fixing that I noticed that I didn't have a use for a  `<` shortcut because `>` was used for thin arrows instead of fat arrows. Fat arrows can be written in both directions, so it'd make more sens to have both shortcuts for them, like in Unix. And then `|` became really tempting as a shortcut for the thin arrow, like in Unix. I resisted that in the past, instead preferring to use it for the or-combinator. If I use the keyword `or` for the or-combinator (or even `||` as in Unix) then `|` is free for the pipe shortcut...

We'll see, but now `>` will stand for `=>` and `<` for `<=`.

While I was doing that I also revisited the decision in #387 to have `=>` appending to files, instead I made it truncate first as it was before and added `=>>` which can be shortened to `>>` ... like in Unix. It's really useful to have both append and truncate in one command instead of having to use `delete` first for the latter. I was missing it while I tested the feature.

In this PR I'm also adding a long syntax for file handles in redirections with the explicit `[1]=>` being equivalent to the implicit `=>` while keeping the short `1=>` that can now be even shorter with `1>`, making it even shorter than in Unix. `[1]=>[3]` will also be possible in the future.