### PR TITLE
Fix BitmapBlock#next_free_addr after 512 allocated blocks

### DIFF
--- a/src/sys/fs/bitmap_block.rs
+++ b/src/sys/fs/bitmap_block.rs
@@ -51,7 +51,8 @@ impl BitmapBlock {
         for i in 0..n {
             let block = Block::read(sb.bitmap_area() + i);
             let bitmap = block.data();
-            for j in 0..size {
+            let m = size / 8;
+            for j in 0..m {
                 for k in 0..8 {
                     if !bitmap[j as usize].get_bit(k) {
                         let bs = BITMAP_SIZE as u32;


### PR DESCRIPTION
MOROS couldn't allocate more than 512 blocks due to a bug preventing to use more than one bitmap block.