### PR TITLE
Add ANSI OSC color palette support

### DIFF
--- a/dsk/ini/palettes/gruvbox-dark.sh
+++ b/dsk/ini/palettes/gruvbox-dark.sh
@@ -1,0 +1,16 @@
+print "\e]P0282828\e[1A" # Black
+print "\e]P1458588\e[1A" # Blue
+print "\e]P298971A\e[1A" # Green
+print "\e]P3689D6A\e[1A" # Cyan
+print "\e]P4CC241D\e[1A" # Red
+print "\e]P5B16286\e[1A" # Magenta
+print "\e]P6D79921\e[1A" # Brown (Dark Yellow)
+print "\e]P7EBDBB2\e[1A" # Light Gray
+print "\e]P8A89984\e[1A" # Dark Gray (Gray)
+print "\e]P983a598\e[1A" # Light Blue
+print "\e]PAB8BB26\e[1A" # Light Green
+print "\e]PB8EC07C\e[1A" # Light Cyan
+print "\e]PCFB4934\e[1A" # Light Red
+print "\e]PDD3869B\e[1A" # Pink (Light Magenta)
+print "\e]PEFABD2F\e[1A" # Yellow (Light Yellow)
+print "\e]PFFBF1C7\e[1A" # White

--- a/dsk/ini/palettes/gruvbox-light.sh
+++ b/dsk/ini/palettes/gruvbox-light.sh
@@ -1,0 +1,16 @@
+print "\e]P0FBF1C7\e[1A" # Black
+print "\e]P1458588\e[1A" # Blue
+print "\e]P298971A\e[1A" # Green
+print "\e]P3689D6A\e[1A" # Cyan
+print "\e]P4CC241D\e[1A" # Red
+print "\e]P5B16286\e[1A" # Magenta
+print "\e]P6D79921\e[1A" # Brown (Dark Yellow)
+print "\e]P73C3836\e[1A" # Light Gray
+print "\e]P87C6F64\e[1A" # Dark Gray (Gray)
+print "\e]P9076678\e[1A" # Light Blue
+print "\e]PA79740E\e[1A" # Light Green
+print "\e]PB427B58\e[1A" # Light Cyan
+print "\e]PC9D0006\e[1A" # Light Red
+print "\e]PD8F3F71\e[1A" # Pink (Light Magenta)
+print "\e]PEB57614\e[1A" # Yellow (Light Yellow)
+print "\e]PF282828\e[1A" # White

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -66,6 +66,15 @@ macro_rules! error {
     });
 }
 
+#[macro_export]
+macro_rules! warning {
+    ($($arg:tt)*) => ({
+        let csi_color = $crate::api::console::Style::color("Yellow");
+        let csi_reset = $crate::api::console::Style::reset();
+        eprintln!("{}Warning:{} {}", csi_color, csi_reset, format_args!($($arg)*));
+    });
+}
+
 pub mod allocator;
 pub mod clock;
 pub mod console;

--- a/src/api/vga/palette.rs
+++ b/src/api/vga/palette.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
+// TODO: Move this to kernel after removing the `vga set palette` command
 pub struct Palette {
     pub colors: [(u8, u8, u8); 16]
 }
@@ -30,6 +31,7 @@ impl Palette {
     }
 }
 
