### PR TITLE
Fix invalid bytes from serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix invalid bytes from serial (#479)
 - Use pbkdf2_hmac to fix compilation warnings (#477)
 - Bump spin from 0.9.5 to 0.9.6 (#474)
 - Bump pbkdf2 from 0.11.0 to 0.12.1 (#470)

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -75,8 +75,8 @@ fn send_csi(c: char) {
 }
 
 fn interrupt_handler() {
-    let scancode = read_scancode();
     if let Some(ref mut keyboard) = *KEYBOARD.lock() {
+        let scancode = read_scancode();
         if let Ok(Some(event)) = keyboard.add_byte(scancode) {
             let ord = Ordering::Relaxed;
             match event.code {

--- a/src/sys/serial.rs
+++ b/src/sys/serial.rs
@@ -87,6 +87,9 @@ pub fn init() {
 
 fn interrupt_handler() {
     let b = SERIAL.lock().read_byte();
+    if b == 0xFF { // Ignore invalid bytes
+        return;
+    }
     let c = match b as char {
         '\r' => '\n',
         '\x7F' => '\x08', // Delete => Backspace


### PR DESCRIPTION
This PR fixes a bug on real hardware where the serial interface would randomly receive `0xff` bytes that would be sent to the console and interpreted as spaces sent by the keyboard, completely breaking the shell.