### PR TITLE
Add support for closing connections in request to HTTP server

### DIFF
--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -135,6 +135,15 @@ impl Response {
         };
         format!("HTTP/1.1 {} {}", self.code, msg)
     }
+
+    fn is_persistent(&self) -> bool {
+        if let Some(value) = self.req.headers.get("Connection") {
+            if value == "close" {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 
 impl fmt::Display for Response {


### PR DESCRIPTION
The HTTP server will now parse the headers and close the connection at the end of a response if the request has a `Connection: close` header field.