### PR TITLE
Fix invalid VGA palette reset

### DIFF
--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -437,7 +437,7 @@ impl Perform for Writer {
                         self.set_palette(i, r, g, b);
                     }
                 }
-                Some('R') => {
+                Some('R') if s.len() == 1 => {
                     let palette = Palette::default();
                     for (i, (r, g, b)) in palette.colors.iter().enumerate() {
                         self.set_palette(i, *r, *g, *b);


### PR DESCRIPTION
This PR will fix another issue discovered while fuzzing the VGA driver by reading `/dev/random` to the console for long enough (#602). The ANSI OSC color palette (#566) reset sequence was not strict enough and should reject more invalid inputs.