### PR TITLE
Improve VGA palette parser

### DIFF
--- a/src/api/vga/palette.rs
+++ b/src/api/vga/palette.rs
@@ -54,7 +54,7 @@ pub fn from_csv(s: &str) -> Result<Palette, ()> {
 }
 
 #[test_case]
-fn parse_palette_csv() {
+fn test_from_csv() {
     assert!(from_csv("").is_err());
     assert!(from_csv("0,0,0,0").is_err());
 

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -585,6 +585,6 @@ pub fn init() {
 fn test_parse_palette() {
     assert_eq!(parse_palette("P0282828"), Ok((0, 0x28, 0x28, 0x28)));
     assert_eq!(parse_palette("P4CC241D"), Ok((4, 0xCC, 0x24, 0x1D)));
-    assert!(parse_palette("PAAAAAAA").is_ok());
-    assert!(parse_palette("PGGAGGGG").is_err());
+    assert!(parse_palette("BAAAAAAD").is_ok());
+    assert!(parse_palette("GOOOOOOD").is_err());
 }


### PR DESCRIPTION
I discovered while fuzzing the VGA driver by reading `/dev/random` to the console for long enough (#602) that the default behavior when parsing an ANSI OSC color palette (#566) was to set the background to black when an invalid input was received.

This change will now reject invalid inputs.