### PR TITLE
Add macro to Lisp

### DIFF
--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -61,10 +61,6 @@
       (f (first ls))
       (map f (rest ls)))))
 
-(def (append x y)
-  (if (nil? x) y
-    (cons (first x) (append (rest x) y))))
-
 (def (reverse x)
   (if (nil? x) x
     (append (reverse (rest x)) (cons (first x) '()))))

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -284,14 +284,14 @@ pub fn default_env() -> Rc<RefCell<Env>> {
             _ => Err(Err::Reason("Expected arg to be a number".to_string()))
         }
     }));
-    data.insert("list".to_string(), Exp::Primitive(|args: &[Exp]| -> Result<Exp, Err> {
-        Ok(Exp::List(args.to_vec()))
-    }));
     data.insert("parse".to_string(), Exp::Primitive(|args: &[Exp]| -> Result<Exp, Err> {
         ensure_length_eq!(args, 1);
         let s = string(&args[0])?;
         let (_, exp) = parse(&s)?;
         Ok(exp)
+    }));
+    data.insert("list".to_string(), Exp::Primitive(|args: &[Exp]| -> Result<Exp, Err> {
+        Ok(Exp::List(args.to_vec()))
     }));
     data.insert("append".to_string(), Exp::Primitive(|args: &[Exp]| -> Result<Exp, Err> {
         let mut res = vec![];

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -294,6 +294,17 @@ pub fn default_env() -> Rc<RefCell<Env>> {
         let (_, exp) = parse(&s)?;
         Ok(exp)
     }));
+    data.insert("append".to_string(), Exp::Primitive(|args: &[Exp]| -> Result<Exp, Err> {
+        let mut res = vec![];
+        for arg in args {
+            if let Exp::List(list) = arg {
+                res.extend_from_slice(&list);
+            } else {
+                return Err(Err::Reason("Expected arg to be a list".to_string()))
+            }
+        }
+        Ok(Exp::List(res))
+    }));
 
     // Setup autocompletion
     *FORMS.lock() = data.keys().cloned().chain(BUILT_INS.map(String::from)).collect();

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -349,7 +349,7 @@ fn inner_env(kind: InnerEnv, params: &Exp, args: &[Exp], outer: &mut Rc<RefCell<
     };
     let mut data: BTreeMap<String, Exp> = BTreeMap::new();
     match params {
-        Exp::Sym(s) =>
+        Exp::Sym(s) => {
             data.insert(s.clone(), Exp::List(args));
         }
         Exp::List(list) => {

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -336,7 +336,7 @@ pub fn function_env(params: &Exp, args: &[Exp], outer: &mut Rc<RefCell<Env>>, is
         let plural = if ks.len() == 1 { "" } else { "s" };
         return Err(Err::Reason(format!("Expected {} argument{}, got {}", ks.len(), plural, args.len())));
     }
-    let vs = if is_macro { args } else { eval_args(args, outer)? };
+    let vs = if is_macro { args.to_vec() } else { eval_args(args, outer)? };
     let mut data: BTreeMap<String, Exp> = BTreeMap::new();
     for (k, v) in ks.iter().zip(vs.iter()) {
         data.insert(k.clone(), v.clone());

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -271,7 +271,7 @@ pub fn default_env() -> Rc<RefCell<Env>> {
             Exp::Num(_) => "number",
             Exp::List(_) => "list",
             Exp::Primitive(_) => "function",
-            Exp::Lambda(_) => "function",
+            Exp::Function(_) => "function",
         };
         Ok(Exp::Str(exp.to_string()))
     }));
@@ -329,7 +329,7 @@ pub fn env_set(key: &str, val: Exp, env: &Rc<RefCell<Env>>) -> Result<(), Err> {
     }
 }
 
-pub fn lambda_env(params: &Exp, args: &[Exp], outer: &mut Rc<RefCell<Env>>) -> Result<Rc<RefCell<Env>>, Err> {
+pub fn function_env(params: &Exp, args: &[Exp], outer: &mut Rc<RefCell<Env>>) -> Result<Rc<RefCell<Env>>, Err> {
     let ks = list_of_symbols(params)?;
     if ks.len() != args.len() {
         let plural = if ks.len() == 1 { "" } else { "s" };

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -1,6 +1,7 @@
 use super::{Err, Exp, Env, Function};
-use super::env::{env_get, env_set, function_env, macro_env};
+use super::env::{env_get, env_set, function_env};
 use super::parse::parse;
+use super::expand::expand;
 use super::string;
 
 use crate::{ensure_length_eq, ensure_length_gt};
@@ -228,129 +229,5 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
             },
             _ => return Err(Err::Reason("Unexpected form".to_string())),
         }
-    }
-}
-
-pub fn expand_quasiquote(exp: &Exp) -> Result<Exp, Err> {
-    match exp {
-        Exp::List(list) if list.len() > 0 => {
-            match &list[0] {
-                Exp::Sym(s) if s == "unquote" => {
-                    Ok(list[1].clone())
-                }
-                _ => {
-                    Ok(Exp::List(vec![
-                        Exp::Sym("cons".to_string()),
-                        expand_quasiquote(&list[0])?,
-                        expand_quasiquote(&Exp::List(list[1..].to_vec()))?,
-                    ]))
-                }
-            }
-        }
-        _ => Ok(Exp::List(vec![Exp::Sym("quote".to_string()), exp.clone()])),
-    }
-}
-
-pub fn expand_list(list: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
-    let expanded: Result<Vec<Exp>, Err> = list.iter().map(|item| expand(item, env)).collect();
-    Ok(Exp::List(expanded?))
-}
-
-pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
-    if let Exp::List(list) = exp {
-        ensure_length_gt!(list, 0);
-        match &list[0] {
-            Exp::Sym(s) if s == "quote" => {
-                ensure_length_eq!(list, 2);
-                Ok(exp.clone())
-            }
-            Exp::Sym(s) if s == "quasiquote" => {
-                ensure_length_eq!(list, 2);
-                expand_quasiquote(&list[1])
-            }
-            Exp::Sym(s) if s == "begin" || s == "progn" => {
-                let mut res = vec![Exp::Sym("do".to_string())];
-                res.extend_from_slice(&list[1..]);
-                expand(&Exp::List(res), env)
-            }
-            Exp::Sym(s) if s == "def" || s == "label" => {
-                let mut res = vec![Exp::Sym("define".to_string())];
-                res.extend_from_slice(&list[1..]);
-                expand(&Exp::List(res), env)
-            }
-            Exp::Sym(s) if s == "fun" || s == "fn" || s == "lambda" => {
-                let mut res = vec![Exp::Sym("function".to_string())];
-                res.extend_from_slice(&list[1..]);
-                expand(&Exp::List(res), env)
-            }
-            Exp::Sym(s) if s == "mac" => {
-                let mut res = vec![Exp::Sym("macro".to_string())];
-                res.extend_from_slice(&list[1..]);
-                expand(&Exp::List(res), env)
-            }
-            Exp::Sym(s) if s == "define-function" || s == "def-fun" || s == "define" => {
-                ensure_length_eq!(list, 3);
-                match (&list[1], &list[2]) {
-                    (Exp::List(args), Exp::List(_)) => {
-                        ensure_length_gt!(args, 0);
-                        let name = args[0].clone();
-                        let args = Exp::List(args[1..].to_vec());
-                        let body = expand(&list[2], env)?;
-                        Ok(Exp::List(vec![
-                            Exp::Sym("define".to_string()), name, Exp::List(vec![
-                                Exp::Sym("function".to_string()), args, body
-                            ])
-                        ]))
-                    }
-                    (Exp::Sym(_), _) => expand_list(list, env),
-                    _ => Err(Err::Reason("Expected first argument to be a symbol or a list".to_string()))
-                }
-            }
-            Exp::Sym(s) if s == "define-macro" || s == "def-mac" => {
-                ensure_length_eq!(list, 3);
-                match (&list[1], &list[2]) {
-                    (Exp::List(args), Exp::List(_)) => {
-                        ensure_length_gt!(args, 0);
-                        let name = args[0].clone();
-                        let args = Exp::List(args[1..].to_vec());
-                        let body = expand(&list[2], env)?;
-                        Ok(Exp::List(vec![
-                            Exp::Sym("define".to_string()), name, Exp::List(vec![
-                                Exp::Sym("macro".to_string()), args, body
-                            ])
-                        ]))
-                    }
-                    (Exp::Sym(_), _) => expand_list(list, env),
-                    _ => Err(Err::Reason("Expected first argument to be a symbol or a list".to_string()))
-                }
-            }
-            Exp::Sym(s) if s == "cond" => {
-                ensure_length_gt!(list, 1);
-                if let Exp::List(args) = &list[1] {
-                    ensure_length_eq!(args, 2);
-                    let mut res = vec![Exp::Sym("if".to_string()), args[0].clone(), args[1].clone()];
-                    if list.len() > 2 {
-                        let mut acc = vec![Exp::Sym("cond".to_string())];
-                        acc.extend_from_slice(&list[2..]);
-                        res.push(expand(&Exp::List(acc), env)?);
-                    }
-                    Ok(Exp::List(res))
-                } else {
-                    Err(Err::Reason("Expected lists of predicate and expression".to_string()))
-                }
-            }
-            Exp::Sym(s) => {
-                if let Ok(Exp::Macro(m)) = env_get(s, env) {
-                    let mut m_env = macro_env(&m.params, &list[1..], env)?;
-                    let m_exp = m.body;
-                    expand(&eval(&m_exp, &mut m_env)?, env)
-                } else {
-                    expand_list(list, env)
-                }
-            }
-            _ => expand_list(list, env),
-        }
-    } else {
-        Ok(exp.clone())
     }
 }

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -1,5 +1,5 @@
-use super::{Err, Exp, Env, Lambda};
-use super::env::{env_get, env_set, lambda_env};
+use super::{Err, Exp, Env, Function};
+use super::env::{env_get, env_set, function_env};
 use super::parse::parse;
 use super::string;
 
