### PR TITLE
Add memory dump command

### DIFF
--- a/src/usr/disk.rs
+++ b/src/usr/disk.rs
@@ -181,13 +181,15 @@ fn help() {
     println!();
     println!("{}Commands:{}", csi_title, csi_reset);
     println!(
-        "  {}list{}             List detected disks",
-        csi_option, csi_reset
+        "  {}erase <path>{}    Erase disk", csi_option, csi_reset
     );
     println!(
-        "  {}usage{}            List disk usage",
-        csi_option, csi_reset
+        "  {}format <path>{}   Format disk", csi_option, csi_reset
     );
-    println!("  {}format <path>{}    Format disk", csi_option, csi_reset);
-    println!("  {}erase <path>{}     Erase disk", csi_option, csi_reset);
+    println!(
+        "  {}list{}            List detected disks", csi_option, csi_reset
+    );
+    println!(
+        "  {}usage{}           List disk usage", csi_option, csi_reset
+    );
 }

--- a/src/usr/list.rs
+++ b/src/usr/list.rs
@@ -113,19 +113,23 @@ fn help() -> Result<(), ExitCode> {
     println!();
     println!("{}Options:{}", csi_title, csi_reset);
     println!(
-        "  {0}-a{1}, {0}--all{1}     Show dot files",
+        "  {0}-b{1}, {0}--binary-size{1}   Use binary size",
         csi_option, csi_reset
     );
     println!(
-        "  {0}-n{1}, {0}--name{1}    Sort by name",
+        "  {0}-a{1}, {0}--all{1}           Show dot files",
         csi_option, csi_reset
     );
     println!(
-        "  {0}-s{1}, {0}--size{1}    Sort by size",
+        "  {0}-n{1}, {0}--name{1}          Sort by name",
         csi_option, csi_reset
     );
     println!(
-        "  {0}-t{1}, {0}--time{1}    Sort by time",
+        "  {0}-s{1}, {0}--size{1}          Sort by size",
+        csi_option, csi_reset
+    );
+    println!(
+        "  {0}-t{1}, {0}--time{1}          Sort by time",
         csi_option, csi_reset
     );
     Ok(())


### PR DESCRIPTION
The `memory dump` command is useful when debugging the kernel, for example I used it to check the content of the ACPI structures in memory.