### PR TITLE
Improve setup process

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ extern crate alloc;
 
 use bootloader::{entry_point, BootInfo};
 use core::panic::PanicInfo;
-use moros::{debug, hlt_loop, print, println, sys, usr};
+use moros::{
+    debug, error, warning, hlt_loop, eprint, eprintln, print, println, sys, usr
+};
 
 entry_point!(main);
 
@@ -30,9 +32,9 @@ fn user_boot() {
         usr::shell::main(&["shell", script]).ok();
     } else {
         if sys::fs::is_mounted() {
-            println!("Could not find '{}'", script);
+            error!("Could not find '{}'", script);
         } else {
-            println!("MFS not found, run 'install' to setup the system");
+            warning!("MFS not found, run 'install' to setup the system");
         }
         println!("Running console in diskless mode");
         usr::shell::main(&["shell"]).ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ fn user_boot() {
         } else {
             warning!("MFS not found, run 'install' to setup the system");
         }
-        println!("Running console in diskless mode");
         usr::shell::main(&["shell"]).ok();
     }
 }

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -299,12 +299,17 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         if !sys::fs::is_mounted() {
             println!("{}Listing disks ...{}", csi_color, csi_reset);
             usr::shell::exec("disk list").ok();
+            println!("/dev/mem        RAM DISK");
             println!();
 
             println!("{}Formatting disk ...{}", csi_color, csi_reset);
             print!("Enter path of disk to format: ");
-            let pathname = io::stdin().read_line();
-            usr::shell::exec(&format!("disk format {}", pathname.trim_end()))?;
+            let path = io::stdin().read_line();
+            if path.trim_end() == "/dev/mem" {
+                usr::shell::exec(&format!("memory format"))?;
+            } else {
+                usr::shell::exec(&format!("disk format {}", path.trim_end()))?;
+            }
             println!();
         }
 


### PR DESCRIPTION
This PR is a continuation of #595 by @kidharb to improve the setup process

- [x] Use `warning` macro when MFS is not present
- [x] Use `error` macro when `/ini/boot.sh` is not present
- [x] Remove diskless mode message
- [x] Add option to setup the system on a RAM disk from the `install` command