### PR TITLE
Fix RTL8139 driver issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Fix RTL8139 driver issues (#483)
+- Improve help system (#481)
+- Refactor lisp functions (#478)
+- Improve asm binaries (#482)
+- Add light palette (#480)
+- Fix invalid bytes from serial (#479)
 - Refactor lisp functions (#478)
 - Improve asm binaries (#482)
 - Add light palette (#480)

--- a/dsk/var/www/index.html
+++ b/dsk/var/www/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>MOROS: Obscure Rust Operating System</title>
+    <link rel="stylesheet" type="text/css" href="moros.css">
+  </head>
+  <body>
+    <h1>MOROS: Obscure Rust Operating System</h1>
+
+    <p><img src="moros.png" alt="screenshot"></p>
+
+    <p>MOROS is a hobby operating system written in Rust by <a href="https://vinc.cc">Vincent Ollivier</a>.</p>
+
+    <p>It targets computers with a x86-64 architecture and a BIOS, so mostly from 2005
+to 2020, but it also runs well on most emulators (Bochs, QEMU, and VirtualBox).</p>
+  </body>
+</html>

--- a/dsk/var/www/moros.css
+++ b/dsk/var/www/moros.css
@@ -1,0 +1,1 @@
+../../../www/moros.css

--- a/dsk/var/www/moros.png
+++ b/dsk/var/www/moros.png
@@ -1,0 +1,1 @@
+../../../www/moros.png

--- a/src/sys/net/mod.rs
+++ b/src/sys/net/mod.rs
@@ -79,7 +79,7 @@ impl<'a> smoltcp::phy::Device<'a> for EthernetDevice {
     fn capabilities(&self) -> DeviceCapabilities {
         let mut caps = DeviceCapabilities::default();
         caps.max_transmission_unit = 1500;
-        caps.max_burst_size = Some(1);
+        caps.max_burst_size = Some(64);
         caps
     }
 

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -15,7 +15,7 @@ use x86_64::instructions::port::Port;
 // 11 = 64K + 16 bytes
 const RX_BUFFER_IDX: usize = 0;
 
-const MTU: usize = 1500;
+const MTU: usize = 1536;
 
 const RX_BUFFER_PAD: usize = 16;
 const RX_BUFFER_LEN: usize = 8192 << RX_BUFFER_IDX;

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -257,6 +257,9 @@ impl EthernetDeviceIO for Device {
         let tx_id = self.tx_id.load(Ordering::SeqCst);
         let mut cmd_port = self.ports.tx_cmds[tx_id].clone();
         unsafe {
+            // RTL8139 will not transmit packets smaller than 64 bits
+            let len = len.max(60); // 60 + 4 bits of CRC
+
             // Fill in Transmit Status: the size of this packet, the early
             // transmit threshold, and clear OWN bit in TSD (this starts the
             // PCI operation).

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -178,6 +178,9 @@ impl Device {
             while self.ports.cmd.read() & CR_RST != 0 {}
         }
 
+        // Set interrupts
+        unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
+
         // Enable Receive and Transmitter
         unsafe { self.ports.cmd.write(CR_RE | CR_TE) }
 
@@ -198,14 +201,11 @@ impl Device {
             unsafe { self.ports.tx_addrs[i].write(tx_addr as u32) }
         }
 
-        // Set interrupts
-        unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
-
         // Configure receive buffer (RCR)
         unsafe { self.ports.rx_config.write(RCR_RBLEN | RCR_WRAP | RCR_AB | RCR_AM | RCR_APM | RCR_AAP) }
 
         // Configure transmit buffer (TCR)
-        unsafe { self.ports.tx_config.write(TCR_IFG | TCR_MXDMA0 | TCR_MXDMA1 | TCR_MXDMA2); }
+        unsafe { self.ports.tx_config.write(TCR_IFG | TCR_MXDMA1 | TCR_MXDMA2); }
     }
 }
 

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -19,7 +19,7 @@ const MTU: usize = 1500;
 const RX_BUFFER_PAD: usize = 16;
 const RX_BUFFER_LEN: usize = (8192 << RX_BUFFER_IDX) + RX_BUFFER_PAD;
 
-const TX_BUFFER_LEN: usize = 4096;
+const TX_BUFFER_LEN: usize = 2048;
 const TX_BUFFERS_COUNT: usize = 4;
 const ROK: u16 = 0x01;
 

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -183,7 +183,7 @@ impl Device {
         }
 
         // Set interrupts
-        unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
+        //unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
 
         // Enable Receive and Transmitter
         unsafe { self.ports.cmd.write(CR_RE | CR_TE) }
@@ -253,6 +253,7 @@ impl EthernetDeviceIO for Device {
             self.ports.capr.write(((self.rx_offset % RX_BUFFER_LEN) - RX_BUFFER_PAD) as u16);
         }
 
+        //unsafe { self.ports.isr.write(0x1); }
         Some(self.rx_buffer[(offset + 4)..(offset + n)].to_vec())
     }
 
@@ -280,6 +281,7 @@ impl EthernetDeviceIO for Device {
                 spin_loop();
             }
         }
+        //unsafe { self.ports.isr.write(0x4); }
     }
 
     fn next_tx_buffer(&mut self, len: usize) -> &mut [u8] {

--- a/src/sys/net/rtl8139.rs
+++ b/src/sys/net/rtl8139.rs
@@ -17,7 +17,7 @@ const RX_BUFFER_IDX: usize = 0;
 const MTU: usize = 1500;
 
 const RX_BUFFER_PAD: usize = 16;
-const RX_BUFFER_LEN: usize = (8129 << RX_BUFFER_IDX) + RX_BUFFER_PAD;
+const RX_BUFFER_LEN: usize = (8192 << RX_BUFFER_IDX) + RX_BUFFER_PAD;
 
 const TX_BUFFER_LEN: usize = 4096;
 const TX_BUFFERS_COUNT: usize = 4;

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -209,11 +209,11 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if let Some(ref mut iface) = *sys::net::IFACE.lock() {
         println!("{}HTTP Server listening on 0.0.0.0:{}{}", csi_color, port, csi_reset);
 
-        let mtu = iface.device().capabilities().max_transmission_unit;
+        let buf_len = iface.device().capabilities().max_transmission_unit - 54;
         let mut connections = Vec::new();
         for _ in 0..MAX_CONNECTIONS {
-            let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; mtu]);
-            let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; mtu]);
+            let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; buf_len]);
+            let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; buf_len]);
             let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
             let tcp_handle = iface.add_socket(tcp_socket);
             let send_queue: VecDeque<Vec<u8>> = VecDeque::new();
@@ -339,12 +339,13 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                         }
                         (buffer.len(), res)
                     }).unwrap();
