### PR TITLE
Improve Lisp forms

### DIFF
--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -63,6 +63,11 @@
     ((null? x) x)
     (true (append (reverse (rest x)) (cons (first x) '())))))
 
+(defn range (i n)
+  (cond
+    ((= i n) null)
+    (true (append (list i) (range (+ i 1) n)))))
+
 (defn read-line ()
   (decode-string (reverse (rest (reverse (read-file-bytes "/dev/console" 256))))))
 

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -31,7 +31,7 @@
   (eq? x null))
 
 (defn not (x)
-  (eq? x false))
+  (cond (x false) (true true)))
 
 (defn rest (x)
   (cdr x))

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -1,5 +1,5 @@
-(defn eq? (a b)
-  (eq a b))
+(defn eq? (x y)
+  (eq x y))
 
 (defn atom? (x)
   (atom x))
@@ -33,27 +33,27 @@
 (defn not (x)
   (eq? x false))
 
-(defn rest (a)
-  (cdr a))
+(defn rest (x)
+  (cdr x))
 
-(defn first (a)
-  (car a))
+(defn first (x)
+  (car x))
 
-(defn second (a)
-  (first (rest a)))
+(defn second (x)
+  (first (rest x)))
 
-(defn third (a)
-  (second (rest a)))
+(defn third (x)
+  (second (rest x)))
 
-(defn append (a b)
+(defn append (x y)
   (cond
-    ((null? a) b)
-    (true (cons (first a) (append (rest a) b)))))
+    ((null? x) y)
+    (true (cons (first x) (append (rest x) y)))))
 
