### PR TITLE
Remove allow other from FUSE driver options

### DIFF
--- a/run/moros-fuse.py
+++ b/run/moros-fuse.py
@@ -255,4 +255,4 @@ if __name__ == '__main__':
     parser.add_argument('mount')
     args = parser.parse_args()
     #logging.basicConfig(level=logging.DEBUG)
-    fuse = FUSE(MorosFuse(args.image), args.mount, ro=False, foreground=True, allow_other=True)
+    fuse = FUSE(MorosFuse(args.image), args.mount, ro=False, foreground=True)


### PR DESCRIPTION
Fix the following error:
```
> sh run/moros-fuse.sh
Mounting disk.img in /tmp/moros
fusermount: option allow_other only allowed if 'user_allow_other' is set in /etc/fuse.conf
```