### PR TITLE
Improve binary support

### DIFF
--- a/src/sys/acpi.rs
+++ b/src/sys/acpi.rs
@@ -26,12 +26,12 @@ pub fn shutdown() {
             if let Ok(fadt) = acpi.find_table::<acpi::fadt::Fadt>() {
                 if let Ok(block) = fadt.pm1a_control_block() {
                     pm1a_control_block = block.address as u32;
-                    //debug!("ACPI Found PM1a Control Block: {:#x}", pm1a_control_block);
+                    //debug!("ACPI Found PM1a Control Block: {:#X}", pm1a_control_block);
                 }
             }
             if let Ok(dsdt) = &acpi.dsdt() {
                 let address = sys::mem::phys_to_virt(PhysAddr::new(dsdt.address as u64));
-                //debug!("ACPI Found DSDT at {:#x} {:#x}", dsdt.address, address);
+                //debug!("ACPI Found DSDT at {:#X} {:#X}", dsdt.address, address);
                 let table = unsafe { core::slice::from_raw_parts(address.as_ptr(), dsdt.length as usize) };
                 if aml.parse_table(table).is_ok() {
                     let name = AmlName::from_str("\\_S5").unwrap();
@@ -69,7 +69,7 @@ pub struct MorosAcpiHandler;
 impl AcpiHandler for MorosAcpiHandler {
     unsafe fn map_physical_region<T>(&self, physical_address: usize, size: usize) -> PhysicalMapping<Self, T> {
         let virtual_address = sys::mem::phys_to_virt(PhysAddr::new(physical_address as u64));
-        //debug!("ACPI mapping phys {:#x} -> virt {:#x}", physical_address, virtual_address);
+        //debug!("ACPI mapping phys {:#X} -> virt {:#X}", physical_address, virtual_address);
         PhysicalMapping::new(physical_address, NonNull::new(virtual_address.as_mut_ptr()).unwrap(), size, size, Self)
     }
 

--- a/src/sys/allocator.rs
+++ b/src/sys/allocator.rs
@@ -55,7 +55,7 @@ pub fn init_heap() -> Result<(), MapToError<Size4KiB>> {
 }
 
 pub fn alloc_pages(mapper: &mut OffsetPageTable, addr: u64, size: usize) -> Result<(), ()> {
-    //debug!("Alloc pages (addr={:#x}, size={})", addr, size);
+    //debug!("Alloc pages (addr={:#X}, size={})", addr, size);
     let mut frame_allocator = sys::mem::frame_allocator();
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
     let pages = {

--- a/src/sys/fs/block.rs
+++ b/src/sys/fs/block.rs
@@ -44,7 +44,7 @@ impl Block {
         let mut buf = [0; super::BLOCK_SIZE];
         if let Some(ref mut block_device) = *super::block_device::BLOCK_DEVICE.lock() {
             if block_device.read(addr, &mut buf).is_err() {
-                debug!("MFS: could not read block {:#x}", addr);
+                debug!("MFS: could not read block {:#X}", addr);
             }
         }
         Self { addr, buf }
@@ -53,7 +53,7 @@ impl Block {
     pub fn write(&self) {
         if let Some(ref mut block_device) = *super::block_device::BLOCK_DEVICE.lock() {
             if block_device.write(self.addr, &self.buf).is_err() {
-                debug!("MFS: could not write block {:#x}", self.addr);
+                debug!("MFS: could not write block {:#X}", self.addr);
             }
         }
     }

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -120,7 +120,7 @@ extern "x86-interrupt" fn page_fault_handler(_stack_frame: InterruptStackFrame, 
     if sys::allocator::alloc_pages(&mut mapper, addr, 1).is_err() {
         let csi_color = api::console::Style::color("LightRed");
         let csi_reset = api::console::Style::reset();
-        printk!("{}Error:{} Could not allocate address {:#x}\n", csi_color, csi_reset, addr);
+        printk!("{}Error:{} Could not allocate address {:#X}\n", csi_color, csi_reset, addr);
         if error_code.contains(PageFaultErrorCode::USER_MODE) {
             api::syscall::exit(ExitCode::PageFaultError);
         } else {

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -401,7 +401,7 @@ impl Process {
         let mut mapper = unsafe { OffsetPageTable::new(page_table, VirtAddr::new(phys_mem_offset)) };
 
         let heap_addr = self.code_addr + (self.stack_addr - self.code_addr) / 2;
-        //debug!("user-args: {:#016x}", heap_addr);
+        //debug!("user-args: {:#016X}", heap_addr);
         sys::allocator::alloc_pages(&mut mapper, heap_addr, 1).expect("proc heap alloc");
 
         let args_ptr = ptr_from_addr(args_ptr as u64) as usize;
@@ -429,7 +429,7 @@ impl Process {
 
         let heap_addr = addr;
         let heap_size = (self.stack_addr - heap_addr) / 2;
-        //debug!("user-heap: {:#016x}..{:#016x}", heap_addr, heap_addr + heap_size);
+        //debug!("user-heap: {:#016X}..{:#016X}", heap_addr, heap_addr + heap_size);
         unsafe { self.allocator.lock().init(heap_addr as *mut u8, heap_size as usize) };
 
         set_id(self.id); // Change PID

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -341,8 +341,8 @@ impl Process {
         let proc_size = MAX_PROC_SIZE as u64;
         let code_addr = CODE_ADDR.fetch_add(proc_size, Ordering::SeqCst);
         let stack_addr = code_addr + proc_size - 4096;
-        //debug!("code_addr:  {:#x}", code_addr);
-        //debug!("stack_addr: {:#x}", stack_addr);
+        //debug!("code_addr:  {:#X}", code_addr);
+        //debug!("stack_addr: {:#X}", stack_addr);
 
         let mut entry_point_addr = 0;
         let code_ptr = code_addr as *mut u8;
@@ -356,7 +356,7 @@ impl Process {
                     let addr = segment.address() as usize;
                     if let Ok(data) = segment.data() {
                         for (i, b) in data.iter().enumerate() {
-                            //debug!("code:       {:#x}", unsafe { code_ptr.add(addr + i) as usize });
+                            //debug!("code:       {:#X}", unsafe { code_ptr.add(addr + i) as usize });
                             unsafe { core::ptr::write(code_ptr.add(addr + i), *b) };
                         }
                     }

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -90,7 +90,7 @@ pub fn close(handle: usize) {
 }
 
 pub fn spawn(path: &str, args_ptr: usize, args_len: usize) -> ExitCode {
-    //debug!("syscall::spawn(path={}, args_ptr={:#x}, args_len={})", path, args_ptr, args_len);
+    //debug!("syscall::spawn(path={}, args_ptr={:#X}, args_len={})", path, args_ptr, args_len);
     let path = match sys::fs::canonicalize(path) {
         Ok(path) => path,
         Err(_) => return ExitCode::OpenError,
@@ -127,7 +127,7 @@ pub fn stop(code: usize) -> usize {
             sys::acpi::shutdown();
         }
         _ => {
-            debug!("STOP SYSCALL: Invalid code '{:#x}' received", code);
+            debug!("STOP SYSCALL: Invalid code '{:#X}' received", code);
         }
     }
     0

--- a/src/usr/elf.rs
+++ b/src/usr/elf.rs
@@ -21,7 +21,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if let Ok(buf) = fs::read_to_bytes(pathname) {
         let bin = buf.as_slice();
         if let Ok(obj) = object::File::parse(bin) {
-            println!("ELF entry address: {:#x}", obj.entry());
+            println!("ELF entry address: {:#X}", obj.entry());
             for section in obj.sections() {
                 if let Ok(name) = section.name() {
                     if name.is_empty() {
@@ -31,7 +31,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     let size = section.size();
                     let align = section.align();
                     println!();
-                    println!("{}{}{} (addr: {:#x}, size: {}, align: {})", color, name, reset, addr, size, align);
+                    println!("{}{}{} (addr: {:#X}, size: {}, align: {})", color, name, reset, addr, size, align);
                     if let Ok(data) = section.data() {
                         usr::hex::print_hex_at(data, addr);
                     }

--- a/src/usr/elf.rs
+++ b/src/usr/elf.rs
@@ -33,7 +33,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     println!();
                     println!("{}{}{} (addr: {:#x}, size: {}, align: {})", color, name, reset, addr, size, align);
                     if let Ok(data) = section.data() {
-                        usr::hex::print_hex(data);
+                        usr::hex::print_hex_at(data, addr);
                     }
                 }
             }

--- a/src/usr/hex.rs
+++ b/src/usr/hex.rs
@@ -2,6 +2,10 @@ use crate::api::fs;
 use crate::api::console::Style;
 use crate::api::process::ExitCode;
 
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
 // TODO: add `--skip` and `--length` params
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if args.len() != 2 {
@@ -24,32 +28,32 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 
 // TODO: move this to api::hex::print_hex
 pub fn print_hex(buf: &[u8]) {
-    let n = buf.len() / 2;
-    for i in 0..n {
-        print!("{}", Style::color("LightCyan"));
-        if i % 8 == 0 {
-            print!("{:08X}: ", i * 2);
-        }
-        print!("{}", Style::color("Pink"));
-        print!("{:02X}{:02X} ", buf[i * 2], buf[i * 2 + 1]);
-        print!("{}", Style::reset());
-        if i % 8 == 7 || i == n - 1 {
-            for _ in 0..(7 - (i % 8)) {
-                print!("     ");
+    print_hex_at(buf, 0)
+}
+
+pub fn print_hex_at(buf: &[u8], offset: usize) {
+    let cyan = Style::color("LightCyan");
+    let pink = Style::color("Pink");
+    let reset = Style::reset();
+
+    for (index, chunk) in buf.chunks(16).enumerate() {
+        let addr = offset + index * 16;
+
+        let hex = chunk.chunks(2).map(|pair|
+            pair.iter().map(|byte|
+                format!("{:02X}", byte)
+            ).collect::<Vec<String>>().join("")
+        ).collect::<Vec<String>>().join(" ");
+
+        let ascii: String = chunk.iter().map(|byte|
+            if *byte >= 32 && *byte <= 126 {
+                *byte as char
+            } else {
+                '.'
             }
-            let m = ((i % 8) + 1) * 2;
-            for j in 0..m {
-                let c = buf[(i * 2 + 1) - (m - 1) + j] as char;
-                if c.is_ascii_graphic() {
-                    print!("{}", c);
-                } else if c.is_ascii_whitespace() {
-                    print!(" ");
-                } else {
-                    print!(".");
-                }
-            }
-            println!();
-        }
+        ).collect();
+
+        println!("{}{:08X}: {}{:40}{}{}", cyan, addr, pink, hex, reset, ascii);
     }
 }
 

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -347,6 +347,10 @@ fn test_lisp() {
     assert_eq!(eval!("0x10"), "16");
     assert_eq!(eval!("1.5"), "1.5");
     assert_eq!(eval!("0xff"), "255");
+    assert_eq!(eval!("0b0"), "0");
+    assert_eq!(eval!("0b1"), "1");
+    assert_eq!(eval!("0b10"), "2");
+    assert_eq!(eval!("0b11"), "3");
 
     assert_eq!(eval!("-6"), "-6");
     assert_eq!(eval!("-16"), "-16");
@@ -355,6 +359,7 @@ fn test_lisp() {
     assert_eq!(eval!("-0x10"), "-16");
     assert_eq!(eval!("-1.5"), "-1.5");
     assert_eq!(eval!("-0xff"), "-255");
+    assert_eq!(eval!("-0b11"), "-3");
 
     // quote
     assert_eq!(eval!("(quote (1 2 3))"), "(1 2 3)");

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -347,7 +347,6 @@ fn test_lisp() {
     assert_eq!(eval!("0x10"), "16");
     assert_eq!(eval!("1.5"), "1.5");
     assert_eq!(eval!("0xff"), "255");
-    assert_eq!(eval!("0XFF"), "255");
 
     assert_eq!(eval!("-6"), "-6");
     assert_eq!(eval!("-16"), "-16");
@@ -356,7 +355,6 @@ fn test_lisp() {
     assert_eq!(eval!("-0x10"), "-16");
     assert_eq!(eval!("-1.5"), "-1.5");
     assert_eq!(eval!("-0xff"), "-255");
-    assert_eq!(eval!("-0XFF"), "-255");
 
     // quote
     assert_eq!(eval!("(quote (1 2 3))"), "(1 2 3)");

--- a/src/usr/lisp/number.rs
+++ b/src/usr/lisp/number.rs
@@ -200,9 +200,9 @@ operator!(Shl, shl);
 operator!(Shr, shr);
 
 fn parse_int(s: &str) -> Result<i64, ParseIntError> {
-    if s.starts_with("0x") || s.starts_with("0X") {
+    if s.starts_with("0x") {
         i64::from_str_radix(&s[2..], 16)
-    } else if s.starts_with("-0x") || s.starts_with("-0X") {
+    } else if s.starts_with("-0x") {
         i64::from_str_radix(&s[3..], 16).map(|n| -n)
     } else {
         i64::from_str_radix(s, 10)

--- a/src/usr/lisp/number.rs
+++ b/src/usr/lisp/number.rs
@@ -209,7 +209,7 @@ fn parse_int(s: &str) -> Result<i64, ParseIntError> {
     }
 }
 
-fn parse_float(s: &str) -> Result<BigInt, ParseBigIntError> {
+fn parse_bigint(s: &str) -> Result<BigInt, ParseBigIntError> {
     if s.starts_with("0x") || s.starts_with("0X") {
         BigInt::from_str_radix(&s[2..], 16)
     } else if s.starts_with("-0x") || s.starts_with("-0X") {
@@ -234,7 +234,7 @@ impl FromStr for Number {
             }
         } else if let Ok(n) = parse_int(s) {
             Ok(Number::Int(n))
-        } else if let Ok(n) = parse_float(s) {
+        } else if let Ok(n) = parse_bigint(s) {
             Ok(Number::BigInt(n))
         } else {
             err

--- a/src/usr/lisp/number.rs
+++ b/src/usr/lisp/number.rs
@@ -204,16 +204,24 @@ fn parse_int(s: &str) -> Result<i64, ParseIntError> {
         i64::from_str_radix(&s[2..], 16)
     } else if s.starts_with("-0x") {
         i64::from_str_radix(&s[3..], 16).map(|n| -n)
+    } else if s.starts_with("0b") {
+        i64::from_str_radix(&s[2..], 2)
+    } else if s.starts_with("-0b") {
+        i64::from_str_radix(&s[3..], 2).map(|n| -n)
     } else {
         i64::from_str_radix(s, 10)
     }
 }
 
 fn parse_bigint(s: &str) -> Result<BigInt, ParseBigIntError> {
-    if s.starts_with("0x") || s.starts_with("0X") {
+    if s.starts_with("0x") {
         BigInt::from_str_radix(&s[2..], 16)
-    } else if s.starts_with("-0x") || s.starts_with("-0X") {
+    } else if s.starts_with("-0x") {
         BigInt::from_str_radix(&s[3..], 16).map(|n| -n)
+    } else if s.starts_with("0b") {
+        BigInt::from_str_radix(&s[2..], 2)
+    } else if s.starts_with("-0b") {
+        BigInt::from_str_radix(&s[3..], 2).map(|n| -n)
     } else {
         BigInt::from_str_radix(s, 10)
     }

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -29,7 +29,7 @@ use nom::sequence::terminated;
 // https://docs.rs/nom/latest/nom/recipes/index.html#hexadecimal
 fn hexadecimal(input: &str) -> IResult<&str, &str> {
     preceded(
-        alt((tag("0x"), tag("0X"))),
+        alt((tag("0x"))),
         recognize(
             many1(
                 terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -29,7 +29,7 @@ use nom::sequence::terminated;
 // https://docs.rs/nom/latest/nom/recipes/index.html#hexadecimal
 fn hexadecimal(input: &str) -> IResult<&str, &str> {
     preceded(
-        alt((tag("0x"))),
+        tag("0x"),
         recognize(
             many1(
                 terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
@@ -43,6 +43,18 @@ fn decimal(input: &str) -> IResult<&str, &str> {
     recognize(
         many1(
             terminated(one_of("0123456789"), many0(char('_')))
+        )
+    )(input)
+}
+
+// https://docs.rs/nom/latest/nom/recipes/index.html#binary
+fn binary(input: &str) -> IResult<&str, &str> {
+    preceded(
+        tag("0b"),
+        recognize(
+            many1(
+                terminated(one_of("01"), many0(char('_')))
+            )
         )
     )(input)
 }
@@ -108,7 +120,7 @@ fn parse_sym(input: &str) -> IResult<&str, Exp> {
 fn parse_num(input: &str) -> IResult<&str, Exp> {
     let (input, num) = recognize(tuple((
         opt(alt((char('+'), char('-')))),
-        alt((float, hexadecimal, decimal))
+        alt((float, hexadecimal, binary, decimal))
     )))(input)?;
     Ok((input, Exp::Num(Number::from(num))))
 }


### PR DESCRIPTION
- [x] Add support for `0b1000` format in Lisp
- [x] Remove support for `0XC0DE` format and keep only `0xC0DE` (and `0xc0de`) in Lisp
- [x] Use `0xC0DE` format everywhere instead of `0xc0de`
- [x] Rewrite `hex` command to handle even number of bytes in binary
- [x] Show correct memory address in `elf` command

```
~
> elf /bin/halt
ELF entry address: 0x2011D0

.rodata (addr: 0x200158, size: 64, align: 1)
00200158: 1B5B 3933 6D4D 4F52 4F53 2068 6173 2072 .[93mMOROS has r
00200168: 6561 6368 6564 2069 7473 2066 6174 652C eached its fate,
00200178: 2074 6865 2073 7973 7465 6D20 6973 206E  the system is n
00200188: 6F77 2068 616C 7469 6E67 2E1B 5B30 6D0A ow halting..[0m.

.eh_frame_hdr (addr: 0x200198, size: 12, align: 4)
00200198: 011B 033B 0C00 0000 0000 0000           ...;........

.eh_frame (addr: 0x2001A8, size: 28, align: 8)
002001A8: 1400 0000 0000 0000 017A 5200 0178 1001 .........zR..x..
002001B8: 1B0C 0708 9001 0000 0000 0000           ............

.text (addr: 0x2011D0, size: 207, align: 16)
002011D0: 5348 8D35 80EF FFFF BF01 0000 00BA 0500 SH.5............
002011E0: 0000 E889 0000 0048 8D35 6FEF FFFF BF01 .......H.5o.....
002011F0: 0000 00BA 3600 0000 E873 0000 0048 8D35 ....6....s...H.5
00201200: 8FEF FFFF BF01 0000 00BA 0400 0000 E85D ...............]
00201210: 0000 0048 8D35 7DEF FFFF BF01 0000 00BA ...H.5}.........
00201220: 0100 0000 E847 0000 0048 BF00 0000 0000 .....G...H......
00201230: 00E0 3FE8 2800 0000 E853 0000 0048 BB00 ..?.(....S...H..
00201240: 0000 0000 00F0 3F66 0F1F 8400 0000 0000 ......?f........
00201250: 4889 DFE8 0800 0000 EBF6 CCCC CCCC CCCC H...............
00201260: 50B8 0B00 0000 CD80 58C3 CCCC CCCC CCCC P.......X.......
00201270: 50B8 0400 0000 CD80 4889 C148 F7D1 48C1 P.......H..H..H.
00201280: E93F 4889 C248 89C8 59C3 CCCC CCCC CCCC .?H..H..Y.......
00201290: 50B8 0A00 0000 BFAD DE00 00CD 8058 C3   P............X.

.comment (addr: 0x0, size: 19, align: 1)
00000000: 4C69 6E6B 6572 3A20 4C4C 4420 3136 2E30 Linker: LLD 16.0
00000010: 2E32 00                                 .2.

.shstrtab (addr: 0x0, size: 58, align: 1)
00000000: 002E 7368 7374 7274 6162 002E 726F 6461 ..shstrtab..roda
00000010: 7461 002E 6568 5F66 7261 6D65 5F68 6472 ta..eh_frame_hdr
00000020: 002E 6568 5F66 7261 6D65 002E 7465 7874 ..eh_frame..text
00000030: 002E 636F 6D6D 656E 7400                ..comment.
```