### PR TITLE
Use pbkdf2_hmac to fix compilation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 ## Unreleased
+- Use pbkdf2_hmac to fix compilation warnings (#477)
+- Bump spin from 0.9.5 to 0.9.6 (#474)
+- Bump pbkdf2 from 0.11.0 to 0.12.1 (#470)
+- Bump aml from 0.16.2 to 0.16.3 (#471)
+- Bump linked_list_allocator from 0.10.4 to 0.10.5 (#472)
+- Bump pic8259 from 0.10.2 to 0.10.3 (#473)
+- Bump spin from 0.9.4 to 0.9.5 (#465)
+- Bump nom from 7.1.2 to 7.1.3 (#461)
+- Bump object from 0.30.0 to 0.30.3 (#462)
+- Bump bit_field from 0.10.1 to 0.10.2 (#468)
+- Bump raw-cpuid from 10.6.0 to 10.7.0 (#469)
+- Bump nom from 7.1.1 to 7.1.2 (#457)
+- Refactor keyboard interrupt handler (#453)
 - Add cut/copy/paste to editor (#456)
 - Improve lisp (#455)
 - Improve lisp (#449)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ dependencies = [
  "base64",
  "bit_field",
  "bootloader",
- "hmac",
  "lazy_static",
  "libm",
  "linked_list_allocator",
@@ -330,6 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
 dependencies = [
  "digest",
+ "hmac",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ aml = "0.16.3"
 base64 = { version = "0.13.1", default-features = false }
 bit_field = "0.10.2"
 bootloader = { version = "0.9.23", features = ["map_physical_memory"] }
-hmac = { version = "0.12.1", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libm = "0.2.6"
 linked_list_allocator = "0.10.5"
@@ -29,7 +28,7 @@ nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 object = { version = "0.30.3", default-features = false, features = ["read"] }
-pbkdf2 = { version = "0.12.1", default-features = false }
+pbkdf2 = { version = "0.12.1", default-features = false, features = ["hmac"] }
 pc-keyboard = "0.6.1"
 pic8259 = "0.10.3"
 rand = { version = "0.8.5", default-features = false }

--- a/src/usr/user.rs
+++ b/src/usr/user.rs
@@ -10,7 +10,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::convert::TryInto;
 use core::str;
-use hmac::Hmac;
 use sha2::Sha256;
 
 const USERS: &str = "/ini/users.csv";
@@ -144,7 +143,7 @@ pub fn check(password: &str, hashed_password: &str) -> bool {
     let salt: [u8; 16] = decoded_field[0..16].try_into().unwrap();
 
     let mut hash = [0u8; 32];
-    pbkdf2::pbkdf2::<Hmac<Sha256>>(password.as_bytes(), &salt, c, &mut hash);
+    pbkdf2::pbkdf2_hmac::<Sha256>(password.as_bytes(), &salt, c, &mut hash);
     let encoded_hash = String::from_utf8(usr::base64::encode(&hash)).unwrap();
 
     encoded_hash == fields[3]
@@ -170,7 +169,7 @@ pub fn hash(password: &str) -> String {
     }
 
     // Hashing password with PBKDF2-HMAC-SHA256
-    pbkdf2::pbkdf2::<Hmac<Sha256>>(password.as_bytes(), &salt, c, &mut hash);
+    pbkdf2::pbkdf2_hmac::<Sha256>(password.as_bytes(), &salt, c, &mut hash);
 
     // Encoding in Base64 standard without padding
     let c = c.to_be_bytes();


### PR DESCRIPTION
The latest version of `pbkdf2` returns a `Result` for `pbkdf2::<Hmac<Sha256>>` that must be used. But it also introduced `pbkdf2_hmac::<Sha256>` that we can use to simplify the code and remove the direct dependency on the `hmac` crate.