-(defn reverse (a)
+(defn reverse (x)
   (cond
-    ((null? a) a)
-    (true (append (reverse (rest a)) (cons (first a) '())))))
+    ((null? x) x)
+    (true (append (reverse (rest x)) (cons (first x) '())))))
 
 (defn read-line ()
   (decode-string (reverse (rest (reverse (read-file-bytes "/dev/console" 256))))))

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -30,8 +30,16 @@
 (defn null? (x)
   (eq? x null))
 
+(defn and (x y)
+  (cond
+    (x (cond (y true) (true false)))
+    (true false)))
+
 (defn not (x)
   (cond (x false) (true true)))
+
+(defn or (x y)
+  (cond (x true) (y true) (true false)))
 
 (defn rest (x)
   (cdr x))

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -80,6 +80,9 @@
 (defn println (exp)
   (do (print exp) (print "\n")))
 
+(def pr print)
+(def prn println)
+
 (defn uptime ()
   (decode-number (read-file-bytes "/dev/clk/uptime" 8)))
 

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -304,20 +304,6 @@ fn default_env() -> Rc<RefCell<Env>> {
         let args = list_of_floats(args)?;
         Ok(Exp::Num(libm::tan(args[0])))
     }));
-    data.insert("or".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
-        ensure_length_eq!(args, 2);
-        match (args[0].clone(), args[1].clone()) {
-            (Exp::Bool(a), Exp::Bool(b)) => Ok(Exp::Bool(a || b)),
-            _ => Err(Err::Reason("Expected booleans".to_string())),
-        }
-    }));
-    data.insert("and".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
-        ensure_length_eq!(args, 2);
-        match (args[0].clone(), args[1].clone()) {
-            (Exp::Bool(a), Exp::Bool(b)) => Ok(Exp::Bool(a && b)),
-            _ => Err(Err::Reason("Expected booleans".to_string())),
-        }
-    }));
     data.insert("system".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let cmd = string(&args[0])?;
@@ -957,18 +943,6 @@ fn test_lisp() {
     assert_eq!(eval!("(= 6 4)"), "false");
     assert_eq!(eval!("(= 6 6)"), "true");
     assert_eq!(eval!("(= (+ 0.15 0.15) (+ 0.1 0.2))"), "true");
-
-    // and
-    assert_eq!(eval!("(and true true)"), "true");
-    assert_eq!(eval!("(and true false)"), "false");
-    assert_eq!(eval!("(and false true)"), "false");
-    assert_eq!(eval!("(and false false)"), "false");
-
-    // or
-    assert_eq!(eval!("(or true true)"), "true");
-    assert_eq!(eval!("(or true false)"), "true");
-    assert_eq!(eval!("(or false true)"), "true");
-    assert_eq!(eval!("(or false false)"), "false");
 
     // number
     assert_eq!(eval!("(decode-number (encode-number 42))"), "42");

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -895,6 +895,8 @@ fn test_lisp() {
     assert_eq!(eval!("(cons (quote 1) (cons (quote 2) (cons (quote 3) (quote ()))))"), "(1 2 3)");
 
     // cond
+    assert_eq!(eval!("(cond ((< 2 4) 1))"), "1");
+    assert_eq!(eval!("(cond ((> 2 4) 1))"), "()");
     assert_eq!(eval!("(cond ((< 2 4) 1) (true 2))"), "1");
     assert_eq!(eval!("(cond ((> 2 4) 1) (true 2))"), "2");
 

--- a/src/usr/lisp.rs
+++ b/src/usr/lisp.rs
@@ -242,15 +242,23 @@ fn default_env() -> Rc<RefCell<Env>> {
         ensure_length_gt!(args, 0);
         let args = list_of_floats(args)?;
         let car = args[0];
-        let cdr = args[1..].iter().fold(0.0, |acc, a| acc + a);
-        Ok(Exp::Num(car - cdr))
+        if args.len() == 1 {
+            Ok(Exp::Num(-car))
+        } else {
+            let res = args[1..].iter().fold(0.0, |acc, a| acc + a);
+            Ok(Exp::Num(car - res))
+        }
     }));
     data.insert("/".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_gt!(args, 0);
         let args = list_of_floats(args)?;
         let car = args[0];
-        let res = args[1..].iter().fold(car, |acc, a| acc / a);
-        Ok(Exp::Num(res))
+        if args.len() == 1 {
+            Ok(Exp::Num(1.0 / car))
+        } else {
+            let res = args[1..].iter().fold(car, |acc, a| acc / a);
+            Ok(Exp::Num(res))
+        }
     }));
     data.insert("%".to_string(), Exp::Func(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_gt!(args, 0);
@@ -910,22 +918,28 @@ fn test_lisp() {
     assert_eq!(eval!("(add 1 2)"), "3");
 
     // addition
+    assert_eq!(eval!("(+)"), "0");
+    assert_eq!(eval!("(+ 2)"), "2");
     assert_eq!(eval!("(+ 2 2)"), "4");
     assert_eq!(eval!("(+ 2 3 4)"), "9");
     assert_eq!(eval!("(+ 2 (+ 3 4))"), "9");
 
     // subtraction
-    assert_eq!(eval!("(- 8 4 2)"), "2");
+    assert_eq!(eval!("(- 2)"), "-2");
     assert_eq!(eval!("(- 2 1)"), "1");
     assert_eq!(eval!("(- 1 2)"), "-1");
     assert_eq!(eval!("(- 2 -1)"), "3");
+    assert_eq!(eval!("(- 8 4 2)"), "2");
 
     // multiplication
+    assert_eq!(eval!("(*)"), "1");
+    assert_eq!(eval!("(* 2)"), "2");
     assert_eq!(eval!("(* 2 2)"), "4");
     assert_eq!(eval!("(* 2 3 4)"), "24");
     assert_eq!(eval!("(* 2 (* 3 4))"), "24");
 
     // division
+    assert_eq!(eval!("(/ 4)"), "0.25");
     assert_eq!(eval!("(/ 4 2)"), "2");
     assert_eq!(eval!("(/ 1 2)"), "0.5");
     assert_eq!(eval!("(/ 8 4 2)"), "1");


### PR DESCRIPTION
This PR is a continuation of #385

- [x] Move `and` and `or` to core library
- [x] Add `pr` and `prn` aliases for `print` and `println`
- [x] Update behavior of `-` and `/` when called with one argument