### PR TITLE
Fix panic in chess move parser

### DIFF
--- a/src/usr/chess.rs
+++ b/src/usr/chess.rs
@@ -263,7 +263,7 @@ impl Chess {
 fn is_move(m: &str) -> bool {
     let m = m.as_bytes();
     let n = m.len();
-    if n < 3 || 5 < n {
+    if n < 4 || 5 < n {
         return false;
     }
     if m[0] < b'a' || b'h' < m[0] {


### PR DESCRIPTION
Fix panic when parsing invalid chess move with 3 chars like `move e2e`.