### PR TITLE
Add hashbang support to execute scripts

### DIFF
--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -585,7 +585,7 @@ fn spawn(path: &str, args: &[&str], config: &mut Config) -> Result<(), ExitCode>
         if contents.starts_with("#!") {
             if let Some(line) = contents.lines().next() {
                 let mut new_args = Vec::with_capacity(args.len() + 1);
-                new_args.push(&line[2..]);
+                new_args.push(line[2..].trim());
                 new_args.push(path);
                 new_args.extend(&args[1..]);
                 return dispatch(&new_args, config);


### PR DESCRIPTION
The files starting with `[0x7F, b'E', b'L', b'F']` are identified as ELF binaries and those starting with `[0x7F, b'B', b'I', b'N']` are identified as flat binaries.

With this PR the files starting with a hashbang `[b'#', b'!']` will be identified as scripts by the shell and the interpreter following the shebang will be used to run them with the rest of the command line arguments.

See https://en.wikipedia.org/wiki/Shebang_%28Unix%29