### PR TITLE
Add number->string function to lisp

### DIFF
--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -47,7 +47,7 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 ### Primitive Operators
 - `type`, `number/type` (aliased to `num/type`), `parse`
 - `string` (aliased to `str`)
-- `string->number` (aliased to to `str->num`)
+- `string->number` and `number->string` (aliased to `str->num` and `num->str`)
 - `string->binary` and `binary->string` (aliased to `str->bin` and `bin->str`)
 - `number->binary` and `binary->number` (aliased to `num->bin` and `bin->num`)
 - `regex/find`
@@ -216,3 +216,4 @@ language and reading from the filesystem.
 - Add `empty?`, `reject`, `put`, `push`, and `host` functions`
 - Add `dict` type
 - Use `/` instead of `.` as namespace separator
+- Add `number->string` (aliased to `num->str`) with an optional radix argument

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -146,6 +146,7 @@
 (var str->num string->number)
 (var str->bin string->binary)
 (var num->bin number->binary)
+(var num->str number->string)
 (var bin->str binary->string)
 (var bin->num binary->number)
 (var bool? boolean?)

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -50,6 +50,7 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("binary->string".to_string(),     Exp::Primitive(primitive::lisp_binary_string));
     data.insert("binary->number".to_string(),     Exp::Primitive(primitive::lisp_binary_number));
     data.insert("number->binary".to_string(),     Exp::Primitive(primitive::lisp_number_binary));
+    data.insert("number->string".to_string(),     Exp::Primitive(primitive::lisp_number_string));
     data.insert("string->number".to_string(),     Exp::Primitive(primitive::lisp_string_number));
     data.insert("type".to_string(),               Exp::Primitive(primitive::lisp_type));
     data.insert("parse".to_string(),              Exp::Primitive(primitive::lisp_parse));

--- a/src/usr/lisp/number.rs
+++ b/src/usr/lisp/number.rs
@@ -310,6 +310,7 @@ macro_rules! try_from_number {
 }
 
 try_from_number!(usize, to_usize);
+try_from_number!(u32, to_u32);
 try_from_number!(u8, to_u8);
 
 impl fmt::Display for Number {

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -66,7 +66,7 @@ of the Shell.</p>
     <ul>
     <li><code>type</code>, <code>number/type</code> (aliased to <code>num/type</code>), <code>parse</code></li>
     <li><code>string</code> (aliased to <code>str</code>)</li>
-    <li><code>string-&gt;number</code> (aliased to to <code>str-&gt;num</code>)</li>
+    <li><code>string-&gt;number</code> and <code>number-&gt;string</code> (aliased to <code>str-&gt;num</code> and <code>num-&gt;str</code>)</li>
     <li><code>string-&gt;binary</code> and <code>binary-&gt;string</code> (aliased to <code>str-&gt;bin</code> and <code>bin-&gt;str</code>)</li>
     <li><code>number-&gt;binary</code> and <code>binary-&gt;number</code> (aliased to <code>num-&gt;bin</code> and <code>bin-&gt;num</code>)</li>
     <li><code>regex/find</code></li>
@@ -262,6 +262,7 @@ language and reading from the filesystem.</p>
     <li>Add <code>empty?</code>, <code>reject</code>, <code>put</code>, <code>push</code>, and <code>host</code> functions`</li>
     <li>Add <code>dict</code> type</li>
     <li>Use <code>/</code> instead of <code>.</code> as namespace separator</li>
+    <li>Add <code>number-&gt;string</code> (aliased to <code>num-&gt;str</code>) with an optional radix argument</li>
     </ul>
   <footer><p><a href="/">MOROS</a></footer>
   </body>


### PR DESCRIPTION
Add a function in lisp to convert a number to a string, with an optional radix argument: `(number->string number radix)`