+// TODO: Remove this
 pub fn from_csv(s: &str) -> Result<Palette, ()> {
     let colors: Vec<_> = s.split('\n').filter_map(|line| {
         let line = line.split('#').next().unwrap(); // Remove comments

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -410,6 +410,19 @@ impl Perform for Writer {
             _ => {},
         }
     }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], _: bool) {
+        if params.len() == 1 {
+            let s = String::from_utf8_lossy(params[0]);
+            if s.len() == 8 && &s[0..1] == "P" {
+                let i = usize::from_str_radix(&s[1..2], 16).unwrap_or(0);
+                let r = u8::from_str_radix(&s[2..4], 16).unwrap_or(0);
+                let g = u8::from_str_radix(&s[4..6], 16).unwrap_or(0);
+                let b = u8::from_str_radix(&s[6..8], 16).unwrap_or(0);
+                self.set_palette(i, r, g, b);
+            }
+        }
+    }
 }
 
 impl fmt::Write for Writer {

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -414,12 +414,21 @@ impl Perform for Writer {
     fn osc_dispatch(&mut self, params: &[&[u8]], _: bool) {
         if params.len() == 1 {
             let s = String::from_utf8_lossy(params[0]);
-            if s.len() == 8 && &s[0..1] == "P" {
-                let i = usize::from_str_radix(&s[1..2], 16).unwrap_or(0);
-                let r = u8::from_str_radix(&s[2..4], 16).unwrap_or(0);
-                let g = u8::from_str_radix(&s[4..6], 16).unwrap_or(0);
-                let b = u8::from_str_radix(&s[6..8], 16).unwrap_or(0);
-                self.set_palette(i, r, g, b);
+            match s.chars().next() {
+                Some('P') if s.len() == 8 => {
+                    let i = usize::from_str_radix(&s[1..2], 16).unwrap_or(0);
+                    let r = u8::from_str_radix(&s[2..4], 16).unwrap_or(0);
+                    let g = u8::from_str_radix(&s[4..6], 16).unwrap_or(0);
+                    let b = u8::from_str_radix(&s[6..8], 16).unwrap_or(0);
+                    self.set_palette(i, r, g, b);
+                }
+                Some('R') => {
+                    let palette = Palette::default();
+                    for (i, (r, g, b)) in palette.colors.iter().enumerate() {
+                        self.set_palette(i, *r, *g, *b);
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -479,6 +488,7 @@ pub fn set_font(font: &Font) {
     })
 }
 
+// TODO: Remove this
 pub fn set_palette(palette: Palette) {
     interrupts::without_interrupts(|| {
         for (i, (r, g, b)) in palette.colors.iter().enumerate() {

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -5,6 +5,7 @@ use crate::sys;
 
 use alloc::string::String;
 use bit_field::BitField;
+use core::cmp;
 use core::fmt;
 use core::fmt::Write;
 use lazy_static::lazy_static;
@@ -302,36 +303,32 @@ impl Perform for Writer {
                 for param in params.iter() {
                     n = param[0] as usize;
                 }
-                // TODO: Don't go past edge
-                self.writer[1] -= n;
-                self.cursor[1] -= n;
+                self.writer[1] = self.writer[1].saturating_sub(n);
+                self.cursor[1] = self.cursor[1].saturating_sub(n);
             },
             'B' => { // Cursor Down
                 let mut n = 1;
                 for param in params.iter() {
                     n = param[0] as usize;
                 }
-                // TODO: Don't go past edge
-                self.writer[1] += n;
-                self.cursor[1] += n;
+                self.writer[1] = cmp::min(self.writer[1] + n, BUFFER_HEIGHT - 1);
+                self.cursor[1] = cmp::min(self.cursor[1] + n, BUFFER_HEIGHT - 1);
             },
             'C' => { // Cursor Forward
                 let mut n = 1;
                 for param in params.iter() {
                     n = param[0] as usize;
                 }
-                // TODO: Don't go past edge
-                self.writer[0] += n;
-                self.cursor[0] += n;
+                self.writer[0] = cmp::min(self.writer[0] + n, BUFFER_WIDTH - 1);
+                self.cursor[0] = cmp::min(self.cursor[0] + n, BUFFER_WIDTH - 1);
             },
             'D' => { // Cursor Backward
                 let mut n = 1;
                 for param in params.iter() {
                     n = param[0] as usize;
                 }
-                // TODO: Don't go past edge
-                self.writer[0] -= n;
-                self.cursor[0] -= n;
+                self.writer[0] = self.writer[0].saturating_sub(n);
+                self.cursor[0] = self.cursor[0].saturating_sub(n);
             },
             'G' => { // Cursor Horizontal Absolute
                 let (_, y) = self.cursor_position();

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -46,8 +46,8 @@ pub fn copy_files(verbose: bool) {
     copy_file("/ini/version.txt", include_bytes!("../../dsk/ini/version.txt"), verbose);
 
     create_dir("/ini/palettes", verbose);
-    copy_file("/ini/palettes/gruvbox-dark.csv", include_bytes!("../../dsk/ini/palettes/gruvbox-dark.csv"), verbose);
-    copy_file("/ini/palettes/gruvbox-light.csv", include_bytes!("../../dsk/ini/palettes/gruvbox-light.csv"), verbose);
+    copy_file("/ini/palettes/gruvbox-dark.sh", include_bytes!("../../dsk/ini/palettes/gruvbox-dark.sh"), verbose);
+    copy_file("/ini/palettes/gruvbox-light.sh", include_bytes!("../../dsk/ini/palettes/gruvbox-light.sh"), verbose);
 
     create_dir("/ini/fonts", verbose);
     //copy_file("/ini/fonts/lat15-terminus-8x16.psf", include_bytes!("../../dsk/ini/fonts/lat15-terminus-8x16.psf"), verbose);

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -34,12 +34,6 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 if let Ok(csv) = fs::read_to_string(args[3]) {
                     if let Ok(palette) = palette::from_csv(&csv) {
                         sys::vga::set_palette(palette);
-                        // TODO: Instead of calling a kernel function we could
-                        // use the following ANSI OSC command to set a palette:
-                        //     for (i, r, g, b) in palette.colors {
-                        //         print!("\x1b]P{:x}{:x}{:x}{:x}", i, r, g, b);
-                        //     }
-                        // And "ESC]R" to reset a palette.
                         Ok(())
                     } else {
                         error!("Could not parse palette file");

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -30,6 +30,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     Err(ExitCode::Failure)
                 }
             } else if args.len() == 4 && args[2] == "palette" {
+                warning!("Use ANSI OSC palette sequence");
                 if let Ok(csv) = fs::read_to_string(args[3]) {
                     if let Ok(palette) = palette::from_csv(&csv) {
                         sys::vga::set_palette(palette);

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -4,6 +4,7 @@ use crate::api::fs;
 use crate::api::vga::palette;
 use crate::api::process::ExitCode;
 
+// TODO: Remove this command when everything can be done from userspace
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if args.len() == 1 {
         help();


### PR DESCRIPTION
Now that we can print escape sequence from the shell (#558) we can easily add support for the `ESC ] P n rr gg bb` sequence to set a color palette compatible with Linux instead of using a kernel function that is not available from userspace.

For example `print "\e]P0282828"` would change the background color to a dark gray.

We might want to terminate the sequence with `ESC \` to be compatible with ECMA-48.

- [x] Refactor VGA palette code to set the colors one by one
- [x] Add OSC dispatch to handle ANSI color palette sequence
- [x] Add warning macro and deprecate `vga set palette <csv>` command
- [x] Add shell scripts to set the palettes
- [x] Add reset palette sequence

References:
- https://man7.org/linux/man-pages/man4/console_codes.4.html
- https://sw.kovidgoyal.net/kitty/graphics-protocol/