### PR TITLE
Adds a helpful println when MFS is not mounted

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn user_boot() {
             println!("Could not find '{}'", script);
         } else {
             println!("MFS is not mounted to '/'");
+            println!("Please run 'install' to setup moros");
         }
         println!("Running console in diskless mode");
         usr::shell::main(&["shell"]).ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,6 @@ fn user_boot() {
         if sys::fs::is_mounted() {
             println!("Could not find '{}'", script);
         } else {
-            println!("MFS is not mounted to '/'");
             println!("MFS not found, run 'install' to setup the system");
         }
         println!("Running console in diskless mode");

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn user_boot() {
             println!("Could not find '{}'", script);
         } else {
             println!("MFS is not mounted to '/'");
-            println!("Please run 'install' to setup moros");
+            println!("MFS not found, run 'install' to setup the system");
         }
         println!("Running console in diskless mode");
         usr::shell::main(&["shell"]).ok();


### PR DESCRIPTION
First time users get stuck after booting disk.img for the first time (as did I). 
This PR adds a helpful debug line which tells the user to run 'install'.
Addresses issue #426 