@@ -198,15 +198,15 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                     }
                     Exp::Sym(s) if s == "function" => {
                         ensure_length_eq!(args, 2);
-                        return Ok(Exp::Lambda(Box::new(Lambda {
+                        return Ok(Exp::Function(Box::new(Function {
                             params: args[0].clone(),
                             body: args[1].clone(),
                         })))
                     }
                     _ => {
                         match eval(&list[0], env)? {
-                            Exp::Lambda(f) => {
-                                env_tmp = lambda_env(&f.params, args, env)?;
+                            Exp::Function(f) => {
+                                env_tmp = function_env(&f.params, args, env)?;
                                 exp_tmp = f.body;
                                 env = &mut env_tmp;
                                 exp = &exp_tmp;
@@ -220,7 +220,7 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 }
             },
             Exp::Primitive(_) => return Err(Err::Reason("Unexpected form".to_string())),
-            Exp::Lambda(_) => return Err(Err::Reason("Unexpected form".to_string())),
+            Exp::Function(_) => return Err(Err::Reason("Unexpected form".to_string())),
         }
     }
 }

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -283,6 +283,11 @@ pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 res.extend_from_slice(&list[1..]);
                 expand(&Exp::List(res), env)
             }
+            Exp::Sym(s) if s == "mac" => {
+                let mut res = vec![Exp::Sym("macro".to_string())];
+                res.extend_from_slice(&list[1..]);
+                expand(&Exp::List(res), env)
+            }
             Exp::Sym(s) if s == "define-function" || s == "def-fun" || s == "define" => {
                 ensure_length_eq!(list, 3);
                 match (&list[1], &list[2]) {

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -80,11 +80,8 @@ pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 match (&list[1], &list[2]) {
                     (Exp::List(args), Exp::List(_)) => {
                         ensure_length_gt!(args, 0);
-                        let (name, args) = if args.len() == 3 && args[0] == Exp::Sym("cons".to_string()) {
-                            (args[1].clone(), args[2].clone())
-                        } else {
-                            (args[0].clone(), Exp::List(args[1..].to_vec()))
-                        };
+                        let name = args[0].clone();
+                        let args = Exp::List(args[1..].to_vec());
                         let body = expand(&list[2], env)?;
                         Ok(Exp::List(vec![
                             Exp::Sym("define".to_string()), name, Exp::List(vec![

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -1,0 +1,136 @@
+use super::{Err, Exp, Env};
+use super::env::{env_get, macro_env};
+use super::eval::eval;
+
+use crate::{ensure_length_eq, ensure_length_gt};
+
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use alloc::vec;
+use core::cell::RefCell;
+
+pub fn expand_quasiquote(exp: &Exp) -> Result<Exp, Err> {
+    match exp {
+        Exp::List(list) if list.len() > 0 => {
+            match &list[0] {
+                Exp::Sym(s) if s == "unquote" => {
+                    Ok(list[1].clone())
+                }
+                _ => {
+                    Ok(Exp::List(vec![
+                        Exp::Sym("cons".to_string()),
+                        expand_quasiquote(&list[0])?,
+                        expand_quasiquote(&Exp::List(list[1..].to_vec()))?,
+                    ]))
+                }
+            }
+        }
+        _ => Ok(Exp::List(vec![Exp::Sym("quote".to_string()), exp.clone()])),
+    }
+}
+
+pub fn expand_list(list: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
+    let expanded: Result<Vec<Exp>, Err> = list.iter().map(|item| expand(item, env)).collect();
+    Ok(Exp::List(expanded?))
+}
+
+pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
+    if let Exp::List(list) = exp {
+        ensure_length_gt!(list, 0);
+        match &list[0] {
+            Exp::Sym(s) if s == "quote" => {
+                ensure_length_eq!(list, 2);
+                Ok(exp.clone())
+            }
+            Exp::Sym(s) if s == "quasiquote" => {
+                ensure_length_eq!(list, 2);
+                expand_quasiquote(&list[1])
+            }
+            Exp::Sym(s) if s == "begin" || s == "progn" => {
+                let mut res = vec![Exp::Sym("do".to_string())];
+                res.extend_from_slice(&list[1..]);
+                expand(&Exp::List(res), env)
+            }
+            Exp::Sym(s) if s == "def" || s == "label" => {
+                let mut res = vec![Exp::Sym("define".to_string())];
+                res.extend_from_slice(&list[1..]);
+                expand(&Exp::List(res), env)
+            }
+            Exp::Sym(s) if s == "fun" || s == "fn" || s == "lambda" => {
+                let mut res = vec![Exp::Sym("function".to_string())];
+                res.extend_from_slice(&list[1..]);
+                expand(&Exp::List(res), env)
+            }
+            Exp::Sym(s) if s == "mac" => {
+                let mut res = vec![Exp::Sym("macro".to_string())];
+                res.extend_from_slice(&list[1..]);
+                expand(&Exp::List(res), env)
+            }
+            Exp::Sym(s) if s == "define-function" || s == "def-fun" || s == "define" => {
+                ensure_length_eq!(list, 3);
+                match (&list[1], &list[2]) {
+                    (Exp::List(args), Exp::List(_)) => {
+                        ensure_length_gt!(args, 0);
+                        let name = args[0].clone();
+                        let args = Exp::List(args[1..].to_vec());
+                        let body = expand(&list[2], env)?;
+                        Ok(Exp::List(vec![
+                            Exp::Sym("define".to_string()), name, Exp::List(vec![
+                                Exp::Sym("function".to_string()), args, body
+                            ])
+                        ]))
+                    }
+                    (Exp::Sym(_), _) => expand_list(list, env),
+                    _ => Err(Err::Reason("Expected first argument to be a symbol or a list".to_string()))
+                }
+            }
+            Exp::Sym(s) if s == "define-macro" || s == "def-mac" => {
+                ensure_length_eq!(list, 3);
+                match (&list[1], &list[2]) {
+                    (Exp::List(args), Exp::List(_)) => {
+                        ensure_length_gt!(args, 0);
+                        let name = args[0].clone();
+                        let args = Exp::List(args[1..].to_vec());
+                        let body = expand(&list[2], env)?;
+                        Ok(Exp::List(vec![
+                            Exp::Sym("define".to_string()), name, Exp::List(vec![
+                                Exp::Sym("macro".to_string()), args, body
+                            ])
+                        ]))
+                    }
+                    (Exp::Sym(_), _) => expand_list(list, env),
+                    _ => Err(Err::Reason("Expected first argument to be a symbol or a list".to_string()))
+                }
+            }
+            Exp::Sym(s) if s == "cond" => {
+                ensure_length_gt!(list, 1);
+                if let Exp::List(args) = &list[1] {
+                    ensure_length_eq!(args, 2);
+                    let mut res = vec![Exp::Sym("if".to_string()), args[0].clone(), args[1].clone()];
+                    if list.len() > 2 {
+                        let mut acc = vec![Exp::Sym("cond".to_string())];
+                        acc.extend_from_slice(&list[2..]);
+                        res.push(expand(&Exp::List(acc), env)?);
+                    }
+                    Ok(Exp::List(res))
+                } else {
+                    Err(Err::Reason("Expected lists of predicate and expression".to_string()))
+                }
+            }
+            Exp::Sym(s) => {
+                if let Ok(Exp::Macro(m)) = env_get(s, env) {
+                    let mut m_env = macro_env(&m.params, &list[1..], env)?;
+                    let m_exp = m.body;
+                    expand(&eval(&m_exp, &mut m_env)?, env)
+                } else {
+                    expand_list(list, env)
+                }
+            }
+            _ => expand_list(list, env),
+        }
+    } else {
+        Ok(exp.clone())
+    }
+}

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -18,6 +18,13 @@ pub fn expand_quasiquote(exp: &Exp) -> Result<Exp, Err> {
                 Exp::Sym(s) if s == "unquote" => {
                     Ok(list[1].clone())
                 }
+                Exp::List(l) if l.len() == 2 && l[0] == Exp::Sym("unquote-splicing".to_string()) => {
+                    Ok(Exp::List(vec![
+                        Exp::Sym("append".to_string()),
+                        l[1].clone(),
+                        expand_quasiquote(&Exp::List(list[1..].to_vec()))?
+                    ]))
+                }
                 _ => {
                     Ok(Exp::List(vec![
                         Exp::Sym("cons".to_string()),

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -80,8 +80,11 @@ pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 match (&list[1], &list[2]) {
                     (Exp::List(args), Exp::List(_)) => {
                         ensure_length_gt!(args, 0);
-                        let name = args[0].clone();
-                        let args = Exp::List(args[1..].to_vec());
+                        let (name, args) = if args.len() == 3 && args[0] == Exp::Sym("cons".to_string()) {
+                            (args[1].clone(), args[2].clone())
+                        } else {
+                            (args[0].clone(), Exp::List(args[1..].to_vec()))
+                        };
                         let body = expand(&list[2], env)?;
                         Ok(Exp::List(vec![
                             Exp::Sym("define".to_string()), name, Exp::List(vec![

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -359,15 +359,13 @@ fn test_lisp() {
     // while
     assert_eq!(eval!("(do (def i 0) (while (< i 5) (set i (+ i 1))) i)"), "5");
 
-    // label
-    eval!("(label a 2)");
+    // define
+    eval!("(define a 2)");
     assert_eq!(eval!("(+ a 1)"), "3");
-    //eval!("(label fn function)");
-    //assert_eq!(eval!("((fn (a) (+ 1 a)) 2)"), "3");
-    eval!("(label add-one (function (b) (+ b 1)))");
+    eval!("(define add-one (function (b) (+ b 1)))");
     assert_eq!(eval!("(add-one 2)"), "3");
-    eval!("(label fib (function (n) (cond ((< n 2) n) (true (+ (fib (- n 1)) (fib (- n 2)))))))");
-    assert_eq!(eval!("(fib 6)"), "8");
+    eval!("(define fibonacci (function (n) (if (< n 2) n (+ (fibonacci (- n 1)) (fibonacci (- n 2))))))");
+    assert_eq!(eval!("(fibonacci 6)"), "8");
 
     // function
     assert_eq!(eval!("((function (a) (+ 1 a)) 2)"), "3");
@@ -479,7 +477,7 @@ fn test_lisp() {
     assert_eq!(eval!("(number-type 9223372036854776000.0)"), "\"float\"");
 
     // quasiquote
-    eval!("(def x 'a)");
+    eval!("(define x 'a)");
     assert_eq!(eval!("`(x ,x y)"), "(x a y)");
     assert_eq!(eval!("`(x ,x y ,(+ 1 2))"), "(x a y 3)");
 

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -488,4 +488,8 @@ fn test_lisp() {
     eval!("(define set-10 (macro (x) `(set ,x 10)))");
     eval!("(set-10 foo)");
     assert_eq!(eval!("foo"), "10");
+
+    eval!("((def x '(1 2 3)))");
+    assert_eq!(eval!("`(+ ,x)"), "(+ (1 2 3))");
+    assert_eq!(eval!("`(+ ,@x)"), "(+ 1 2 3)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -478,16 +478,7 @@ fn test_lisp() {
     eval!("(set-10 foo)");
     assert_eq!(eval!("foo"), "10");
 
-    // dotted pair
-    assert_eq!(eval!("(cons 1 (cons 2 (cons 3 '())))"), "(1 2 3)");
-    assert_eq!(eval!("(cons 1 (2 . (3 . '())))"),       "(1 2 3)");
-    assert_eq!(eval!("(cons 1 (list 2 3))"),            "(1 2 3)");
-    assert_eq!(eval!("'(cons 1 (cons 2 (cons 3 '())))"), "(cons 1 (cons 2 (cons 3 (quote ()))))");
-    assert_eq!(eval!("'(1 . (2 . (3 . '())))"),          "(cons 1 (cons 2 (cons 3 (quote ()))))");
-
     // args
     eval!("(define list* (function args (append args '())))");
-    assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
-    eval!("(define (list* . args) (append args '())))");
     assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -369,9 +369,11 @@ fn test_lisp() {
     assert_eq!(eval!("((lambda (a) (* a a)) 2)"), "4");
     assert_eq!(eval!("((lambda (x) (cons x '(b c))) 'a)"), "(a b c)");
 
-    // defun
-    eval!("(defun add (a b) (+ a b))");
-    assert_eq!(eval!("(add 1 2)"), "3");
+    // function definition shortcut
+    eval!("(define (double x) (* x 2))");
+    assert_eq!(eval!("(double 2)"), "4");
+    eval!("(define-function (triple x) (* x 3))");
+    assert_eq!(eval!("(triple 2)"), "6");
 
     // addition
     assert_eq!(eval!("(+)"), "0");

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -489,7 +489,7 @@ fn test_lisp() {
     eval!("(set-10 foo)");
     assert_eq!(eval!("foo"), "10");
 
-    eval!("((def x '(1 2 3)))");
+    eval!("(define x '(1 2 3))");
     assert_eq!(eval!("`(+ ,x)"), "(+ (1 2 3))");
     assert_eq!(eval!("`(+ ,@x)"), "(+ 1 2 3)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -7,7 +7,7 @@ pub use number::Number;
 pub use env::Env;
 
 use env::default_env;
-use eval::{eval, eval_label_args};
+use eval::{eval, eval_define_args, expand};
 use parse::parse;
 
 use crate::api;
@@ -172,6 +172,7 @@ pub fn byte(exp: &Exp) -> Result<u8, Err> {
 
 fn parse_eval(exp: &str, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
     let (_, exp) = parse(exp)?;
+    let exp = expand(&exp)?;
     let exp = eval(&exp, env)?;
     Ok(exp)
 }
@@ -244,7 +245,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         args[2..].iter().map(|arg| Exp::Str(arg.to_string())).collect()
     });
     let quote = Exp::List(vec![Exp::Sym("quote".to_string()), list]);
-    if eval_label_args(&[key, quote], env).is_err() {
+    if eval_define_args(&[key, quote], env).is_err() {
         error!("Could not parse args");
         return Err(ExitCode::Failure);
     }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -1,5 +1,6 @@
 mod env;
 mod eval;
+mod expand;
 mod number;
 mod parse;
 
@@ -7,7 +8,8 @@ pub use number::Number;
 pub use env::Env;
 
 use env::default_env;
-use eval::{eval, eval_define_args, expand};
+use eval::{eval, eval_define_args};
+use expand::expand;
 use parse::parse;
 
 use crate::api;

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -46,7 +46,7 @@ use spin::Mutex;
 #[derive(Clone)]
 pub enum Exp {
     Primitive(fn(&[Exp]) -> Result<Exp, Err>),
-    Lambda(Box<Lambda>),
+    Function(Box<Function>),
     List(Vec<Exp>),
     Bool(bool),
     Num(Number),
@@ -57,12 +57,12 @@ pub enum Exp {
 impl PartialEq for Exp {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Exp::Lambda(a), Exp::Lambda(b)) => a == b,
-            (Exp::List(a),   Exp::List(b))   => a == b,
-            (Exp::Bool(a),   Exp::Bool(b))   => a == b,
-            (Exp::Num(a),    Exp::Num(b))    => a == b,
-            (Exp::Str(a),    Exp::Str(b))    => a == b,
-            (Exp::Sym(a),    Exp::Sym(b))    => a == b,
+            (Exp::Function(a), Exp::Function(b)) => a == b,
+            (Exp::List(a),     Exp::List(b))     => a == b,
+            (Exp::Bool(a),     Exp::Bool(b))     => a == b,
+            (Exp::Num(a),      Exp::Num(b))      => a == b,
+            (Exp::Str(a),      Exp::Str(b))      => a == b,
+            (Exp::Sym(a),      Exp::Sym(b))      => a == b,
             _ => false,
         }
     }
@@ -72,7 +72,7 @@ impl fmt::Display for Exp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let out = match self {
             Exp::Primitive(_) => "<function>".to_string(),
-            Exp::Lambda(_)    => "<function>".to_string(),
+            Exp::Function(_)  => "<function>".to_string(),
             Exp::Bool(a)      => a.to_string(),
             Exp::Num(n)       => n.to_string(),
             Exp::Sym(s)       => s.clone(),
@@ -87,7 +87,7 @@ impl fmt::Display for Exp {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Lambda {
+pub struct Function {
     params: Exp,
     body: Exp,
 }
@@ -357,17 +357,17 @@ fn test_lisp() {
     // label
     eval!("(label a 2)");
     assert_eq!(eval!("(+ a 1)"), "3");
-    //eval!("(label fn lambda)");
+    //eval!("(label fn function)");
     //assert_eq!(eval!("((fn (a) (+ 1 a)) 2)"), "3");
-    eval!("(label add-one (lambda (b) (+ b 1)))");
+    eval!("(label add-one (function (b) (+ b 1)))");
     assert_eq!(eval!("(add-one 2)"), "3");
-    eval!("(label fib (lambda (n) (cond ((< n 2) n) (true (+ (fib (- n 1)) (fib (- n 2)))))))");
+    eval!("(label fib (function (n) (cond ((< n 2) n) (true (+ (fib (- n 1)) (fib (- n 2)))))))");
     assert_eq!(eval!("(fib 6)"), "8");
 
-    // lambda
-    assert_eq!(eval!("((lambda (a) (+ 1 a)) 2)"), "3");
-    assert_eq!(eval!("((lambda (a) (* a a)) 2)"), "4");
-    assert_eq!(eval!("((lambda (x) (cons x '(b c))) 'a)"), "(a b c)");
+    // function
+    assert_eq!(eval!("((function (a) (+ 1 a)) 2)"), "3");
+    assert_eq!(eval!("((function (a) (* a a)) 2)"), "4");
+    assert_eq!(eval!("((function (x) (cons x '(b c))) 'a)"), "(a b c)");
 
     // function definition shortcut
     eval!("(define (double x) (* x 2))");

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -478,7 +478,16 @@ fn test_lisp() {
     eval!("(set-10 foo)");
     assert_eq!(eval!("foo"), "10");
 
+    // dotted pair
+    assert_eq!(eval!("(cons 1 (cons 2 (cons 3 '())))"), "(1 2 3)");
+    assert_eq!(eval!("(cons 1 (2 . (3 . '())))"),       "(1 2 3)");
+    assert_eq!(eval!("(cons 1 (list 2 3))"),            "(1 2 3)");
+    assert_eq!(eval!("'(cons 1 (cons 2 (cons 3 '())))"), "(cons 1 (cons 2 (cons 3 (quote ()))))");
+    assert_eq!(eval!("'(1 . (2 . (3 . '())))"),          "(cons 1 (cons 2 (cons 3 (quote ()))))");
+
     // args
     eval!("(define list* (function args (append args '())))");
+    assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
+    eval!("(define (list* . args) (append args '())))");
     assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -472,4 +472,9 @@ fn test_lisp() {
     assert_eq!(eval!("(number-type 9223372036854775807)"),   "\"int\"");
     assert_eq!(eval!("(number-type 9223372036854775808)"),   "\"bigint\"");
     assert_eq!(eval!("(number-type 9223372036854776000.0)"), "\"float\"");
+
+    // quasiquote
+    eval!("(def x 'a)");
+    assert_eq!(eval!("`(x ,x y)"), "(x a y)");
+    assert_eq!(eval!("`(x ,x y ,(+ 1 2))"), "(x a y 3)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -126,20 +126,6 @@ macro_rules! ensure_length_gt {
     };
 }
 
-fn list_of_symbols(form: &Exp) -> Result<Vec<String>, Err> {
-    match form {
-        Exp::List(list) => {
-            list.iter().map(|exp| {
-                match exp {
-                    Exp::Sym(sym) => Ok(sym.clone()),
-                    _ => Err(Err::Reason("Expected symbols in the argument list".to_string()))
-                }
-            }).collect()
-        }
-        _ => Err(Err::Reason("Expected args form to be a list".to_string()))
-    }
-}
-
 pub fn list_of_numbers(args: &[Exp]) -> Result<Vec<Number>, Err> {
     args.iter().map(number).collect()
 }
@@ -481,13 +467,18 @@ fn test_lisp() {
     assert_eq!(eval!("`(x ,x y)"), "(x a y)");
     assert_eq!(eval!("`(x ,x y ,(+ 1 2))"), "(x a y 3)");
 
+    // unquote-splicing
+    eval!("(define x '(1 2 3))");
+    assert_eq!(eval!("`(+ ,x)"), "(+ (1 2 3))");
+    assert_eq!(eval!("`(+ ,@x)"), "(+ 1 2 3)");
+
     // macro
     eval!("(define foo 42)");
     eval!("(define set-10 (macro (x) `(set ,x 10)))");
     eval!("(set-10 foo)");
     assert_eq!(eval!("foo"), "10");
 
-    eval!("(define x '(1 2 3))");
-    assert_eq!(eval!("`(+ ,x)"), "(+ (1 2 3))");
-    assert_eq!(eval!("`(+ ,@x)"), "(+ 1 2 3)");
+    // args
+    eval!("(define list* (function args (append args '())))");
+    assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
 }

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -67,8 +67,22 @@ fn parse_quote(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
+fn parse_unquote(input: &str) -> IResult<&str, Exp> {
+    let (input, list) = preceded(char(','), parse_exp)(input)?;
+    let list = vec![Exp::Sym("unquote".to_string()), list];
+    Ok((input, Exp::List(list)))
+}
+
+fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
+    let (input, list) = preceded(char('`'), parse_exp)(input)?;
+    let list = vec![Exp::Sym("quasiquote".to_string()), list];
+    Ok((input, Exp::List(list)))
+}
+
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
-    delimited(multispace0, alt((parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_sym)), multispace0)(input)
+    delimited(multispace0, alt((
+        parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_unquote, parse_quasiquote, parse_sym
+    )), multispace0)(input)
 }
 
 pub fn parse(input: &str)-> Result<(String, Exp), Err> {

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -67,6 +67,12 @@ fn parse_quote(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
+fn parse_unquote_splicing(input: &str) -> IResult<&str, Exp> {
+    let (input, list) = preceded(tag(",@"), parse_exp)(input)?;
+    let list = vec![Exp::Sym("unquote-splicing".to_string()), list];
+    Ok((input, Exp::List(list)))
+}
+
 fn parse_unquote(input: &str) -> IResult<&str, Exp> {
     let (input, list) = preceded(char(','), parse_exp)(input)?;
     let list = vec![Exp::Sym("unquote".to_string()), list];
@@ -81,7 +87,7 @@ fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
 
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
     delimited(multispace0, alt((
-        parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_unquote, parse_quasiquote, parse_sym
+        parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_unquote_splicing, parse_unquote, parse_quasiquote, parse_sym
     )), multispace0)(input)
 }
 

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -21,6 +21,7 @@ use nom::multi::many0;
 use nom::sequence::delimited;
 use nom::sequence::preceded;
 use nom::sequence::tuple;
+use nom::sequence::separated_pair;
 
 fn is_symbol_letter(c: char) -> bool {
     let chars = "<>=-+*/%^?:";
@@ -61,6 +62,16 @@ fn parse_list(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
+fn parse_pair(input: &str) -> IResult<&str, Exp> {
+    let (input, (car, cdr)) = delimited(
+        char('('),
+        separated_pair(parse_exp, char('.'), parse_exp),
+        char(')')
+    )(input)?;
+    let list = vec![Exp::Sym("cons".to_string()), car, cdr];
+    Ok((input, Exp::List(list)))
+}
+
 fn parse_quote(input: &str) -> IResult<&str, Exp> {
     let (input, list) = preceded(char('\''), parse_exp)(input)?;
     let list = vec![Exp::Sym("quote".to_string()), list];
@@ -87,7 +98,8 @@ fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
 
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
     delimited(multispace0, alt((
-        parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_unquote_splicing, parse_unquote, parse_quasiquote, parse_sym
+        parse_num, parse_bool, parse_str, parse_list, parse_pair, parse_quote,
+        parse_unquote_splicing, parse_unquote, parse_quasiquote, parse_sym
     )), multispace0)(input)
 }
 

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -21,7 +21,6 @@ use nom::multi::many0;
 use nom::sequence::delimited;
 use nom::sequence::preceded;
 use nom::sequence::tuple;
-use nom::sequence::separated_pair;
 
 fn is_symbol_letter(c: char) -> bool {
     let chars = "<>=-+*/%^?:";
@@ -62,16 +61,6 @@ fn parse_list(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
-fn parse_pair(input: &str) -> IResult<&str, Exp> {
-    let (input, (car, cdr)) = delimited(
-        char('('),
-        separated_pair(parse_exp, char('.'), parse_exp),
-        char(')')
-    )(input)?;
-    let list = vec![Exp::Sym("cons".to_string()), car, cdr];
-    Ok((input, Exp::List(list)))
-}
-
 fn parse_quote(input: &str) -> IResult<&str, Exp> {
     let (input, list) = preceded(char('\''), parse_exp)(input)?;
     let list = vec![Exp::Sym("quote".to_string()), list];
@@ -98,8 +87,7 @@ fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
 
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
     delimited(multispace0, alt((
-        parse_num, parse_bool, parse_str, parse_list, parse_pair, parse_quote,
-        parse_unquote_splicing, parse_unquote, parse_quasiquote, parse_sym
+        parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_unquote_splicing, parse_unquote, parse_quasiquote, parse_sym
     )), multispace0)(input)
 }
 


### PR DESCRIPTION
- [x] Add `macro` form (aliased to `mac`)
- [x] Add `define-macro` form (aliased to `def-mac`)
- [x] Add `quasiquote` form (aliased to `` ` ``)
- [x] Add `unquote` form (aliased to `,`)
- [x] Add `unquote-splicing` form (aliased to `,@`)
- [x] Add `(function args body)` for functions with multiple arguments
- [ ] Add dotted pair `(a . b)` equivalent to `(cons a b)`