### PR TITLE
Evaluate load argument in lisp

### DIFF
--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -135,7 +135,7 @@ fn eval_do_args(args: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
 
 fn eval_load_args(args: &[Exp], env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
     ensure_length_eq!(args, 1);
-    let path = string(&args[0])?;
+    let path = string(&eval(&args[0], env)?)?;
     let mut input = fs::read_to_string(&path).or(could_not!("find file '{}'", path))?;
     loop {
         let (rest, _) = parse_eval(&input, env)?;


### PR DESCRIPTION
This will allow the following code in lisp:
```janet
(var path "/path/to/lib.lsp")
(load path)
```