### PR TITLE
Add size unit options to commands

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -76,5 +76,6 @@ pub mod random;
 pub mod regex;
 pub mod syscall;
 pub mod time;
+pub mod unit;
 pub mod vga;
 // TODO: add mod wildcard

--- a/src/api/unit.rs
+++ b/src/api/unit.rs
@@ -13,7 +13,7 @@ impl SizeUnit {
         match self {
             SizeUnit::None => format!("{}", size),
             SizeUnit::Binary => binary_size(size),
-            SizeUnit::Decimal => todo!(),
+            SizeUnit::Decimal => decimal_size(size),
         }
     }
 }
@@ -25,9 +25,23 @@ fn binary_size(size: usize) -> String {
     for i in 0..n {
         let prefix = PREFIXES[i];
         if size < (1 << ((i + 1) * 10)) || i == n - 1 {
-            let s = ((10 * size) >> (i * 10)) as f64 / 10.0;
+            let s = ((size * 10) >> (i * 10)) as f64 / 10.0;
             let s = if s >= 10.0 { libm::round(s) } else { s };
             return format!("{}{}", s, prefix);
+        }
+    }
+    unreachable!();
+}
+
+fn decimal_size(size: usize) -> String {
+    let size = size;
+    let n = PREFIXES.len();
+    for i in 0..n {
+        let prefix = PREFIXES[i];
+        if size < usize::pow(10, 3 * (i + 1) as u32) || i == n - 1 {
+            let s = (size as f64) / libm::pow(10.0, 3.0 * (i as f64));
+            let precision = if s >= 10.0 { 0 } else { 1 };
+            return format!("{:.2$}{}", s, prefix, precision);
         }
     }
     unreachable!();

--- a/src/api/unit.rs
+++ b/src/api/unit.rs
@@ -1,0 +1,34 @@
+use alloc::format;
+use alloc::string::String;
+
+#[derive(Clone)]
+pub enum SizeUnit {
+    None,
+    Binary,
+    Decimal,
+}
+
+impl SizeUnit {
+    pub fn format(&self, size: usize) -> String {
+        match self {
+            SizeUnit::None => format!("{}", size),
+            SizeUnit::Binary => binary_size(size),
+            SizeUnit::Decimal => todo!(),
+        }
+    }
+}
+
+const PREFIXES: [&str; 5] = ["", "K", "M", "G", "T"];
+
+fn binary_size(size: usize) -> String {
+    let n = PREFIXES.len();
+    for i in 0..n {
+        let prefix = PREFIXES[i];
+        if size < (1 << ((i + 1) * 10)) || i == n - 1 {
+            let s = ((10 * size) >> (i * 10)) as f64 / 10.0;
+            let s = if s >= 10.0 { libm::round(s) } else { s };
+            return format!("{}{}", s, prefix);
+        }
+    }
+    unreachable!();
+}

--- a/src/usr/disk.rs
+++ b/src/usr/disk.rs
@@ -130,9 +130,9 @@ fn usage(args: &[&str]) -> Result<(), ExitCode> {
     });
     let color = Style::color("LightCyan");
     let reset = Style::reset();
-    println!("{}size:{} {:width$}", color, reset, unit.format(size), width = width);
-    println!("{}used:{} {:width$}", color, reset, unit.format(used), width = width);
-    println!("{}free:{} {:width$}", color, reset, unit.format(free), width = width);
+    println!("{}size:{} {:>width$}", color, reset, unit.format(size), width = width);
+    println!("{}used:{} {:>width$}", color, reset, unit.format(used), width = width);
+    println!("{}free:{} {:>width$}", color, reset, unit.format(free), width = width);
     Ok(())
 }
 

--- a/src/usr/disk.rs
+++ b/src/usr/disk.rs
@@ -112,6 +112,9 @@ fn usage(args: &[&str]) -> Result<(), ExitCode> {
             "-b" | "--binary-size" => {
                 unit = SizeUnit::Binary;
             }
+            "-d" | "--decimal-size" => {
+                unit = SizeUnit::Decimal;
+            }
             "-h" | "--help" => {
                 help_usage();
                 return Ok(());

--- a/src/usr/list.rs
+++ b/src/usr/list.rs
@@ -26,6 +26,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             "-s" | "--size" => sort = "size",
             "-t" | "--time" => sort = "time",
             "-b" | "--binary-size" => unit = SizeUnit::Binary,
+            "-d" | "--decimal-size" => unit = SizeUnit::Decimal,
             _ => path = args[i],
         }
     }

--- a/src/usr/list.rs
+++ b/src/usr/list.rs
@@ -90,7 +90,7 @@ fn print_file(file: &FileInfo, width: usize, unit: SizeUnit) {
     } else {
         csi_reset
     };
-    println!("{:width$} {} {}{}{}", size, time, color, file.name(), csi_reset, width = width);
+    println!("{:>width$} {} {}{}{}", size, time, color, file.name(), csi_reset, width = width);
 }
 
 fn help() -> Result<(), ExitCode> {

--- a/src/usr/memory.rs
+++ b/src/usr/memory.rs
@@ -51,9 +51,9 @@ fn usage(args: &[&str]) -> Result<(), ExitCode> {
     });
     let color = Style::color("LightCyan");
     let reset = Style::reset();
