### PR TITLE
Fix shell autocomplete

### DIFF
--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -63,7 +63,7 @@ fn shell_completer(line: &str) -> Vec<String> {
     let i = args.len() - 1;
 
     // Autocomplete command
-    if i == 2 && !args[i].starts_with('/') && !args[i].starts_with('~') {
+    if i == 0 && !args[i].starts_with('/') && !args[i].starts_with('~') {
         for cmd in autocomplete_commands() {
             if let Some(entry) = cmd.strip_prefix(&args[i]) {
                 entries.push(entry.into());


### PR DESCRIPTION
Fix an off by one error preventing command autocompletion that was introduced in #567 (here: https://github.com/vinc/moros/pull/567/files#diff-98e43632da19520dedbe64ff5262b2788e83282eb4d1188ea46977a31a74bd29R66)