### PR TITLE
Fix panic on commands containing only spaces

### DIFF
--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -345,7 +345,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
 
     let cmd = variables_expansion(cmd, config);
 
-    let mut args = split_args(&cmd);
+    let mut args = split_args(&cmd.trim());
 
     if args.is_empty() {
         return Ok(());

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -347,6 +347,10 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
 
     let mut args = split_args(&cmd);
 
+    if args.is_empty() {
+        return Ok(());
+    }
+
     // Replace command alias
     if let Some(alias) = config.aliases.get(&args[0]) {
         args.remove(0);


### PR DESCRIPTION
```
>   
DEBUG: panicked at 'index out of bounds: the len is 0 but the index is 0', src/usr/shell.rs:351:46
```