### PR TITLE
Fix process table panic

### DIFF
--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -256,10 +256,10 @@ impl Process {
     }
 
     pub fn spawn(bin: &[u8], args_ptr: usize, args_len: usize) -> Result<(), ExitCode> {
-        if let Ok(pid) = Self::create(bin) {
+        if let Ok(id) = Self::create(bin) {
             let proc = {
                 let table = PROCESS_TABLE.read();
-                table[pid].clone()
+                table[id].clone()
             };
             proc.exec(args_ptr, args_len);
             Ok(())

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -297,8 +297,10 @@ impl Process {
             return Err(());
         }
 
-        let mut table = PROCESS_TABLE.write();
-        let parent = &table[id()];
+        let parent = {
+            let table = PROCESS_TABLE.read();
+            table[id()].clone()
+        };
 
         let data = parent.data.clone();
         let registers = parent.registers;
@@ -306,6 +308,8 @@ impl Process {
 
         let id = MAX_PID.fetch_add(1, Ordering::SeqCst);
         let proc = Process { id, code_addr, stack_addr, entry_point, data, stack_frame, registers };
+
+        let mut table = PROCESS_TABLE.write();
         table[id] = Box::new(proc);
 
         Ok(id)


### PR DESCRIPTION
The rust version upgrade from #432 caused a panic on the second process call that this PR fixes:

```
> print hello
hello

> print hello
DEBUG: panicked at 'Once has panicked', /home/v/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.5.2/src/once.rs:128:29
```