### PR TITLE
Add compilation option to set memory size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ setup:
 	cargo install bootimage
 
 # Compilation options
+memory = 32
 output = video# video, serial
 keyboard = qwerty# qwerty, azerty, dvorak
 mode = release
@@ -19,6 +20,7 @@ kvm = false
 pcap = false
 
 export MOROS_KEYBOARD = $(keyboard)
+export MOROS_MEMORY = $(memory)
 
 # Build userspace binaries
 user-nasm:
@@ -56,7 +58,7 @@ image: $(img)
 	dd conv=notrunc if=$(bin) of=$(img)
 
 
-qemu-opts = -m 32 -drive file=$(img),format=raw \
+qemu-opts = -m $(memory) -drive file=$(img),format=raw \
 			 -audiodev $(audio),id=a0 -machine pcspk-audiodev=a0 \
 			 -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0
 ifeq ($(kvm),true)

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -200,7 +200,12 @@ use crate::sys::gdt::GDT;
 use core::sync::atomic::AtomicU64;
 use x86_64::VirtAddr;
 
-static CODE_ADDR: AtomicU64 = AtomicU64::new((sys::allocator::HEAP_START as u64) + (16 << 20));
+static CODE_ADDR: AtomicU64 = AtomicU64::new(0);
+
+// Called during kernel heap initialization
+pub fn init_process_addr(addr: u64) {
+    sys::process::CODE_ADDR.store(addr, Ordering::SeqCst);
+}
 
 #[repr(align(8), C)]
 #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
The kernel heap size is hardcoded to half the memory and at most 16MB because the allocator is too slow after that on QEMU without KVM support, and the processes use the rest of the memory.

A `MOROS_MEMORY` env var is introduced to be able to increase that hardcoded limit for applications that need more memory like those using bigint. This can also be set with the Makefile by doing `make image memory=...` and `make qemu memory=...`.