### PR TITLE
Speed up VGA text mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Speed up VGA text mode ([#516](https://github.com/vinc/moros/pull/516))
 - Add PageUp and PageDown keys support ([#515](https://github.com/vinc/moros/pull/515))
 - Bump pbkdf2 from 0.12.1 to 0.12.2 ([#513](https://github.com/vinc/moros/pull/513))
 - Bump uart_16550 from 0.2.18 to 0.2.19 ([#514](https://github.com/vinc/moros/pull/514))

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -191,11 +191,7 @@ impl Writer {
             ascii_code: b' ',
             color_code: self.color_code,
         };
-        for i in x..BUFFER_WIDTH {
-            unsafe {
-                core::ptr::write_volatile(&mut self.buffer.chars[y][i], c);
-            }
-        }
+        self.buffer.chars[y][x..BUFFER_WIDTH].fill(c);
     }
 
     fn clear_screen(&mut self) {

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -179,12 +179,7 @@ impl Writer {
             self.writer[1] += 1;
         } else {
             for y in 1..BUFFER_HEIGHT {
-                for x in 0..BUFFER_WIDTH {
-                    unsafe {
-                        let c = core::ptr::read_volatile(&self.buffer.chars[y][x]);
-                        core::ptr::write_volatile(&mut self.buffer.chars[y - 1][x], c);
-                    }
-                }
+                self.buffer.chars[y - 1] = self.buffer.chars[y];
             }
             self.clear_row_after(0, BUFFER_HEIGHT - 1);
         }


### PR DESCRIPTION
Scrolling was a bit slow in QEMU and a simple refactor of the new line method made it appear almost instantaneous.

Before:
```
> time read /tmp/alice.txt
...
Executed 'read /tmp/alice.txt' in 1.691047s
```

After:
```
> time read /tmp/alice.txt
...
Executed 'read /tmp/alice.txt' in 0.003999s
```