### PR TITLE
Add hash command

### DIFF
--- a/src/usr/hash.rs
+++ b/src/usr/hash.rs
@@ -1,0 +1,83 @@
+use crate::api;
+use crate::api::console::Style;
+use crate::api::process::ExitCode;
+use crate::api::syscall;
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::str;
+use sha2::{Digest, Sha256};
+
+pub fn main(args: &[&str]) -> Result<(), ExitCode> {
+    let mut i = 1;
+    let n = args.len();
+    let mut paths = Vec::new();
+    let mut full = false;
+    while i < n {
+        match args[i] {
+            "-h" | "--help" => {
+                help();
+                return Ok(());
+            }
+            "-f" | "--full" => {
+                full = true;
+            }
+            arg => {
+                if arg.starts_with('-') {
+                    error!("Unknown option '{}'", arg);
+                    return Err(ExitCode::UsageError);
+                }
+                paths.push(arg);
+            }
+        }
+        i += 1;
+    }
+
+    paths.sort();
+    for path in paths {
+        if let Err(code) = print_hash(path, full) {
+            return Err(code);
+        }
+    }
+    Ok(())
+}
+
+pub fn print_hash(path: &str, full: bool) -> Result<(), ExitCode> {
+    let n = if full { 32 } else { 16 };
+    if let Some(info) = syscall::info(path) {
+        if info.is_file() {
+            if let Ok(bytes) = api::fs::read_to_bytes(path) {
+                let mut hasher = Sha256::new();
+                hasher.update(bytes);
+                let res = hasher.finalize();
+                let hex = res.iter().map(|byte|
+                    format!("{:02X}", byte)
+                ).take(n).collect::<Vec<String>>().join("");
+                let pink = Style::color("Pink");
+                let reset = Style::reset();
+                println!("{}{}{} {}", pink, hex, reset, path);
+                Ok(())
+            } else {
+                error!("Could not read '{}'", path);
+                Err(ExitCode::Failure)
+            }
+        } else {
+            error!("Could not read '{}'", path);
+            Err(ExitCode::Failure)
+        }
+    } else {
+        error!("Could not find file '{}'", path);
+        Err(ExitCode::Failure)
+    }
+}
+
+fn help() {
+    let csi_option = Style::color("LightCyan");
+    let csi_title = Style::color("Yellow");
+    let csi_reset = Style::reset();
+    println!("{}Usage:{} hash {}<file>{}", csi_title, csi_reset, csi_option, csi_reset);
+    println!();
+    println!("{}Options:{}", csi_title, csi_reset);
+    println!("  {0}-f{1}, {0}--full{1}     Show full hash", csi_option, csi_reset);
+}

--- a/src/usr/mod.rs
+++ b/src/usr/mod.rs
@@ -11,6 +11,7 @@ pub mod editor;
 pub mod elf;
 pub mod env;
 pub mod find;
+pub mod hash;
 pub mod help;
 pub mod hex;
 pub mod host;

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -14,11 +14,11 @@ use alloc::vec::Vec;
 use alloc::string::{String, ToString};
 
 // TODO: Scan /bin
-const AUTOCOMPLETE_COMMANDS: [&str; 35] = [
+const AUTOCOMPLETE_COMMANDS: [&str; 36] = [
     "2048", "base64", "calc", "copy", "date", "delete", "dhcp", "disk", "edit", "elf", "env",
-    "goto", "help", "hex", "host", "http", "httpd", "install", "keyboard", "life", "lisp",
-    "list", "memory", "move", "net", "pci", "quit", "read", "shell", "socket", "tcp",
-    "time", "user", "vga", "write"
+    "goto", "hash", "help", "hex", "host", "http", "httpd", "install", "keyboard", "life", "lisp",
+    "list", "memory", "move", "net", "pci", "quit", "read", "shell", "socket", "tcp", "time",
+    "user", "vga", "write"
 ];
 
 struct Config {
@@ -454,6 +454,7 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
         "env"      => usr::env::main(&args),
         "find"     => usr::find::main(&args),
         "goto"     => cmd_change_dir(&args, config), // TODO: Remove this
+        "hash"     => usr::hash::main(&args),
         "help"     => usr::help::main(&args),
         "hex"      => usr::hex::main(&args),
         "host"     => usr::host::main(&args),

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -142,10 +142,10 @@ fn glob_to_regex(pattern: &str) -> String {
 fn glob(arg: &str) -> Vec<String> {
     let mut matches = Vec::new();
     if is_globbing(arg) {
-        let (dir, pattern) = if arg.contains('/') {
-            (fs::dirname(arg).to_string(), fs::filename(arg).to_string())
+        let (dir, pattern, show_dir) = if arg.contains('/') {
+            (fs::dirname(arg).to_string(), fs::filename(arg).to_string(), true)
         } else {
-            (sys::process::dir(), arg.to_string())
+            (sys::process::dir(), arg.to_string(), false)
         };
 
         let re = Regex::new(&glob_to_regex(&pattern));
@@ -155,7 +155,11 @@ fn glob(arg: &str) -> Vec<String> {
             for file in files {
                 let name = file.name();
                 if re.is_match(&name) {
-                    matches.push(format!("{}{}{}", dir, sep, name));
+                    if show_dir {
+                        matches.push(format!("{}{}{}", dir, sep, name));
+                    } else {
+                        matches.push(name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add a `hash` command to compute the SHA256 digest of a file.

By default it'll only show half of the digest (same width as MD5) because the VGA screen is only 80 chars long.

```
/tmp
> hash /tmp/lisp/*.lsp
CC96B368B747E0C1988D96BFE4DF6527 /tmp/lisp/colors.lsp
5BA4E29B643AFE102D136786D1148FB4 /tmp/lisp/factorial.lsp
61E20049870E053CA52AC878ED063C9C /tmp/lisp/fetch.lsp
9C075B38308B785539D7052100250663 /tmp/lisp/fibonacci.lsp
4337A80396D3E6CCA664D61A95361E67 /tmp/lisp/geotime.lsp
9C0DD640E8DC34C04BA925906F71D911 /tmp/lisp/ntp.lsp
B9C1239245B00DD89CEA35334511CC2C /tmp/lisp/pi.lsp
589CBBC31EB7B2C521A4D66CA4506201 /tmp/lisp/sum.lsp

/tmp
> hash lisp/*.lsp
CC96B368B747E0C1988D96BFE4DF6527 lisp/colors.lsp
5BA4E29B643AFE102D136786D1148FB4 lisp/factorial.lsp
61E20049870E053CA52AC878ED063C9C lisp/fetch.lsp
9C075B38308B785539D7052100250663 lisp/fibonacci.lsp
4337A80396D3E6CCA664D61A95361E67 lisp/geotime.lsp
9C0DD640E8DC34C04BA925906F71D911 lisp/ntp.lsp
B9C1239245B00DD89CEA35334511CC2C lisp/pi.lsp
589CBBC31EB7B2C521A4D66CA4506201 lisp/sum.lsp

/tmp
> hash *.txt
6DFD0C65EE6CAE71124406A3126D10BD alice.txt
E04EFE3389B3A36BE5FF6D80A486BBA7 machines.txt

/tmp
> hash *.txt --full
6DFD0C65EE6CAE71124406A3126D10BD4D563858A51C5404D9E82194390D8767 alice.txt
E04EFE3389B3A36BE5FF6D80A486BBA76681686A2956A59A7CEB5440439DD548 machines.txt
```