### PR TITLE
Use git describe to display version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ audio = sdl# sdl, coreaudio
 kvm = false
 pcap = false
 
-export MOROS_KEYBOARD = $(keyboard)
+export MOROS_VERSION = $(shell git describe --tags | sed "s/^v//")
 export MOROS_MEMORY = $(memory)
+export MOROS_KEYBOARD = $(keyboard)
 
 # Build userspace binaries
 user-nasm:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn init(boot_info: &'static BootInfo) {
     sys::keyboard::init();
     sys::time::init();
 
-    log!("MOROS v{}\n", env!("CARGO_PKG_VERSION"));
+    log!("MOROS v{}\n", option_env!("MOROS_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")));
     sys::mem::init(boot_info);
     sys::cpu::init();
     sys::pci::init(); // Require MEM

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -334,6 +334,11 @@ fn cmd_unset(args: &[&str], config: &mut Config) -> Result<(), ExitCode> {
     Ok(())
 }
 
+fn cmd_version(_args: &[&str]) -> Result<(), ExitCode> {
+    println!("MOROS v{}", option_env!("MOROS_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")));
+    Ok(())
+}
+
 fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
     #[cfg(test)] // FIXME: tests with `print foo => /bar` are failing without that
     sys::console::print_fmt(format_args!(""));
@@ -483,6 +488,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
         "time"     => usr::time::main(&args),
         "unalias"  => cmd_unalias(&args, config),
         "unset"    => cmd_unset(&args, config),
+        "version"  => cmd_version(&args),
         "user"     => usr::user::main(&args),
         "vga"      => usr::vga::main(&args),
         "write"    => usr::write::main(&args),


### PR DESCRIPTION
Use `git describe` to display a more precise version of MOROS between releases based on the commit of the current development version.

```
> version
MOROS v0.8.0-52-g396f374
```