### PR TITLE
Add timeout to socket accept

### DIFF
--- a/doc/editor.md
+++ b/doc/editor.md
@@ -10,6 +10,6 @@
 - `CTRL` + `E` to move cursor to enf of line
 - `CTRL` + `T` to move cursor to begining of file
 - `CTRL` + `B` to move cursor to enf of file
-- `CTRL` + `d` to cut (delete) a line
-- `CTRL` + `y` to copy (yank) a line
-- `CTRL` + `p` to paste (put) a line
+- `CTRL` + `D` to cut (delete) a line
+- `CTRL` + `Y` to copy (yank) a line
+- `CTRL` + `P` to paste (put) a line

--- a/src/sys/net/socket/tcp.rs
+++ b/src/sys/net/socket/tcp.rs
@@ -118,8 +118,13 @@ impl TcpSocket {
     }
 
     pub fn accept(&mut self) -> Result<IpAddress, ()> {
+        let timeout = 5.0;
+        let started = sys::clock::realtime();
         if let Some((ref mut iface, ref mut device)) = *sys::net::NET.lock() {
             loop {
+                if sys::clock::realtime() - started > timeout {
+                    return Err(());
+                }
                 let mut sockets = SOCKETS.lock();
                 iface.poll(sys::net::time(), device, &mut sockets);
                 let socket = sockets.get_mut::<tcp::Socket>(self.handle);


### PR DESCRIPTION
This will avoid blocking indefinitely while waiting for a connection.

We will now be able to use `CTRL` + `C` when running `socket -l 80` to exit the program.