### PR TITLE
Add PageUp and PageDown keys support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Add PageUp and PageDown keys support ([#515](https://github.com/vinc/moros/pull/515))
+- Bump pbkdf2 from 0.12.1 to 0.12.2 ([#513](https://github.com/vinc/moros/pull/513))
+- Bump uart_16550 from 0.2.18 to 0.2.19 ([#514](https://github.com/vinc/moros/pull/514))
 - Add namespaces to lisp ([#511](https://github.com/vinc/moros/pull/511))
 - Update smoltcp from 0.9.1 to 0.10.0 ([#510](https://github.com/vinc/moros/pull/510))
 

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -68,10 +68,12 @@ fn send_key(c: char) {
     sys::console::key_handle(c);
 }
 
-fn send_csi(c: char) {
+fn send_csi(code: &str) {
     send_key('\x1B'); // ESC
     send_key('[');
-    send_key(c);
+    for c in code.chars() {
+        send_key(c);
+    }
 }
 
 fn interrupt_handler() {
@@ -91,11 +93,13 @@ fn interrupt_handler() {
             if let Some(key) = keyboard.process_keyevent(event) {
                 match key {
                     DecodedKey::Unicode('\u{7f}') if is_alt && is_ctrl => syscall::reboot(), // Ctrl-Alt-Del
-                    DecodedKey::RawKey(KeyCode::ArrowUp)    => send_csi('A'),
-                    DecodedKey::RawKey(KeyCode::ArrowDown)  => send_csi('B'),
-                    DecodedKey::RawKey(KeyCode::ArrowRight) => send_csi('C'),
-                    DecodedKey::RawKey(KeyCode::ArrowLeft)  => send_csi('D'),
-                    DecodedKey::Unicode('\t') if is_shift   => send_csi('Z'), // Convert Shift-Tab into Backtab
+                    DecodedKey::RawKey(KeyCode::PageUp)     => send_csi("5~"),
+                    DecodedKey::RawKey(KeyCode::PageDown)   => send_csi("6~"),
+                    DecodedKey::RawKey(KeyCode::ArrowUp)    => send_csi("A"),
+                    DecodedKey::RawKey(KeyCode::ArrowDown)  => send_csi("B"),
+                    DecodedKey::RawKey(KeyCode::ArrowRight) => send_csi("C"),
+                    DecodedKey::RawKey(KeyCode::ArrowLeft)  => send_csi("D"),
+                    DecodedKey::Unicode('\t') if is_shift   => send_csi("Z"), // Convert Shift-Tab into Backtab
                     DecodedKey::Unicode(c)                  => send_key(c),
                     _ => {},
                 };

--- a/src/usr/editor.rs
+++ b/src/usr/editor.rs
@@ -304,7 +304,11 @@ impl Editor {
                 },
                 '~' if csi && csi_params == "6" => { // Page Down
                     let scroll = self.rows() - 1; // Keep one previous line on screen
-                    self.offset.y += cmp::min(scroll, (self.lines.len() - 2) - self.offset.y);
+                    let remaining = cmp::max(self.lines.len(), 1) - self.offset.y - 1;
+                    self.offset.y += cmp::min(scroll, remaining);
+                    if self.cursor.y + scroll > remaining {
+                        self.cursor.y = 0;
+                    }
                     self.print_screen();
                 },
                 'A' if csi => { // Arrow Up


### PR DESCRIPTION
Pressing `PageDown` on the keyboard in the editor will scroll the screen, leaving only the previous last line at the top, and vice versa for `PageUp`. The keys are translated to ANSI CSI codes `^[5~` and `^[6~` respectively to be compatible with the serial console.