-                    for chunk in res.buf.chunks(mtu) {
+                    for chunk in res.buf.chunks(buf_len) {
                         send_queue.push_back(chunk.to_vec());
                     }
                     if socket.can_send() {
                         if let Some(chunk) = send_queue.pop_front() {
-                            socket.send_slice(&chunk).unwrap();
+                            let sent = socket.send_slice(&chunk).expect("Could not send chunk");
+                            debug_assert!(sent == chunk.len());
                         }
                     }
                     if send_queue.is_empty() && !res.is_persistent() {

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -209,7 +209,8 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if let Some(ref mut iface) = *sys::net::IFACE.lock() {
         println!("{}HTTP Server listening on 0.0.0.0:{}{}", csi_color, port, csi_reset);
 
-        let buf_len = iface.device().capabilities().max_transmission_unit - 54;
+        let mtu = iface.device().capabilities().max_transmission_unit;
+        let buf_len = mtu - 14 - 20 - 20; // ETH+TCP+IP headers
         let mut connections = Vec::new();
         for _ in 0..MAX_CONNECTIONS {
             let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; buf_len]);

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -82,8 +82,9 @@ pub fn copy_files(verbose: bool) {
     copy_file("/tmp/beep/mario.sh", include_bytes!("../../dsk/tmp/beep/mario.sh"), verbose);
 
     create_dir("/var/www", verbose);
-    copy_file("/var/www/index.html", include_bytes!("../../www/index.html"), verbose);
-    copy_file("/var/www/moros.png", include_bytes!("../../www/moros.png"), verbose);
+    copy_file("/var/www/index.html", include_bytes!("../../dsk/var/www/index.html"), verbose);
+    copy_file("/var/www/moros.png", include_bytes!("../../dsk/var/www/moros.png"), verbose);
+    copy_file("/var/www/moros.css", include_bytes!("../../dsk/var/www/moros.css"), verbose);
 }
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {

--- a/www/build.sh
+++ b/www/build.sh
@@ -14,7 +14,7 @@ for md in ../doc/*.md; do
   <head>
     <meta charset="utf-8">
     <title>$title</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
 EOF


### PR DESCRIPTION
The RTL8139 driver was working well in QEMU but not so much on real hardware.

- [x] Add `fence` before polling for status change
- [x] Use `spin_loop` while polling for status change
- [x] Use 1024 bytes for max DMA burst size instead of 2048
- [x] Fix transmit ring overflow
- [x] Change transmit buffer length from 4096 to 2048 bytes
- [x] Fix issue when transmitting packets < 64 bytes
- [x] Fix typo in receive buffer size (8129 instead of 8192)
- [x] Fix httpd buffer size issue

Fix #325 