### PR TITLE
Add full support for comments in MOROS Lisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add full support for comments in lisp (#489)
 - Add parenthesis matching to editor (#488)
 - Upgrade smoltcp from 0.8.2 to 0.9.1 (#484)
 - Update rust to nightly-2022-12-21 (#485)

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -187,3 +187,4 @@ Rewrite parts of the code and add new functions and examples.
 
 ### 0.5.0 (unpublished)
 - Rename or add aliases to many functions
+- Add full support for line and inline comments

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -1,6 +1,5 @@
-use super::{Err, Exp, Env, Function};
+use super::{Err, Exp, Env, Function, parse_eval};
 use super::env::{env_get, env_set, function_env};
-use super::parse::parse;
 use super::expand::expand;
 use super::string;
 
@@ -130,15 +129,13 @@ fn eval_do_args(args: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
 fn eval_load_args(args: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     let path = string(&args[0])?;
-    let mut code = fs::read_to_string(&path).or(Err(Err::Reason("Could not read file".to_string())))?;
+    let mut input = fs::read_to_string(&path).or(Err(Err::Reason(format!("File not found '{}'", path))))?;
     loop {
-        let (rest, exp) = parse(&code)?;
-        let exp = expand(&exp, env)?;
-        eval(&exp, env)?;
+        let (rest, _) = parse_eval(&input, env)?;
         if rest.is_empty() {
             break;
         }
-        code = rest;
+        input = rest;
     }
     Ok(Exp::Bool(true))
 }

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -4,6 +4,7 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;
 
+use nom::Err::Error;
 use nom::IResult;
 use nom::branch::alt;
 use nom::bytes::complete::escaped_transform;
@@ -91,7 +92,15 @@ fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
+use nom::sequence::pair;
+use alloc::format;
+
+fn parse_comment(input: &str) -> IResult<&str, ()> {
+    value((), pair(char('#'), is_not("\n")))(input)
+}
+
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = opt(parse_comment)(input)?;
     delimited(multispace0, alt((
         parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_quasiquote, parse_unquote_splice, parse_unquote, parse_splice, parse_sym
     )), multispace0)(input)
@@ -100,6 +109,10 @@ fn parse_exp(input: &str) -> IResult<&str, Exp> {
 pub fn parse(input: &str)-> Result<(String, Exp), Err> {
     match parse_exp(input) {
         Ok((input, exp)) => Ok((input.to_string(), exp)),
-        Err(_) => Err(Err::Reason("Could not parse input".to_string())),
+        Err(Error(err)) if !err.input.is_empty() => {
+            let line = err.input.lines().next().unwrap();
+            Err(Err::Reason(format!("Could not parse '{}'", line)))
+        }
+        _ => Err(Err::Reason(format!("Could not parse input"))),
     }
 }

--- a/www/calculator.html
+++ b/www/calculator.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Calculator</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Calculator</h1>

--- a/www/editor.html
+++ b/www/editor.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Editor</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Editor</h1>

--- a/www/filesystem.html
+++ b/www/filesystem.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Filesystem</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Filesystem</h1>

--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS: Obscure Rust Operating System</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS: Obscure Rust Operating System</h1>

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Lisp</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Lisp</h1>
@@ -220,6 +220,7 @@ language and reading from the filesystem.</p>
 
     <ul>
     <li>Rename or add aliases to many functions</li>
+    <li>Add full support for line and inline comments</li>
     </ul>
   </body>
 </html>

--- a/www/manual.html
+++ b/www/manual.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Manual</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Manual</h1>

--- a/www/network.html
+++ b/www/network.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Network</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Network</h1>

--- a/www/regex.html
+++ b/www/regex.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Regular Expression Engine</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Regular Expression Engine</h1>

--- a/www/shell.html
+++ b/www/shell.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Shell</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Shell</h1>

--- a/www/syscalls.html
+++ b/www/syscalls.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS Syscalls</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS Syscalls</h1>

--- a/www/test.html
+++ b/www/test.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>MOROS</title>
-    <link rel="stylesheet" type="text/css" href="/moros.css">
+    <link rel="stylesheet" type="text/css" href="moros.css">
   </head>
   <body>
     <h1>MOROS</h1>


### PR DESCRIPTION
This PR add full support for comments in MOROS Lisp. Previously comments where striped in the main code source but not in other files loaded with the `load` function, and the naive comment stripping had known bugs. Comments will now be parsed directly during the parsing step.

The error output will be a little worse for the main code source but it will be consistent with the `load` function. Better context will be added later.

In MOROS Lisp comments start with the char `#` like in Perl, Ruby, and Python instead of the traditional `;` to be consistent with the shell and the shebang character sequence at the beginning of scripts: `#!/bin/shell` or `#!/bin/lisp`.

```janet
# Line comment
(def (fibonacci n) # Inline comment
  (if (< n 2) n
    (+ (fibonacci (- n 1)) (fibonacci (- n 2)))))
```