### PR TITLE
Add time synchronisation with NTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ user-rust:
 		cargo rustc --no-default-features --features userspace --release --bin {}
 	basename -s .rs src/bin/*.rs | xargs -I {} \
 		cp target/x86_64-moros/release/{} dsk/bin/{}
-	strip dsk/bin/*
+	basename -s .rs src/bin/*.rs | xargs -I {} \
+		strip dsk/bin/{}
 
 bin = target/x86_64-moros/$(mode)/bootimage-moros.bin
 img = disk.img

--- a/dsk/bin/ntp
+++ b/dsk/bin/ntp
@@ -1,6 +1,14 @@
+#!lisp
+
 (load "/lib/lisp/core.lsp")
 
-(var addr (or (host (head args)) (head args)))
+(var config "/ini/ntp")
+(var default-server "time.cloudflare.com")
+
+(var server (if (not (nil? args))
+  (first args)
+  (if (file/exists? config) (str/trim (read config)) default-server)))
+(var addr (or (host server) server))
 (var port 123)
 (var socket (socket/connect "udp" addr port))
 
@@ -10,4 +18,4 @@
 
 (var buf (slice res 40 4))
 (var time (- (bin->num (concat '(0 0 0 0) buf) "int") 2208988800))
-(print time)
+(print (date time))

--- a/dsk/bin/ntp
+++ b/dsk/bin/ntp
@@ -12,7 +12,7 @@
 (var port 123)
 (var socket (socket/connect "udp" addr port))
 
-(var req (map (fun (i) (if (eq? i 0) 0x33 0)) (range 0 48)))
+(var req (map (fun (i) (if (eq? i 0) 0x23 0)) (range 0 48)))
 (file/write socket req)
 (var res (file/read socket 48))
 

--- a/src/api/time.rs
+++ b/src/api/time.rs
@@ -16,7 +16,11 @@ pub fn now_utc() -> OffsetDateTime {
 }
 
 pub fn from_timestamp(ts: i64) -> OffsetDateTime {
-    OffsetDateTime::from_unix_timestamp(ts).to_offset(offset())
+    from_timestamp_utc(ts).to_offset(offset())
+}
+
+pub fn from_timestamp_utc(ts: i64) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp(ts)
 }
 
 fn offset() -> UtcOffset {

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -24,6 +24,7 @@ pub fn copy_files(verbose: bool) {
     //copy_file("/bin/exec", include_bytes!("../../dsk/bin/exec"), verbose);
     copy_file("/bin/halt", include_bytes!("../../dsk/bin/halt"), verbose);
     //copy_file("/bin/hello", include_bytes!("../../dsk/bin/hello"), verbose);
+    copy_file("/bin/ntp", include_bytes!("../../dsk/bin/ntp"), verbose);
     copy_file("/bin/print", include_bytes!("../../dsk/bin/print"), verbose);
     copy_file(
         "/bin/reboot",
@@ -166,11 +167,6 @@ pub fn copy_files(verbose: bool) {
     copy_file(
         "/tmp/lisp/geotime.lsp",
         include_bytes!("../../dsk/tmp/lisp/geotime.lsp"),
-        verbose,
-    );
-    copy_file(
-        "/tmp/lisp/ntp.lsp",
-        include_bytes!("../../dsk/tmp/lisp/ntp.lsp"),
         verbose,
     );
     copy_file(

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -200,6 +200,10 @@ pub fn default_env() -> Rc<RefCell<Env>> {
         Exp::Primitive(primitive::lisp_file_size),
     );
     data.insert(
+        "file/exists?".to_string(),
+        Exp::Primitive(primitive::lisp_file_exists),
+    );
+    data.insert(
         "file/open".to_string(),
         Exp::Primitive(primitive::lisp_file_open),
     );

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -243,6 +243,10 @@ pub fn default_env() -> Rc<RefCell<Env>> {
         "put".to_string(),
         Exp::Primitive(primitive::lisp_put),
     );
+    data.insert(
+        "date".to_string(),
+        Exp::Primitive(primitive::lisp_date),
+    );
 
     // Setup autocompletion
     *FUNCTIONS.lock() = data.keys().cloned().

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -3,6 +3,7 @@ use super::{bytes, numbers, strings};
 use super::{float, number, string};
 use super::{Err, Exp, Number};
 
+use crate::api;
 use crate::api::regex::Regex;
 use crate::api::syscall;
 use crate::sys::fs::OpenFlag;
@@ -653,4 +654,12 @@ pub fn lisp_host(args: &[Exp]) -> Result<Exp, Err> {
         Ok(addr) => Ok(Exp::Str(format!("{}", addr))),
         Err(_) => Ok(Exp::List(vec![])),
     }
+}
+
+pub fn lisp_date(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    let ts = usize::try_from(number(&args[0])?)? as i64;
+    let fmt = api::clock::DATE_TIME;
+    let date = api::time::from_timestamp_utc(ts).format(fmt);
+    Ok(Exp::Str(date))
 }

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -469,6 +469,12 @@ pub fn lisp_file_size(args: &[Exp]) -> Result<Exp, Err> {
     }
 }
 
+pub fn lisp_file_exists(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    let path = string(&args[0])?;
+    Ok(Exp::Bool(syscall::info(&path).is_some()))
+}
+
 pub fn lisp_file_open(args: &[Exp]) -> Result<Exp, Err> {
     ensure_length_eq!(args, 2);
     let path = string(&args[0])?;


### PR DESCRIPTION
A new `ntp` program will now be available to get the time from NTP servers and update the RTC of the computer. This is the first program written in Lisp using the new hashbang system for scripts (#570).

![ntp](https://github.com/vinc/moros/assets/305625/4b6ba95f-d600-4cdd-aff0-072a21f98b97)