### PR TITLE
Fix random memory issues

### DIFF
--- a/src/sys/acpi.rs
+++ b/src/sys/acpi.rs
@@ -19,8 +19,6 @@ pub fn shutdown() {
     let slp_len = 1 << 13;
 
     log!("ACPI Shutdown\n");
-    let handler = Box::new(MorosAmlHandler);
-    let mut aml = AmlContext::new(handler, DebugVerbosity::None);
     let res = unsafe { AcpiTables::search_for_rsdp_bios(MorosAcpiHandler) };
     match res {
         Ok(acpi) => {
@@ -36,6 +34,8 @@ pub fn shutdown() {
                 let table = unsafe {
                     core::slice::from_raw_parts(ptr , dsdt.length as usize)
                 };
+                let handler = Box::new(MorosAmlHandler);
+                let mut aml = AmlContext::new(handler, DebugVerbosity::None);
                 if aml.parse_table(table).is_ok() {
                     let name = AmlName::from_str("\\_S5").unwrap();
                     let res = aml.namespace.get_by_path(&name);
@@ -45,21 +45,22 @@ pub fn shutdown() {
                         }
                     }
                 } else {
-                    debug!("ACPI Failed to parse AML in DSDT");
+                    debug!("ACPI: Could not parse AML in DSDT");
                     // FIXME: AML parsing works on QEMU and Bochs but not
                     // on VirtualBox at the moment, so we use the following
                     // hardcoded value:
                     slp_typa = (5 & 7) << 10;
                 }
+            } else {
+                debug!("ACPI: Could not find DSDT in BIOS");
             }
         }
         Err(_e) => {
-            debug!("ACPI Could not find RDSP in BIOS\n");
+            debug!("ACPI: Could not find RDSP in BIOS");
         }
     };
 
     let mut port: Port<u16> = Port::new(pm1a_control_block as u16);
-    //debug!("ACPI shutdown");
     unsafe {
         port.write(slp_typa | slp_len);
     }

--- a/src/sys/allocator.rs
+++ b/src/sys/allocator.rs
@@ -83,6 +83,9 @@ pub fn alloc_pages(
                 mapping.flush();
             } else {
                 debug!("Could not map {:?} to {:?}", page, frame);
+                if let Ok(old_frame) = mapper.translate_page(page) {
+                    debug!("Aleardy mapped to {:?}", old_frame);
+                }
                 return Err(());
             }
         } else {

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -7,7 +7,7 @@ use x86_64::structures::gdt::{
 use x86_64::structures::tss::TaskStateSegment;
 use x86_64::VirtAddr;
 
-const STACK_SIZE: usize = 1024 * 8;
+const STACK_SIZE: usize = 1024 * 8 * 16;
 pub const DOUBLE_FAULT_IST: u16 = 0;
 pub const PAGE_FAULT_IST: u16 = 1;
 pub const GENERAL_PROTECTION_FAULT_IST: u16 = 2;

--- a/src/sys/mem.rs
+++ b/src/sys/mem.rs
@@ -57,7 +57,9 @@ pub fn memory_size() -> u64 {
 }
 
 pub fn phys_to_virt(addr: PhysAddr) -> VirtAddr {
-    let phys_mem_offset = unsafe { PHYS_MEM_OFFSET.unwrap() };
+    let phys_mem_offset = unsafe {
+        PHYS_MEM_OFFSET.unwrap()
+    };
     VirtAddr::new(addr.as_u64() + phys_mem_offset)
 }
 


### PR DESCRIPTION
We've had two memory issues for the longest time that happen randomly on some builds depending on the size of the kernel.

The first one is an error when allocating memory from userspace. It happens if the page is already mapped to a frame. This PR is adding a second line to the error message with the frame address causing the issue. In this case we can see that the frame is in the memory used by the kernel at 4MB:

```
~
> hello alice
alice
DEBUG: Could not map Page[4KiB](0x207000) to PhysFrame[4KiB](0x15af000)
DEBUG: Aleardy mapped to PhysFrame[4KiB](0x407000)
Error: Could not allocate address 0x207880
```

The second one was randomly causing a freeze or a reboot during ACPI shutdown after using the `halt` command. It took a few days to understand what was going on. I experimented a lot with the physical mapping of the ACPI handler, and I wrote a tool to print the content of the memory to understand what was being mapped. The tool will be published in another PR.

After using `gdb` a lot with the kernel compiled in debug mode I finally managed to get to a point where I could move the exception further along the code as I increased the stack size until we could map everything and finish the shutdown. The stack needed to be increased 16 times! But now I can't reproduce the issue anymore.