### PR TITLE
Add namespaces to lisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add namespaces to lisp ([#511](https://github.com/vinc/moros/pull/511))
 - Update smoltcp from 0.9.1 to 0.10.0 ([#510](https://github.com/vinc/moros/pull/510))
 
 ## 0.10.0 (2023-06-21)

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -196,3 +196,6 @@ language and reading from the filesystem.
 - Add full support for line and inline comments
 - Add params to function representations
 - Add docstring to functions
+
+### Unreleased
+- Add file, number, string, and regex namespaces

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -41,18 +41,18 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 
 ### Primitive Operators
 - `append`
-- `type`, `number-type` (aliased to `num-type`)
+- `type`, `number:type` (aliased to `num:type`)
 - `string` (aliased to `str`)
 - `string->number` (aliased to to `str->num`)
 - `string->binary` and `binary->string` (aliased to `str->bin` and `bin->str`)
 - `number->binary` and `binary->number` (aliased to `num->bin` and `bin->num`)
-- `regex-find`
+- `regex:find`
 - `system`
 - Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`, `abs`
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Enumerable: `length` (aliased to `len`), `nth`, `first`, `second`, `third`, `last`, `rest`, `slice`
-- String: `trim`, `split`
+- String: `string:trim`, `string:split`
 - List: `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
 - File: `file:size`, `file:open`, `file:close`, `file:read`, `file:write`
 
@@ -64,8 +64,8 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `map`, `reduce`, `reverse` (aliased to `rev`), `range`, `filter`, `intersection`
 - `not`, `and`, `or`
 - `let`
-- `join-string` (aliased to `join-str`), `lines`, `words`, `chars`
-- `regex-match?`
+- `string:join` (aliased to `str:join`), `lines`, `words`, `chars`
+- `regex:match?`
 
 ### File Library
 - `read-file-binary`, `write-file-binary`, `append-file-binary`

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -48,7 +48,7 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `number->binary` and `binary->number` (aliased to `num->bin` and `bin->num`)
 - `regex:find`
 - `system`
-- Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`, `abs`
+- Arithmetic operations: `+`, `-`, `*`, `/`, `^`, `abs`, `mod`, `rem` (aliased to `%`)
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Enumerable: `length` (aliased to `len`), `nth`, `first`, `second`, `third`, `last`, `rest`, `slice`

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -40,7 +40,6 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `load`
 
 ### Primitive Operators
-- `append`
 - `type`, `number.type` (aliased to `num.type`)
 - `string` (aliased to `str`)
 - `string->number` (aliased to to `str->num`)
@@ -53,7 +52,7 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Enumerable: `length` (aliased to `len`), `nth`, `first`, `second`, `third`, `last`, `rest`, `slice`
 - String: `string.trim`, `string.split`
-- List: `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
+- List: `concat`, `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
 - File: `file.size`, `file.open`, `file.close`, `file.read`, `file.write`
 
 ### Core Library
@@ -68,8 +67,8 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `regex.match?`
 
 ### File Library
-- `read-file-binary`, `write-file-binary`, `append-file-binary`
-- `read-file`, `write-file`, `append-file`
+- `read`, `write`, `append`
+- `read-binary`, `write-binary`, `append-binary`
 - `read-line`, `read-char`
 - `uptime`, `realtime`
 - `p`, `print`

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -41,20 +41,20 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 
 ### Primitive Operators
 - `append`
-- `type`, `number:type` (aliased to `num:type`)
+- `type`, `number.type` (aliased to `num.type`)
 - `string` (aliased to `str`)
 - `string->number` (aliased to to `str->num`)
 - `string->binary` and `binary->string` (aliased to `str->bin` and `bin->str`)
 - `number->binary` and `binary->number` (aliased to `num->bin` and `bin->num`)
-- `regex:find`
+- `regex.find`
 - `system`
 - Arithmetic operations: `+`, `-`, `*`, `/`, `^`, `abs`, `mod`, `rem` (aliased to `%`)
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
 - Enumerable: `length` (aliased to `len`), `nth`, `first`, `second`, `third`, `last`, `rest`, `slice`
-- String: `string:trim`, `string:split`
+- String: `string.trim`, `string.split`
 - List: `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
-- File: `file:size`, `file:open`, `file:close`, `file:read`, `file:write`
+- File: `file.size`, `file.open`, `file.close`, `file.read`, `file.write`
 
 ### Core Library
 - `nil`, `nil?`, `list?`
@@ -64,8 +64,8 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `map`, `reduce`, `reverse` (aliased to `rev`), `range`, `filter`, `intersection`
 - `not`, `and`, `or`
 - `let`
-- `string:join` (aliased to `str:join`), `lines`, `words`, `chars`
-- `regex:match?`
+- `string.join` (aliased to `str.join`), `lines`, `words`, `chars`
+- `regex.match?`
 
 ### File Library
 - `read-file-binary`, `write-file-binary`, `append-file-binary`

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -51,10 +51,10 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - Arithmetic operations: `+`, `-`, `*`, `/`, `%`, `^`, `abs`
 - Trigonometric functions: `acos`, `asin`, `atan`, `cos`, `sin`, `tan`
 - Comparisons: `>`, `<`, `>=`, `<=`, `=`
-- File IO: `read-file`, `read-file-binary`, `write-file-binary`, `append-file-binary`
-- List: `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
-- String: `trim`, `split`
 - Enumerable: `length` (aliased to `len`), `nth`, `first`, `second`, `third`, `last`, `rest`, `slice`
+- String: `trim`, `split`
+- List: `chunks`, `sort`, `unique` (aliased to `uniq`), `min`, `max`
+- File: `file:size`, `file:open`, `file:close`, `file:read`, `file:write`
 
 ### Core Library
 - `nil`, `nil?`, `list?`
@@ -65,11 +65,14 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `not`, `and`, `or`
 - `let`
 - `join-string` (aliased to `join-str`), `lines`, `words`, `chars`
-- `read-line`, `read-char`
-- `p`, `print`
-- `write-file`, `append-file`
-- `uptime`, `realtime`
 - `regex-match?`
+
+### File Library
+- `read-file-binary`, `write-file-binary`, `append-file-binary`
+- `read-file`, `write-file`, `append-file`
+- `read-line`, `read-char`
+- `uptime`, `realtime`
+- `p`, `print`
 
 ### Compatibility Library
 

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -85,24 +85,24 @@
 (def (mod a b)
   (rem (+ (rem a b) b) b))
 
-(def (string:join ls s)
+(def (string.join ls s)
   "Join the elements of the list with the string"
   (reduce (fun (x y) (string x s y)) ls))
 
-(def (regex:match? pattern s)
-  (not (nil? (regex:find pattern str))))
+(def (regex.match? pattern s)
+  (not (nil? (regex.find pattern str))))
 
 (def (lines text)
   "Split text into a list of lines"
-  (string:split (string:trim text) "\n"))
+  (string.split (string.trim text) "\n"))
 
 (def (words text)
   "Split text into a list of words"
-  (string:split text " "))
+  (string.split text " "))
 
 (def (chars text)
   "Split text into a list of chars"
-  (string:split text ""))
+  (string.split text ""))
 
 (def (first lst)
   (nth lst 0))
@@ -121,10 +121,10 @@
 
 (var % rem)
 (var str string)
-(var str:split string:split)
-(var str:join string:join)
-(var str:trim string:trim)
-(var num:type number:type)
+(var str.split string.split)
+(var str.join string.join)
+(var str.trim string.trim)
+(var num.type number.type)
 (var str->num string->number)
 (var str->bin string->binary)
 (var num->bin number->binary)

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -89,17 +89,17 @@
 (def (regex:match? pattern s)
   (not (nil? (regex:find pattern str))))
 
-(def (lines contents)
-  "Split contents into a list of lines"
-  (split (string:trim contents) "\n"))
+(def (lines text)
+  "Split text into a list of lines"
+  (string:split (string:trim text) "\n"))
 
-(def (words contents)
-  "Split contents into a list of words"
-  (split contents " "))
+(def (words text)
+  "Split text into a list of words"
+  (string:split text " "))
 
-(def (chars contents)
-  "Split contents into a list of chars"
-  (split contents ""))
+(def (chars text)
+  "Split text into a list of chars"
+  (string:split text ""))
 
 (def (first lst)
   (nth lst 0))

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -91,7 +91,7 @@
 
 (def (lines contents)
   "Split contents into a list of lines"
-  (split (trim contents) "\n"))
+  (split (string:trim contents) "\n"))
 
 (def (words contents)
   "Split contents into a list of words"

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -82,6 +82,9 @@
 (def (abs x)
   (if (> x 0) x (- x)))
 
+(def (mod a b)
+  (rem (+ (rem a b) b) b))
+
 (def (string:join ls s)
   "Join the elements of the list with the string"
   (reduce (fun (x y) (string x s y)) ls))
@@ -116,6 +119,7 @@
 
 # Short aliases
 
+(var % rem)
 (var str string)
 (var str:split string:split)
 (var str:join string:join)

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -64,12 +64,12 @@
 (def (reverse x)
   "Reverse list"
   (if (nil? x) x
-    (append (reverse (tail x)) (cons (head x) '()))))
+    (concat (reverse (tail x)) (cons (head x) '()))))
 
 (def (range start stop)
   "Return a list of integers from start to stop excluded"
   (if (= start stop) nil
-    (append (list start) (range (+ start 1) stop))))
+    (concat (list start) (range (+ start 1) stop))))
 
 (def (min lst)
   "Return the minimum element of the list"

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -82,12 +82,12 @@
 (def (abs x)
   (if (> x 0) x (- x)))
 
-(def (join-string ls s)
+(def (string:join ls s)
   "Join the elements of the list with the string"
   (reduce (fun (x y) (string x s y)) ls))
 
-(def (regex-match? pattern s)
-  (not (nil? (regex-find pattern str))))
+(def (regex:match? pattern s)
+  (not (nil? (regex:find pattern str))))
 
 (def (lines contents)
   "Split contents into a list of lines"
@@ -117,8 +117,10 @@
 # Short aliases
 
 (var str string)
-(var num-type number-type)
-(var join-str join-string)
+(var str:split string:split)
+(var str:join string:join)
+(var str:trim string:trim)
+(var num:type number:type)
 (var str->num string->number)
 (var str->bin string->binary)
 (var num->bin number->binary)

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -86,38 +86,6 @@
   "Join the elements of the list with the string"
   (reduce (fun (x y) (string x s y)) ls))
 
-(def (read-line)
-  "Read line from the console"
-  (binary->string (reverse (tail (reverse (read-file-binary "/dev/console" 256))))))
-
-(def (read-char)
-  "Read char from the console"
-  (binary->string (read-file-binary "/dev/console" 4)))
-
-(def (p exp)
-  "Print expression to the console"
-  (do
-    (append-file-binary "/dev/console" (string->binary (string exp)))
-    '()))
-
-(def (print exp)
-  "Print expression to the console with a newline"
-  (p (string exp "\n")))
-
-(def (uptime)
-  (binary->number (read-file-binary "/dev/clk/uptime" 8) "float"))
-
-(def (realtime)
-  (binary->number (read-file-binary "/dev/clk/realtime" 8) "float"))
-
-(def (write-file path s)
-  "Write string to file"
-  (write-file-binary path (string->binary s)))
-
-(def (append-file path s)
-  "Append string to file"
-  (append-file-binary path (string->binary s)))
-
 (def (regex-match? pattern s)
   (not (nil? (regex-find pattern str))))
 
@@ -147,6 +115,7 @@
     (if (= (length lst) 0) 0 (- (length lst) 1))))
 
 # Short aliases
+
 (var str string)
 (var num-type number-type)
 (var join-str join-string)
@@ -164,3 +133,5 @@
 (var len length)
 (var rev reverse)
 (var uniq unique)
+
+(load "/lib/lisp/file.lsp")

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -1,0 +1,72 @@
+(var stdin 0)
+(var stdout 1)
+(var stderr 2)
+
+# Read
+
+(def (read-file-binary path)
+  "Read binary file"
+  (do
+    (var size (file:size path))
+    (var file (file:open path "r"))
+    (var data (file:read file size))
+    (file:close file)
+    data))
+
+(def (read-file path)
+  "Read text file"
+  (binary->string (read-file-binary path)))
+
+# Write
+
+(def (write-file-binary path data)
+  "Write binary to file"
+  (do
+    (var file (file:open path "w"))
+    (file:write file data)
+    (file:close file)))
+
+(def (write-file path text)
+  "Write text to file"
+  (write-file-binary path (string->binary text)))
+
+# Append
+
+(def (append-file-binary path data)
+  "Append binary to file"
+  (do
+    (var file (file:open path "a"))
+    (file:write file data)
+    (file:close file)))
+
+(def (append-file path text)
+  "Append text to file"
+  (append-file-binary path (string->binary text)))
+
+# Console
+
+(def (read-line)
+  "Read line from the console"
+  (trim (binary->string (file:read stdin 256))))
+
+(def (read-char)
+  "Read char from the console"
+  (binary->string (file:read stdin 4)))
+
+(def (p exp)
+  "Print expression to the console"
+  (do
+    (file:write stdout (string->binary (string exp)))
+    '()))
+
+(def (print exp)
+  "Print expression to the console with a newline"
+  (p (string exp "\n")))
+
+# Special
+
+(def (uptime)
+  (binary->number (read-file-binary "/dev/clk/uptime") "float"))
+
+(def (realtime)
+  (binary->number (read-file-binary "/dev/clk/realtime") "float"))

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -7,10 +7,10 @@
 (def (read-file-binary path)
   "Read binary file"
   (do
-    (var size (file:size path))
-    (var file (file:open path "r"))
-    (var data (file:read file size))
-    (file:close file)
+    (var size (file.size path))
+    (var file (file.open path "r"))
+    (var data (file.read file size))
+    (file.close file)
     data))
 
 (def (read-file path)
@@ -22,9 +22,9 @@
 (def (write-file-binary path data)
   "Write binary to file"
   (do
-    (var file (file:open path "w"))
-    (file:write file data)
-    (file:close file)))
+    (var file (file.open path "w"))
+    (file.write file data)
+    (file.close file)))
 
 (def (write-file path text)
   "Write text to file"
@@ -35,9 +35,9 @@
 (def (append-file-binary path data)
   "Append binary to file"
   (do
-    (var file (file:open path "a"))
-    (file:write file data)
-    (file:close file)))
+    (var file (file.open path "a"))
+    (file.write file data)
+    (file.close file)))
 
 (def (append-file path text)
   "Append text to file"
@@ -47,16 +47,16 @@
 
 (def (read-line)
   "Read line from the console"
-  (string:trim (binary->string (file:read stdin 256))))
+  (string.trim (binary->string (file.read stdin 256))))
 
 (def (read-char)
   "Read char from the console"
-  (binary->string (file:read stdin 4)))
+  (binary->string (file.read stdin 4)))
 
 (def (p exp)
   "Print expression to the console"
   (do
-    (file:write stdout (string->binary (string exp)))
+    (file.write stdout (string->binary (string exp)))
     '()))
 
 (def (print exp)

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -4,7 +4,7 @@
 
 # Read
 
-(def (read-file-binary path)
+(def (read-binary path)
   "Read binary file"
   (do
     (var size (file.size path))
@@ -13,35 +13,35 @@
     (file.close file)
     data))
 
-(def (read-file path)
+(def (read path)
   "Read text file"
-  (binary->string (read-file-binary path)))
+  (binary->string (read-binary path)))
 
 # Write
 
-(def (write-file-binary path data)
+(def (write-binary path data)
   "Write binary to file"
   (do
     (var file (file.open path "w"))
     (file.write file data)
     (file.close file)))
 
-(def (write-file path text)
+(def (write path text)
   "Write text to file"
-  (write-file-binary path (string->binary text)))
+  (write-binary path (string->binary text)))
 
 # Append
 
-(def (append-file-binary path data)
+(def (append-binary path data)
   "Append binary to file"
   (do
     (var file (file.open path "a"))
     (file.write file data)
     (file.close file)))
 
-(def (append-file path text)
+(def (append path text)
   "Append text to file"
-  (append-file-binary path (string->binary text)))
+  (append-binary path (string->binary text)))
 
 # Console
 
@@ -66,7 +66,7 @@
 # Special
 
 (def (uptime)
-  (binary->number (read-file-binary "/dev/clk/uptime") "float"))
+  (binary->number (read-binary "/dev/clk/uptime") "float"))
 
 (def (realtime)
-  (binary->number (read-file-binary "/dev/clk/realtime") "float"))
+  (binary->number (read-binary "/dev/clk/realtime") "float"))

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -47,7 +47,7 @@
 
 (def (read-line)
   "Read line from the console"
-  (trim (binary->string (file:read stdin 256))))
+  (string:trim (binary->string (file:read stdin 256))))
 
 (def (read-char)
   "Read char from the console"

--- a/dsk/tmp/lisp/colors.lsp
+++ b/dsk/tmp/lisp/colors.lsp
@@ -15,7 +15,7 @@
   (str " " (f c) (if (< c 100) " " "") c (ansi-color 0 0)))
 
 (def (colors fs i j)
-  (str:join (map (fun (c) (color fs c)) (range i j)) ""))
+  (str.join (map (fun (c) (color fs c)) (range i j)) ""))
 
 (print (colors fg 30 38))
 (print (colors fg 90 98))

--- a/dsk/tmp/lisp/colors.lsp
+++ b/dsk/tmp/lisp/colors.lsp
@@ -15,7 +15,7 @@
   (str " " (f c) (if (< c 100) " " "") c (ansi-color 0 0)))
 
 (def (colors fs i j)
-  (join-str (map (fun (c) (color fs c)) (range i j)) ""))
+  (str:join (map (fun (c) (color fs c)) (range i j)) ""))
 
 (print (colors fg 30 38))
 (print (colors fg 90 98))

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -50,8 +50,9 @@ pub fn copy_files(verbose: bool) {
     copy_file("/ini/fonts/zap-vga-8x16.psf", include_bytes!("../../dsk/ini/fonts/zap-vga-8x16.psf"), verbose);
 
     create_dir("/lib/lisp", verbose);
-    copy_file("/lib/lisp/core.lsp", include_bytes!("../../dsk/lib/lisp/core.lsp"), verbose);
     copy_file("/lib/lisp/alias.lsp", include_bytes!("../../dsk/lib/lisp/alias.lsp"), verbose);
+    copy_file("/lib/lisp/core.lsp", include_bytes!("../../dsk/lib/lisp/core.lsp"), verbose);
+    copy_file("/lib/lisp/file.lsp", include_bytes!("../../dsk/lib/lisp/file.lsp"), verbose);
     //copy_file("/lib/lisp/legacy.lsp", include_bytes!("../../dsk/lib/lisp/legacy.lsp"), verbose);
 
     copy_file("/tmp/alice.txt", include_bytes!("../../dsk/tmp/alice.txt"), verbose);

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -47,10 +47,10 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("trunc".to_string(),              Exp::Primitive(primitive::lisp_trunc));
     data.insert("system".to_string(),             Exp::Primitive(primitive::lisp_system));
     data.insert("string".to_string(),             Exp::Primitive(primitive::lisp_string));
-    data.insert("string->binary".to_string(),     Exp::Primitive(primitive::lisp_string_bytes));
-    data.insert("binary->string".to_string(),     Exp::Primitive(primitive::lisp_bytes_string));
-    data.insert("binary->number".to_string(),     Exp::Primitive(primitive::lisp_bytes_number));
-    data.insert("number->binary".to_string(),     Exp::Primitive(primitive::lisp_number_bytes));
+    data.insert("string->binary".to_string(),     Exp::Primitive(primitive::lisp_string_binary));
+    data.insert("binary->string".to_string(),     Exp::Primitive(primitive::lisp_binary_string));
+    data.insert("binary->number".to_string(),     Exp::Primitive(primitive::lisp_binary_number));
+    data.insert("number->binary".to_string(),     Exp::Primitive(primitive::lisp_number_binary));
     data.insert("string->number".to_string(),     Exp::Primitive(primitive::lisp_string_number));
     data.insert("type".to_string(),               Exp::Primitive(primitive::lisp_type));
     data.insert("parse".to_string(),              Exp::Primitive(primitive::lisp_parse));

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -62,7 +62,7 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("slice".to_string(),              Exp::Primitive(primitive::lisp_slice));
     data.insert("chunks".to_string(),             Exp::Primitive(primitive::lisp_chunks));
     data.insert("length".to_string(),             Exp::Primitive(primitive::lisp_length));
-    data.insert("append".to_string(),             Exp::Primitive(primitive::lisp_append));
+    data.insert("concat".to_string(),             Exp::Primitive(primitive::lisp_concat));
 
     data.insert("number.type".to_string(),        Exp::Primitive(primitive::lisp_number_type));
     data.insert("regex.find".to_string(),         Exp::Primitive(primitive::lisp_regex_find));

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -46,10 +46,6 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("tan".to_string(),                Exp::Primitive(primitive::lisp_tan));
     data.insert("trunc".to_string(),              Exp::Primitive(primitive::lisp_trunc));
     data.insert("system".to_string(),             Exp::Primitive(primitive::lisp_system));
-    data.insert("read-file".to_string(),          Exp::Primitive(primitive::lisp_read_file));
-    data.insert("read-file-binary".to_string(),   Exp::Primitive(primitive::lisp_read_file_bytes));
-    data.insert("write-file-binary".to_string(),  Exp::Primitive(primitive::lisp_write_file_bytes));
-    data.insert("append-file-binary".to_string(), Exp::Primitive(primitive::lisp_append_file_bytes));
     data.insert("string".to_string(),             Exp::Primitive(primitive::lisp_string));
     data.insert("string->binary".to_string(),     Exp::Primitive(primitive::lisp_string_bytes));
     data.insert("binary->string".to_string(),     Exp::Primitive(primitive::lisp_bytes_string));
@@ -71,6 +67,12 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("trim".to_string(),               Exp::Primitive(primitive::lisp_trim));
     data.insert("length".to_string(),             Exp::Primitive(primitive::lisp_length));
     data.insert("append".to_string(),             Exp::Primitive(primitive::lisp_append));
+
+    data.insert("file:size".to_string(),          Exp::Primitive(primitive::lisp_file_size));
+    data.insert("file:open".to_string(),          Exp::Primitive(primitive::lisp_file_open));
+    data.insert("file:read".to_string(),          Exp::Primitive(primitive::lisp_file_read));
+    data.insert("file:write".to_string(),         Exp::Primitive(primitive::lisp_file_write));
+    data.insert("file:close".to_string(),         Exp::Primitive(primitive::lisp_file_close));
 
     // Setup autocompletion
     *FUNCTIONS.lock() = data.keys().cloned().chain(BUILT_INS.map(String::from)).collect();

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -34,10 +34,10 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("+".to_string(),                  Exp::Primitive(primitive::lisp_add));
     data.insert("-".to_string(),                  Exp::Primitive(primitive::lisp_sub));
     data.insert("/".to_string(),                  Exp::Primitive(primitive::lisp_div));
-    data.insert("%".to_string(),                  Exp::Primitive(primitive::lisp_rem));
     data.insert("^".to_string(),                  Exp::Primitive(primitive::lisp_exp));
     data.insert("<<".to_string(),                 Exp::Primitive(primitive::lisp_shl));
     data.insert(">>".to_string(),                 Exp::Primitive(primitive::lisp_shr));
+    data.insert("rem".to_string(),                Exp::Primitive(primitive::lisp_rem));
     data.insert("cos".to_string(),                Exp::Primitive(primitive::lisp_cos));
     data.insert("acos".to_string(),               Exp::Primitive(primitive::lisp_acos));
     data.insert("asin".to_string(),               Exp::Primitive(primitive::lisp_asin));

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -34,7 +34,7 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("+".to_string(),                  Exp::Primitive(primitive::lisp_add));
     data.insert("-".to_string(),                  Exp::Primitive(primitive::lisp_sub));
     data.insert("/".to_string(),                  Exp::Primitive(primitive::lisp_div));
-    data.insert("%".to_string(),                  Exp::Primitive(primitive::lisp_mod));
+    data.insert("%".to_string(),                  Exp::Primitive(primitive::lisp_rem));
     data.insert("^".to_string(),                  Exp::Primitive(primitive::lisp_exp));
     data.insert("<<".to_string(),                 Exp::Primitive(primitive::lisp_shl));
     data.insert(">>".to_string(),                 Exp::Primitive(primitive::lisp_shr));

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -51,10 +51,8 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("binary->string".to_string(),     Exp::Primitive(primitive::lisp_bytes_string));
     data.insert("binary->number".to_string(),     Exp::Primitive(primitive::lisp_bytes_number));
     data.insert("number->binary".to_string(),     Exp::Primitive(primitive::lisp_number_bytes));
-    data.insert("regex-find".to_string(),         Exp::Primitive(primitive::lisp_regex_find));
     data.insert("string->number".to_string(),     Exp::Primitive(primitive::lisp_string_number));
     data.insert("type".to_string(),               Exp::Primitive(primitive::lisp_type));
-    data.insert("number-type".to_string(),        Exp::Primitive(primitive::lisp_number_type));
     data.insert("parse".to_string(),              Exp::Primitive(primitive::lisp_parse));
     data.insert("list".to_string(),               Exp::Primitive(primitive::lisp_list));
     data.insert("sort".to_string(),               Exp::Primitive(primitive::lisp_sort));
@@ -63,10 +61,13 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("contains?".to_string(),          Exp::Primitive(primitive::lisp_contains));
     data.insert("slice".to_string(),              Exp::Primitive(primitive::lisp_slice));
     data.insert("chunks".to_string(),             Exp::Primitive(primitive::lisp_chunks));
-    data.insert("split".to_string(),              Exp::Primitive(primitive::lisp_split));
-    data.insert("trim".to_string(),               Exp::Primitive(primitive::lisp_trim));
     data.insert("length".to_string(),             Exp::Primitive(primitive::lisp_length));
     data.insert("append".to_string(),             Exp::Primitive(primitive::lisp_append));
+
+    data.insert("number:type".to_string(),        Exp::Primitive(primitive::lisp_number_type));
+    data.insert("regex:find".to_string(),         Exp::Primitive(primitive::lisp_regex_find));
+    data.insert("string:split".to_string(),       Exp::Primitive(primitive::lisp_string_split));
+    data.insert("string:trim".to_string(),        Exp::Primitive(primitive::lisp_string_trim));
 
     data.insert("file:size".to_string(),          Exp::Primitive(primitive::lisp_file_size));
     data.insert("file:open".to_string(),          Exp::Primitive(primitive::lisp_file_open));

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -64,16 +64,16 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("length".to_string(),             Exp::Primitive(primitive::lisp_length));
     data.insert("append".to_string(),             Exp::Primitive(primitive::lisp_append));
 
-    data.insert("number:type".to_string(),        Exp::Primitive(primitive::lisp_number_type));
-    data.insert("regex:find".to_string(),         Exp::Primitive(primitive::lisp_regex_find));
-    data.insert("string:split".to_string(),       Exp::Primitive(primitive::lisp_string_split));
-    data.insert("string:trim".to_string(),        Exp::Primitive(primitive::lisp_string_trim));
+    data.insert("number.type".to_string(),        Exp::Primitive(primitive::lisp_number_type));
+    data.insert("regex.find".to_string(),         Exp::Primitive(primitive::lisp_regex_find));
+    data.insert("string.split".to_string(),       Exp::Primitive(primitive::lisp_string_split));
+    data.insert("string.trim".to_string(),        Exp::Primitive(primitive::lisp_string_trim));
 
-    data.insert("file:size".to_string(),          Exp::Primitive(primitive::lisp_file_size));
-    data.insert("file:open".to_string(),          Exp::Primitive(primitive::lisp_file_open));
-    data.insert("file:read".to_string(),          Exp::Primitive(primitive::lisp_file_read));
-    data.insert("file:write".to_string(),         Exp::Primitive(primitive::lisp_file_write));
-    data.insert("file:close".to_string(),         Exp::Primitive(primitive::lisp_file_close));
+    data.insert("file.size".to_string(),          Exp::Primitive(primitive::lisp_file_size));
+    data.insert("file.open".to_string(),          Exp::Primitive(primitive::lisp_file_open));
+    data.insert("file.read".to_string(),          Exp::Primitive(primitive::lisp_file_read));
+    data.insert("file.write".to_string(),         Exp::Primitive(primitive::lisp_file_write));
+    data.insert("file.close".to_string(),         Exp::Primitive(primitive::lisp_file_close));
 
     // Setup autocompletion
     *FUNCTIONS.lock() = data.keys().cloned().chain(BUILT_INS.map(String::from)).collect();

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -20,7 +20,7 @@ pub fn expand_quasiquote(exp: &Exp) -> Result<Exp, Err> {
                 }
                 Exp::List(l) if l.len() == 2 && l[0] == Exp::Sym("unquote-splice".to_string()) => {
                     Ok(Exp::List(vec![
-                        Exp::Sym("append".to_string()),
+                        Exp::Sym("concat".to_string()),
                         l[1].clone(),
                         expand_quasiquote(&Exp::List(list[1..].to_vec()))?
                     ]))

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -537,7 +537,7 @@ fn test_lisp() {
     assert_eq!(eval!("foo"), "10");
 
     // args
-    eval!("(variable list* (function args (append args '())))");
+    eval!("(variable list* (function args (concat args '())))");
     assert_eq!(eval!("(list* 1 2 3)"), "(1 2 3)");
 
     // comments

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -469,7 +469,8 @@ fn test_lisp() {
     assert_eq!(eval!("(string \"foo \" 3)"), "\"foo 3\"");
     assert_eq!(eval!("(equal? \"foo\" \"foo\")"), "true");
     assert_eq!(eval!("(equal? \"foo\" \"bar\")"), "false");
-    assert_eq!(eval!("(split \"a\nb\nc\" \"\n\")"), "(\"a\" \"b\" \"c\")");
+    assert_eq!(eval!("(string:trim \"abc\n\")"), "\"abc\"");
+    assert_eq!(eval!("(string:split \"a\nb\nc\" \"\n\")"), "(\"a\" \"b\" \"c\")");
 
     // apply
     assert_eq!(eval!("(apply + '(1 2 3))"), "6");
@@ -506,9 +507,9 @@ fn test_lisp() {
     assert_eq!(eval!("(^ 2 128)"),   "340282366920938463463374607431768211456");   // -> bigint
     assert_eq!(eval!("(^ 2.0 128)"), "340282366920938500000000000000000000000.0"); // -> float
 
-    assert_eq!(eval!("(number-type 9223372036854775807)"),   "\"int\"");
-    assert_eq!(eval!("(number-type 9223372036854775808)"),   "\"bigint\"");
-    assert_eq!(eval!("(number-type 9223372036854776000.0)"), "\"float\"");
+    assert_eq!(eval!("(number:type 9223372036854775807)"),   "\"int\"");
+    assert_eq!(eval!("(number:type 9223372036854775808)"),   "\"bigint\"");
+    assert_eq!(eval!("(number:type 9223372036854776000.0)"), "\"float\"");
 
     // quasiquote
     eval!("(variable x 'a)");

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -473,8 +473,8 @@ fn test_lisp() {
     assert_eq!(eval!("(string \"foo \" 3)"), "\"foo 3\"");
     assert_eq!(eval!("(equal? \"foo\" \"foo\")"), "true");
     assert_eq!(eval!("(equal? \"foo\" \"bar\")"), "false");
-    assert_eq!(eval!("(string:trim \"abc\n\")"), "\"abc\"");
-    assert_eq!(eval!("(string:split \"a\nb\nc\" \"\n\")"), "(\"a\" \"b\" \"c\")");
+    assert_eq!(eval!("(string.trim \"abc\n\")"), "\"abc\"");
+    assert_eq!(eval!("(string.split \"a\nb\nc\" \"\n\")"), "(\"a\" \"b\" \"c\")");
 
     // apply
     assert_eq!(eval!("(apply + '(1 2 3))"), "6");
@@ -511,9 +511,9 @@ fn test_lisp() {
     assert_eq!(eval!("(^ 2 128)"),   "340282366920938463463374607431768211456");   // -> bigint
     assert_eq!(eval!("(^ 2.0 128)"), "340282366920938500000000000000000000000.0"); // -> float
 
-    assert_eq!(eval!("(number:type 9223372036854775807)"),   "\"int\"");
-    assert_eq!(eval!("(number:type 9223372036854775808)"),   "\"bigint\"");
-    assert_eq!(eval!("(number:type 9223372036854776000.0)"), "\"float\"");
+    assert_eq!(eval!("(number.type 9223372036854775807)"),   "\"int\"");
+    assert_eq!(eval!("(number.type 9223372036854775808)"),   "\"bigint\"");
+    assert_eq!(eval!("(number.type 9223372036854776000.0)"), "\"float\"");
 
     // quasiquote
     eval!("(variable x 'a)");

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -445,8 +445,12 @@ fn test_lisp() {
     assert_eq!(eval!("(^ 2 4)"), "16");
     assert_eq!(eval!("(^ 2 4 2)"), "256"); // Left to right
 
-    // modulo
-    assert_eq!(eval!("(% 3 2)"), "1");
+    // remainder
+    assert_eq!(eval!("(rem 0 2)"), "0");
+    assert_eq!(eval!("(rem 1 2)"), "1");
+    assert_eq!(eval!("(rem 2 2)"), "0");
+    assert_eq!(eval!("(rem 3 2)"), "1");
+    assert_eq!(eval!("(rem -1 2)"), "-1");
 
     // comparisons
     assert_eq!(eval!("(< 6 4)"), "false");

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -25,7 +25,7 @@ use nom::sequence::preceded;
 use nom::sequence::tuple;
 
 fn is_symbol_letter(c: char) -> bool {
-    let chars = "<>=-+*/%^?:";
+    let chars = "<>=-+*/%^?.";
     c.is_alphanumeric() || chars.contains(c)
 }
 

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -34,6 +34,8 @@ fn parse_str(input: &str) -> IResult<&str, Exp> {
         value("\\", tag("\\")),
         value("\"", tag("\"")),
         value("\n", tag("n")),
+        value("\r", tag("r")),
+        value("\t", tag("t")),
     )))), |inner| inner.unwrap_or("".to_string()));
     let (input, s) = delimited(char('"'), escaped, char('"'))(input)?;
     Ok((input, Exp::Str(s)))

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -337,7 +337,8 @@ pub fn lisp_length(args: &[Exp]) -> Result<Exp, Err> {
     }
 }
 
-pub fn lisp_append(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_concat(args: &[Exp]) -> Result<Exp, Err> {
+    // TODO: This could also concat strings
     let mut res = vec![];
     for arg in args {
         if let Exp::List(list) = arg {

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -212,19 +212,6 @@ pub fn lisp_number_bytes(args: &[Exp]) -> Result<Exp, Err> {
     Ok(Exp::List(n.to_be_bytes().iter().map(|b| Exp::Num(Number::from(*b))).collect()))
 }
 
-pub fn lisp_regex_find(args: &[Exp]) -> Result<Exp, Err> {
-    ensure_length_eq!(args, 2);
-    match (&args[0], &args[1]) {
-        (Exp::Str(regex), Exp::Str(s)) => {
-            let res = Regex::new(regex).find(s).map(|(a, b)| {
-                vec![Exp::Num(Number::from(a)), Exp::Num(Number::from(b))]
-            }).unwrap_or(vec![]);
-            Ok(Exp::List(res))
-        }
-        _ => expected!("arguments to be a regex and a string")
-    }
-}
-
 pub fn lisp_string_number(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     let s = string(&args[0])?;
@@ -245,16 +232,6 @@ pub fn lisp_type(args: &[Exp]) -> Result<Exp, Err> {
         Exp::Num(_)       => "number",
     };
     Ok(Exp::Str(exp.to_string()))
-}
-
-pub fn lisp_number_type(args: &[Exp]) -> Result<Exp, Err> {
-    ensure_length_eq!(args, 1);
-    match args[0] {
-        Exp::Num(Number::Int(_)) => Ok(Exp::Str("int".to_string())),
-        Exp::Num(Number::BigInt(_)) => Ok(Exp::Str("bigint".to_string())),
-        Exp::Num(Number::Float(_)) => Ok(Exp::Str("float".to_string())),
-        _ => expected!("argument to be a number")
-    }
 }
 
 pub fn lisp_parse(args: &[Exp]) -> Result<Exp, Err> {
@@ -351,31 +328,6 @@ pub fn lisp_chunks(args: &[Exp]) -> Result<Exp, Err> {
     }
 }
 
-pub fn lisp_split(args: &[Exp]) -> Result<Exp, Err> {
-    ensure_length_eq!(args, 2);
-    match (&args[0], &args[1]) {
-        (Exp::Str(string), Exp::Str(pattern)) => {
-            let list = if pattern.is_empty() {
-                // NOTE: "abc".split("") => ["", "b", "c", ""]
-                string.chars().map(|s| Exp::Str(s.to_string())).collect()
-            } else {
-                string.split(pattern).map(|s| Exp::Str(s.to_string())).collect()
-            };
-            Ok(Exp::List(list))
-        }
-        _ => expected!("a string and a pattern")
-    }
-}
-
-pub fn lisp_trim(args: &[Exp]) -> Result<Exp, Err> {
-    ensure_length_eq!(args, 1);
-    if let Exp::Str(s) = &args[0] {
-        Ok(Exp::Str(s.trim().to_string()))
-    } else {
-        expected!("a string and a pattern")
-    }
-}
-
 pub fn lisp_length(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     match &args[0] {
@@ -396,6 +348,62 @@ pub fn lisp_append(args: &[Exp]) -> Result<Exp, Err> {
     }
     Ok(Exp::List(res))
 }
+
+// Number module
+
+pub fn lisp_number_type(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    match args[0] {
+        Exp::Num(Number::Int(_)) => Ok(Exp::Str("int".to_string())),
+        Exp::Num(Number::BigInt(_)) => Ok(Exp::Str("bigint".to_string())),
+        Exp::Num(Number::Float(_)) => Ok(Exp::Str("float".to_string())),
+        _ => expected!("argument to be a number")
+    }
+}
+
+// Regex module
+
+pub fn lisp_regex_find(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    match (&args[0], &args[1]) {
+        (Exp::Str(regex), Exp::Str(s)) => {
+            let res = Regex::new(regex).find(s).map(|(a, b)| {
+                vec![Exp::Num(Number::from(a)), Exp::Num(Number::from(b))]
+            }).unwrap_or(vec![]);
+            Ok(Exp::List(res))
+        }
+        _ => expected!("arguments to be a regex and a string")
+    }
+}
+
+// String module
+
+pub fn lisp_string_split(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    match (&args[0], &args[1]) {
+        (Exp::Str(string), Exp::Str(pattern)) => {
+            let list = if pattern.is_empty() {
+                // NOTE: "abc".split("") => ["", "b", "c", ""]
+                string.chars().map(|s| Exp::Str(s.to_string())).collect()
+            } else {
+                string.split(pattern).map(|s| Exp::Str(s.to_string())).collect()
+            };
+            Ok(Exp::List(list))
+        }
+        _ => expected!("a string and a pattern")
+    }
+}
+
+pub fn lisp_string_trim(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Str(s) = &args[0] {
+        Ok(Exp::Str(s.trim().to_string()))
+    } else {
+        expected!("a string and a pattern")
+    }
+}
+
+// File module
 
 pub fn lisp_file_size(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -76,7 +76,7 @@ pub fn lisp_div(args: &[Exp]) -> Result<Exp, Err> {
     Ok(Exp::Num(res))
 }
 
-pub fn lisp_mod(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_rem(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_gt!(args, 0);
     let args = numbers(args)?;
     for arg in &args[1..] {

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -171,14 +171,14 @@ pub fn lisp_string(args: &[Exp]) -> Result<Exp, Err> {
     Ok(Exp::Str(args.join("")))
 }
 
-pub fn lisp_string_bytes(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_string_binary(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     let s = string(&args[0])?;
     let buf = s.as_bytes();
     Ok(Exp::List(buf.iter().map(|b| Exp::Num(Number::from(*b))).collect()))
 }
 
-pub fn lisp_bytes_string(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_binary_string(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     match &args[0] {
         Exp::List(list) => {
@@ -190,7 +190,7 @@ pub fn lisp_bytes_string(args: &[Exp]) -> Result<Exp, Err> {
     }
 }
 
-pub fn lisp_bytes_number(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_binary_number(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 2);
     match (&args[0], &args[1]) { // TODO: default type to "int" and make it optional
         (Exp::List(list), Exp::Str(kind)) => {
@@ -206,7 +206,7 @@ pub fn lisp_bytes_number(args: &[Exp]) -> Result<Exp, Err> {
     }
 }
 
-pub fn lisp_number_bytes(args: &[Exp]) -> Result<Exp, Err> {
+pub fn lisp_number_binary(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
     let n = number(&args[0])?;
     Ok(Exp::List(n.to_be_bytes().iter().map(|b| Exp::Num(Number::from(*b))).collect()))

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -292,10 +292,10 @@ pub fn lisp_sort(args: &[Exp]) -> Result<Exp, Err> {
 
 pub fn lisp_contains(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 2);
-    if let Exp::List(list) = &args[0] {
-        Ok(Exp::Bool(list.contains(&args[1])))
-    } else {
-        expected!("first argument to be a list")
+    match &args[0] {
+        Exp::List(l) => Ok(Exp::Bool(l.contains(&args[1]))),
+        Exp::Str(s) => Ok(Exp::Bool(s.contains(&string(&args[1])?))),
+        _ => expected!("first argument to be a list or a string"),
     }
 }
 

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -234,5 +234,11 @@ language and reading from the filesystem.</p>
     <li>Add params to function representations</li>
     <li>Add docstring to functions</li>
     </ul>
+
+    <h3>Unreleased</h3>
+
+    <ul>
+    <li>Add file, number, string, and regex namespaces</li>
+    </ul>
   </body>
 </html>

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -56,21 +56,20 @@ of the Shell.</p>
     <h3>Primitive Operators</h3>
 
     <ul>
-    <li><code>append</code></li>
-    <li><code>type</code>, <code>number-type</code> (aliased to <code>num-type</code>)</li>
+    <li><code>type</code>, <code>number.type</code> (aliased to <code>num.type</code>)</li>
     <li><code>string</code> (aliased to <code>str</code>)</li>
     <li><code>string-&gt;number</code> (aliased to to <code>str-&gt;num</code>)</li>
     <li><code>string-&gt;binary</code> and <code>binary-&gt;string</code> (aliased to <code>str-&gt;bin</code> and <code>bin-&gt;str</code>)</li>
     <li><code>number-&gt;binary</code> and <code>binary-&gt;number</code> (aliased to <code>num-&gt;bin</code> and <code>bin-&gt;num</code>)</li>
-    <li><code>regex-find</code></li>
+    <li><code>regex.find</code></li>
     <li><code>system</code></li>
-    <li>Arithmetic operations: <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>%</code>, <code>^</code>, <code>abs</code></li>
+    <li>Arithmetic operations: <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>^</code>, <code>abs</code>, <code>mod</code>, <code>rem</code> (aliased to <code>%</code>)</li>
     <li>Trigonometric functions: <code>acos</code>, <code>asin</code>, <code>atan</code>, <code>cos</code>, <code>sin</code>, <code>tan</code></li>
     <li>Comparisons: <code>&gt;</code>, <code>&lt;</code>, <code>&gt;=</code>, <code>&lt;=</code>, <code>=</code></li>
-    <li>File IO: <code>read-file</code>, <code>read-file-binary</code>, <code>write-file-binary</code>, <code>append-file-binary</code></li>
-    <li>List: <code>chunks</code>, <code>sort</code>, <code>unique</code> (aliased to <code>uniq</code>), <code>min</code>, <code>max</code></li>
-    <li>String: <code>trim</code>, <code>split</code></li>
     <li>Enumerable: <code>length</code> (aliased to <code>len</code>), <code>nth</code>, <code>first</code>, <code>second</code>, <code>third</code>, <code>last</code>, <code>rest</code>, <code>slice</code></li>
+    <li>String: <code>string.trim</code>, <code>string.split</code></li>
+    <li>List: <code>concat</code>, <code>chunks</code>, <code>sort</code>, <code>unique</code> (aliased to <code>uniq</code>), <code>min</code>, <code>max</code></li>
+    <li>File: <code>file.size</code>, <code>file.open</code>, <code>file.close</code>, <code>file.read</code>, <code>file.write</code></li>
     </ul>
 
     <h3>Core Library</h3>
@@ -83,12 +82,18 @@ of the Shell.</p>
     <li><code>map</code>, <code>reduce</code>, <code>reverse</code> (aliased to <code>rev</code>), <code>range</code>, <code>filter</code>, <code>intersection</code></li>
     <li><code>not</code>, <code>and</code>, <code>or</code></li>
     <li><code>let</code></li>
-    <li><code>join-string</code> (aliased to <code>join-str</code>), <code>lines</code>, <code>words</code>, <code>chars</code></li>
+    <li><code>string.join</code> (aliased to <code>str.join</code>), <code>lines</code>, <code>words</code>, <code>chars</code></li>
+    <li><code>regex.match?</code></li>
+    </ul>
+
+    <h3>File Library</h3>
+
+    <ul>
+    <li><code>read</code>, <code>write</code>, <code>append</code></li>
+    <li><code>read-binary</code>, <code>write-binary</code>, <code>append-binary</code></li>
     <li><code>read-line</code>, <code>read-char</code></li>
-    <li><code>p</code>, <code>print</code></li>
-    <li><code>write-file</code>, <code>append-file</code></li>
     <li><code>uptime</code>, <code>realtime</code></li>
-    <li><code>regex-match?</code></li>
+    <li><code>p</code>, <code>print</code></li>
     </ul>
 
     <h3>Compatibility Library</h3>


### PR DESCRIPTION
This PR introduces a lower level `file` namespace to the lisp allowing reading (`file:read`) and writing (`file:write`) directly from a file handle to have a better `print` function so the output of a script can now be redirected to a file from the shell for example.

This wasn't possible before:
```
lisp /tmp/lisp/pi.lsp 100 => pi.txt
```

The new notation using a dot `.` to group functions within a namespace will also be used for `number`, `string`, and `regex` with `number.type`, `string.trim`, and `regex.match?` for example.