-    println!("{}size:{} {:width$}", color, reset, unit.format(size), width = width);
-    println!("{}used:{} {:width$}", color, reset, unit.format(used), width = width);
-    println!("{}free:{} {:width$}", color, reset, unit.format(free), width = width);
+    println!("{}size:{} {:>width$}", color, reset, unit.format(size), width = width);
+    println!("{}used:{} {:>width$}", color, reset, unit.format(used), width = width);
+    println!("{}free:{} {:>width$}", color, reset, unit.format(free), width = width);
     Ok(())
 }
 

--- a/src/usr/memory.rs
+++ b/src/usr/memory.rs
@@ -1,36 +1,70 @@
 use crate::sys;
 use crate::api::console::Style;
 use crate::api::process::ExitCode;
-
-use alloc::string::ToString;
+use crate::api::unit::SizeUnit;
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
-    if args.len() == 1 || args[1] == "usage" {
-        usage();
-        Ok(())
-    } else if args[1] == "format" {
-        sys::fs::mount_mem();
-        sys::fs::format_mem();
-        println!("Memory successfully formatted");
-        println!("MFS is now mounted to '/'");
-        Ok(())
-    } else {
-        help();
-        Err(ExitCode::Failure)
+    match *args.get(1).unwrap_or(&"") {
+        "u" | "usage" => {
+            usage(&args[2..])
+        }
+        "f" | "format" => {
+            sys::fs::mount_mem();
+            sys::fs::format_mem();
+            println!("Memory successfully formatted");
+            println!("MFS is now mounted to '/'");
+            Ok(())
+        }
+        "-h" | "--help" => {
+            help();
+            Ok(())
+        }
+        _ => {
+            help();
+            Err(ExitCode::UsageError)
+        }
     }
 }
 
-fn usage() {
+fn usage(args: &[&str]) -> Result<(), ExitCode> {
+    let mut unit = SizeUnit::None;
+    for arg in args {
+        match *arg {
+            "-b" | "--binary-size" => {
+                unit = SizeUnit::Binary;
+            }
+            "-h" | "--help" => {
+                help_usage();
+                return Ok(());
+            }
+            _ => {
+                help_usage();
+                return Err(ExitCode::Failure);
+            }
+        }
+    }
     let size = sys::allocator::memory_size();
     let used = sys::allocator::memory_used();
     let free = size - used;
-
-    let width = size.to_string().len();
+    let width = [size, used, free].iter().fold(0, |acc, num| {
+        core::cmp::max(acc, unit.format(*num).len())
+    });
     let color = Style::color("LightCyan");
     let reset = Style::reset();
-    println!("{}size:{} {:width$} bytes", color, reset, size, width = width);
-    println!("{}used:{} {:width$} bytes", color, reset, used, width = width);
-    println!("{}free:{} {:width$} bytes", color, reset, free, width = width);
+    println!("{}size:{} {:width$}", color, reset, unit.format(size), width = width);
+    println!("{}used:{} {:width$}", color, reset, unit.format(used), width = width);
+    println!("{}free:{} {:width$}", color, reset, unit.format(free), width = width);
+    Ok(())
+}
+
+fn help_usage() {
+    let csi_option = Style::color("LightCyan");
+    let csi_title = Style::color("Yellow");
+    let csi_reset = Style::reset();
+    println!("{}Usage:{} memory usage {}<options>{}", csi_title, csi_reset, csi_option, csi_reset);
+    println!();
+    println!("{}Options:{}", csi_title, csi_reset);
+    println!("  {0}-b{1},{0} --binary-size{1}   Use binary size", csi_option, csi_reset);
 }
 
 fn help() {

--- a/src/usr/memory.rs
+++ b/src/usr/memory.rs
@@ -33,6 +33,9 @@ fn usage(args: &[&str]) -> Result<(), ExitCode> {
             "-b" | "--binary-size" => {
                 unit = SizeUnit::Binary;
             }
+            "-d" | "--decimal-size" => {
+                unit = SizeUnit::Decimal;
+            }
             "-h" | "--help" => {
                 help_usage();
                 return Ok(());

--- a/src/usr/net.rs
+++ b/src/usr/net.rs
@@ -18,17 +18,12 @@ use smoltcp::time::Instant;
 use smoltcp::phy::Device;
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
-    if args.len() == 1 {
-        help();
-        return Err(ExitCode::UsageError);
-    }
-
-    match args[1] {
+    match *args.get(1).unwrap_or(&"") {
         "-h" | "--help" => {
             help();
             return Ok(());
         }
-        "config" => {
+        "c" | "config" => {
             if args.len() < 3 {
                 print_config("mac");
                 print_config("ip");
@@ -43,7 +38,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 set_config(args[2], args[3]);
             }
         }
-        "stat" => {
+        "s" | "stat" => {
             if let Some(ref mut iface) = *sys::net::IFACE.lock() {
                 let stats = iface.device().stats();
                 let csi_color = Style::color("LightCyan");
@@ -54,7 +49,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 error!("Network error");
             }
         }
-        "monitor" => {
+        "m" | "monitor" => {
             if let Some(ref mut iface) = *sys::net::IFACE.lock() {
                 iface.device_mut().config().enable_debug();
 


### PR DESCRIPTION
- [x] Add `list --binary-size` (aliased to `l -b`)
- [x] Add `disk usage --binary-size` (aliased to `dsk u -b`)
- [x] Add `memory usage --binary-size` (aliased to `mem u -b`)
- [x] Align sizes to the right