### PR TITLE
Allow copying file to dir

### DIFF
--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -224,7 +224,14 @@ pub fn read_dir(path: &str) -> Result<Vec<FileInfo>, ()> {
 }
 
 #[test_case]
-fn test_file() {
+fn test_filename() {
+    assert_eq!(filename("/path/to/file.txt"), "file.txt");
+    assert_eq!(filename("/file.txt"), "file.txt");
+    assert_eq!(filename("file.txt"), "file.txt");
+}
+
+#[test_case]
+fn test_fs() {
     use crate::sys::fs::{dismount, format_mem, mount_mem};
     mount_mem();
     format_mem();

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -43,11 +43,8 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 }
 
 fn destination(source: &str, dest: &str) -> String {
-    let mut dest = dest.to_string();
-    if dest.ends_with('/') {
-        dest = dest.trim_end_matches('/').to_string();
-    }
-    if fs::is_dir(&dest) {
+    let mut dest = dest.trim_end_matches('/').to_string();
+    if dest.is_empty() || fs::is_dir(&dest) {
         let file = fs::filename(source);
         dest = format!("{}/{}", dest, file);
     }
@@ -73,8 +70,12 @@ fn test_copy() {
     usr::install::copy_files(false);
 
     assert_eq!(destination("foo.txt", "bar.txt"), "bar.txt");
+
+    assert_eq!(destination("foo.txt", "/"), "/foo.txt");
     assert_eq!(destination("foo.txt", "/tmp"), "/tmp/foo.txt");
     assert_eq!(destination("foo.txt", "/tmp/"), "/tmp/foo.txt");
+
+    assert_eq!(destination("/usr/vinc/foo.txt", "/"), "/foo.txt");
     assert_eq!(destination("/usr/vinc/foo.txt", "/tmp"), "/tmp/foo.txt");
     assert_eq!(destination("/usr/vinc/foo.txt", "/tmp/"), "/tmp/foo.txt");
 

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -21,6 +21,11 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         return Err(ExitCode::UsageError);
     }
 
+    if args[2].is_empty() {
+        error!("Could not write to ''");
+        return Err(ExitCode::Failure);
+    }
+
     let source = args[1];
     let dest = destination(args[1], args[2]);
 
@@ -43,6 +48,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 }
 
 fn destination(source: &str, dest: &str) -> String {
+    debug_assert!(!dest.is_empty());
     let mut dest = dest.trim_end_matches('/').to_string();
     if dest.is_empty() || fs::is_dir(&dest) {
         let file = fs::filename(source);

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -2,6 +2,9 @@ use crate::api::console::Style;
 use crate::api::fs;
 use crate::api::process::ExitCode;
 
+use alloc::format;
+use alloc::string::{String, ToString};
+
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let n = args.len();
     if n != 3 {
@@ -19,10 +22,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     }
 
     let source = args[1];
-    let dest = args[2];
+    let dest = destination(args[1], args[2]);
 
     if let Ok(contents) = fs::read_to_bytes(source) {
-        if fs::write(dest, &contents).is_ok() {
+        if fs::write(&dest, &contents).is_ok() {
             Ok(())
         } else {
             error!("Could not write to '{}'", dest);
@@ -34,6 +37,18 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     }
 }
 
+fn destination(source: &str, dest: &str) -> String {
+    let mut dest = dest.to_string();
+    if dest.ends_with('/') {
+        dest = dest.trim_end_matches('/').to_string();
+    }
+    if fs::is_dir(&dest) {
+        let file = fs::filename(source);
+        dest = format!("{}/{}", dest, file);
+    }
+    dest
+}
+
 fn help() {
     let csi_option = Style::color("LightCyan");
     let csi_title = Style::color("Yellow");
@@ -42,4 +57,21 @@ fn help() {
         "{}Usage:{} copy {}<src> <dst>{}",
         csi_title, csi_reset, csi_option, csi_reset
     );
+}
+
+#[test_case]
+fn test_copy() {
+    use crate::{usr, sys};
+
+    sys::fs::mount_mem();
+    sys::fs::format_mem();
+    usr::install::copy_files(false);
+
+    assert_eq!(destination("foo.txt", "bar.txt"), "bar.txt");
+    assert_eq!(destination("foo.txt", "/tmp"), "/tmp/foo.txt");
+    assert_eq!(destination("foo.txt", "/tmp/"), "/tmp/foo.txt");
+    assert_eq!(destination("/usr/vinc/foo.txt", "/tmp"), "/tmp/foo.txt");
+    assert_eq!(destination("/usr/vinc/foo.txt", "/tmp/"), "/tmp/foo.txt");
+
+    sys::fs::dismount();
 }

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -7,10 +7,6 @@ use alloc::string::{String, ToString};
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let n = args.len();
-    if n != 3 {
-        help();
-        return Err(ExitCode::UsageError);
-    }
     for i in 1..n {
         match args[i] {
             "-h" | "--help" => {
@@ -19,6 +15,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             }
             _ => continue,
         }
+    }
+    if n != 3 {
+        help();
+        return Err(ExitCode::UsageError);
     }
 
     let source = args[1];

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -24,6 +24,11 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let source = args[1];
     let dest = destination(args[1], args[2]);
 
+    if fs::is_dir(source) {
+        error!("Could not copy directory '{}'", source);
+        return Err(ExitCode::Failure);
+    }
+
     if let Ok(contents) = fs::read_to_bytes(source) {
         if fs::write(&dest, &contents).is_ok() {
             Ok(())

--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -68,7 +68,7 @@ fn help() {
 }
 
 #[test_case]
-fn test_copy() {
+fn test_destination() {
     use crate::{usr, sys};
 
     sys::fs::mount_mem();

--- a/src/usr/move.rs
+++ b/src/usr/move.rs
@@ -19,9 +19,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     }
 
     // TODO: Avoid doing copy+delete
-    match usr::copy::main(args) {
-        Ok(()) => usr::delete::main(&args[0..2]),
-        _ => Err(ExitCode::Failure),
+    if usr::copy::main(args).is_ok() {
+        usr::delete::main(&args[0..2])
+    } else {
+        Err(ExitCode::Failure)
     }
 }
 


### PR DESCRIPTION
We will now be able to do `copy foo.txt /tmp` to copy `foo.txt` to `/tmp/foo.txt`.

If the source is an absolute path the file will be copied into the dir, for example `copy /usr/vinc/foo.txt /tmp` will be copied to `/tmp/foo.txt`.

Copying a dir is not yet allowed, this PR will make it an error instead of a silent failure.