### PR TITLE
Add parenthesis matching to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add parenthesis matching to editor (#488)
 - Upgrade smoltcp from 0.8.2 to 0.9.1 (#484)
 - Update rust to nightly-2022-12-21 (#485)
 - Fix RTL8139 driver issues (#483)

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -222,6 +222,7 @@ impl Editor {
             print!("\x1b[{};{}H", y + 1, x + 1);
             print!("{}{}{}", color, c, reset);
         }
+        print!("\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
     }
 
     fn clear_highlighted(&mut self) {
@@ -234,6 +235,7 @@ impl Editor {
             print!("{}{}", reset, c);
         }
         self.highlighted.clear();
+        print!("\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
     }
 
     pub fn run(&mut self) -> Result<(), ExitCode> {

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -218,17 +218,23 @@ impl Editor {
 
     fn print_highlighted(&mut self) {
         self.match_parenthesis();
+        let color = Style::color("LightRed");
+        let reset = Style::reset();
         for (x, y, c) in &self.highlighted {
-            let color = Style::color("LightRed");
-            let reset = Style::reset();
+            if *x == self.cols() - 1 {
+                continue;
+            }
             print!("\x1b[{};{}H", y + 1, x + 1);
             print!("{}{}{}", color, c, reset);
         }
     }
 
     fn clear_highlighted(&mut self) {
+        let reset = Style::reset();
         for (x, y, c) in &self.highlighted {
-            let reset = Style::reset();
+            if *x == self.cols() - 1 {
+                continue;
+            }
             print!("\x1b[{};{}H", y + 1, x + 1);
             print!("{}{}", reset, c);
         }

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -222,7 +222,6 @@ impl Editor {
             print!("\x1b[{};{}H", y + 1, x + 1);
             print!("{}{}{}", color, c, reset);
         }
-        print!("\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
     }
 
     fn clear_highlighted(&mut self) {
@@ -235,7 +234,6 @@ impl Editor {
             print!("{}{}", reset, c);
         }
         self.highlighted.clear();
-        print!("\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
     }
 
     pub fn run(&mut self) -> Result<(), ExitCode> {
@@ -251,6 +249,7 @@ impl Editor {
             let c = io::stdin().read_char().unwrap_or('\0');
             print!("\x1b[?25l"); // Disable cursor
             self.clear_highlighted();
+            print!("\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
 
             match c {
                 '\x1B' => { // ESC


### PR DESCRIPTION
This PR will help writing Lisp code in the editor by highlighting the opening or clothing parenthesis matching the one at the cursor:

![parenthesis](https://github.com/vinc/moros/assets/305625/da68c5d5-0682-4f9a-b35b-23fbf4ca547b)

![parenthesis](https://github.com/vinc/moros/assets/305625/014394ec-ec8e-49bd-8830-fee7446f836a)