### PR TITLE
Fix Lisp comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix Lisp comments (#493)
 - Add docstring to lisp (#490)
 - Add full support for comments in lisp (#489)
 - Add parenthesis matching to editor (#488)

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -535,4 +535,9 @@ fn test_lisp() {
     // args
     eval!("(variable list* (function args (append args '())))");
     assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
+
+    // comments
+    assert_eq!(eval!("# comment"), "()");
+    assert_eq!(eval!("# comment\n# comment"), "()");
+    assert_eq!(eval!("(+ 1 2 3) # comment"), "6");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -540,4 +540,5 @@ fn test_lisp() {
     assert_eq!(eval!("# comment"), "()");
     assert_eq!(eval!("# comment\n# comment"), "()");
     assert_eq!(eval!("(+ 1 2 3) # comment"), "6");
+    assert_eq!(eval!("(+ 1 2 3) # comment\n# comment"), "6");
 }

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -93,11 +93,8 @@ fn parse_quasiquote(input: &str) -> IResult<&str, Exp> {
     Ok((input, Exp::List(list)))
 }
 
-use nom::sequence::pair;
-use alloc::format;
-
-fn parse_comment(input: &str) -> IResult<&str, ()> {
-    value((), pair(char('#'), is_not("\n")))(input)
+fn parse_comment(input: &str) -> IResult<&str, &str> {
+    preceded(multispace0, preceded(char('#'), is_not("\n")))(input)
 }
 
 fn parse_exp(input: &str) -> IResult<&str, Exp> {

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -101,7 +101,7 @@ fn parse_exp(input: &str) -> IResult<&str, Exp> {
     let (input, _) = opt(many0(parse_comment))(input)?;
     delimited(multispace0, alt((
         parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_quasiquote, parse_unquote_splice, parse_unquote, parse_splice, parse_sym
-    )), multispace0)(input)
+    )), alt((parse_comment, multispace0)))(input)
 }
 
 pub fn parse(input: &str)-> Result<(String, Exp), Err> {

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -107,9 +107,13 @@ fn parse_exp(input: &str) -> IResult<&str, Exp> {
 pub fn parse(input: &str)-> Result<(String, Exp), Err> {
     match parse_exp(input) {
         Ok((input, exp)) => Ok((input.to_string(), exp)),
-        Err(Error(err)) if !err.input.is_empty() => {
-            let line = err.input.lines().next().unwrap();
-            could_not!("parse '{}'", line)
+        Err(Error(err)) => {
+            if err.input.is_empty() {
+                Ok(("".to_string(), Exp::List(vec![Exp::Sym("quote".to_string()), Exp::List(vec![])])))
+            } else {
+                let line = err.input.lines().next().unwrap();
+                could_not!("parse '{}'", line)
+            }
         }
         _ => could_not!("parse input"),
     }

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -98,7 +98,7 @@ fn parse_comment(input: &str) -> IResult<&str, &str> {
 }
 
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
-    let (input, _) = opt(parse_comment)(input)?;
+    let (input, _) = opt(many0(parse_comment))(input)?;
     delimited(multispace0, alt((
         parse_num, parse_bool, parse_str, parse_list, parse_quote, parse_quasiquote, parse_unquote_splice, parse_unquote, parse_splice, parse_sym
     )), multispace0)(input)


### PR DESCRIPTION
Fix a few remaining edge cases after #489 

- [x] Handle multiple successive line comments
- [x] Handle line comments at the end of input
- [x] Handle inline comments at the end of input

```janet
# A line comment
# Another line comment
(+ 1 2 3) # Inline comment
# Yet another line comment
# One last line comment
```