### PR TITLE
Update x86_64 crate from 0.14.12 to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
  "time",
  "uart_16550",
  "vte",
- "x86_64",
+ "x86_64 0.15.0",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb844b5b01db1e0b17938685738f113bfc903846f18932b378bc0eabfa40e194"
 dependencies = [
- "x86_64",
+ "x86_64 0.14.12",
 ]
 
 [[package]]
@@ -799,6 +799,18 @@ name = "x86_64"
 version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96cb6fd45bfeab6a5055c5bffdb08768bd0c069f1d946debe585bbb380a7c062"
+dependencies = [
+ "bit_field",
+ "bitflags 2.4.1",
+ "rustversion",
+ "volatile",
+]
+
+[[package]]
+name = "x86_64"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9b58dbbd61248db1d7d5b7068fbe91b042e889361fe79fb4fd16a12daa66d3"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ spin = "0.9.8"
 time = { version = "0.2.27", default-features = false }
 uart_16550 = "0.3.0"
 vte = "0.13.0"
-x86_64 = "0.14.12"
+x86_64 = "0.15.0"
 
 [package.metadata.bootloader]
 physical-memory-offset = "0xFFFF800000000000"

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -39,11 +39,11 @@ lazy_static! {
     pub static ref GDT: (GlobalDescriptorTable, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
 
-        let tss = gdt.add_entry(Descriptor::tss_segment(&TSS));
-        let code = gdt.add_entry(Descriptor::kernel_code_segment());
-        let data = gdt.add_entry(Descriptor::kernel_data_segment());
-        let user_code = gdt.add_entry(Descriptor::user_code_segment());
-        let user_data = gdt.add_entry(Descriptor::user_data_segment());
+        let tss = gdt.append(Descriptor::tss_segment(&TSS));
+        let code = gdt.append(Descriptor::kernel_code_segment());
+        let data = gdt.append(Descriptor::kernel_data_segment());
+        let user_code = gdt.append(Descriptor::user_code_segment());
+        let user_data = gdt.append(Descriptor::user_data_segment());
 
         (
             gdt,

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -17,19 +17,19 @@ lazy_static! {
         let mut tss = TaskStateSegment::new();
         tss.privilege_stack_table[0] = {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE
+            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE as u64
         };
         tss.interrupt_stack_table[DOUBLE_FAULT_IST as usize] = {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE
+            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE as u64
         };
         tss.interrupt_stack_table[PAGE_FAULT_IST as usize] = {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE
+            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE as u64
         };
         tss.interrupt_stack_table[GENERAL_PROTECTION_FAULT_IST as usize] = {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE
+            VirtAddr::from_ptr(unsafe { &STACK }) + STACK_SIZE as u64
         };
         tss
     };

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -55,22 +55,22 @@ lazy_static! {
                 set_handler_fn(core::mem::transmute(f)).
                 set_privilege_level(x86_64::PrivilegeLevel::Ring3);
         }
-        idt[interrupt_index(0) as usize].set_handler_fn(irq0_handler);
-        idt[interrupt_index(1) as usize].set_handler_fn(irq1_handler);
-        idt[interrupt_index(2) as usize].set_handler_fn(irq2_handler);
-        idt[interrupt_index(3) as usize].set_handler_fn(irq3_handler);
-        idt[interrupt_index(4) as usize].set_handler_fn(irq4_handler);
-        idt[interrupt_index(5) as usize].set_handler_fn(irq5_handler);
-        idt[interrupt_index(6) as usize].set_handler_fn(irq6_handler);
-        idt[interrupt_index(7) as usize].set_handler_fn(irq7_handler);
-        idt[interrupt_index(8) as usize].set_handler_fn(irq8_handler);
-        idt[interrupt_index(9) as usize].set_handler_fn(irq9_handler);
-        idt[interrupt_index(10) as usize].set_handler_fn(irq10_handler);
-        idt[interrupt_index(11) as usize].set_handler_fn(irq11_handler);
-        idt[interrupt_index(12) as usize].set_handler_fn(irq12_handler);
-        idt[interrupt_index(13) as usize].set_handler_fn(irq13_handler);
-        idt[interrupt_index(14) as usize].set_handler_fn(irq14_handler);
-        idt[interrupt_index(15) as usize].set_handler_fn(irq15_handler);
+        idt[interrupt_index(0)].set_handler_fn(irq0_handler);
+        idt[interrupt_index(1)].set_handler_fn(irq1_handler);
+        idt[interrupt_index(2)].set_handler_fn(irq2_handler);
+        idt[interrupt_index(3)].set_handler_fn(irq3_handler);
+        idt[interrupt_index(4)].set_handler_fn(irq4_handler);
+        idt[interrupt_index(5)].set_handler_fn(irq5_handler);
+        idt[interrupt_index(6)].set_handler_fn(irq6_handler);
+        idt[interrupt_index(7)].set_handler_fn(irq7_handler);
+        idt[interrupt_index(8)].set_handler_fn(irq8_handler);
+        idt[interrupt_index(9)].set_handler_fn(irq9_handler);
+        idt[interrupt_index(10)].set_handler_fn(irq10_handler);
+        idt[interrupt_index(11)].set_handler_fn(irq11_handler);
+        idt[interrupt_index(12)].set_handler_fn(irq12_handler);
+        idt[interrupt_index(13)].set_handler_fn(irq13_handler);
+        idt[interrupt_index(14)].set_handler_fn(irq14_handler);
+        idt[interrupt_index(15)].set_handler_fn(irq15_handler);
         idt
     };
 }

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -127,7 +127,7 @@ extern "x86-interrupt" fn page_fault_handler(
     error_code: PageFaultErrorCode,
 ) {
     //debug!("EXCEPTION: PAGE FAULT ({:?})", error_code);
-    let addr = Cr2::read().as_u64();
+    let addr = Cr2::read().unwrap().as_u64();
 
     let page_table = unsafe { sys::process::page_table() };
     let phys_mem_offset = unsafe { sys::mem::PHYS_MEM_OFFSET.unwrap() };


### PR DESCRIPTION
A few things needed to be changed for the latest release of the `x86_64` crate: https://github.com/rust-osdev/x86_64/pull/463

- Some types needed to be changed from `usize` to `u8` or `u64`
- GDT method `add_entry` was changed to `append` (https://github.com/rust-osdev/x86_64/pull/380)
- InterruptStackFrameValue cannot be constructed anymore so we need to wrap it with `Option` and use `None` when creating empty processes (https://github.com/rust-osdev/x86_64/pull/263)