### PR TITLE
Fix HTTP server buffer

### DIFF
--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -23,6 +23,7 @@ use smoltcp::wire::IpAddress;
 
 const MAX_CONNECTIONS: usize = 32;
 const POLL_DELAY_DIV: usize = 128;
+const INDEX: [&str; 4] = ["", "/index.html", "/index.htm", "/index.txt"];
 
 #[derive(Clone)]
 struct Request {
@@ -212,10 +213,8 @@ fn get(req: &Request, res: &mut Response) {
         res.body.extend_from_slice(b"<h1>Moved Permanently</h1>\r\n");
     } else {
         let mut not_found = true;
-        for autocomplete in
-            &["", "/index.html", "/index.htm", "/index.txt"]
-        {
-            let real_path = format!("{}{}", res.real_path, autocomplete);
+        for index in INDEX {
+            let real_path = format!("{}{}", res.real_path, index);
             if fs::is_dir(&real_path) {
                 continue;
             }

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -480,9 +480,10 @@ fn content_type(path: &str) -> String {
 }
 
 fn join_path(dir: &str, path: &str) -> String {
-    let sep = if path == "/" { "" } else { "/" };
-    let path = path.strip_suffix('/').unwrap_or(&path);
-    format!("{}{}{}", dir, sep, path).replace("//", "/")
+    let dir = dir.trim_matches('/');
+    let path = path.trim_matches('/');
+    let sep = if dir == "" || path == "" { "" } else { "/" };
+    format!("/{}{}{}", dir, sep, path)
 }
 
 fn usage() {
@@ -507,4 +508,17 @@ fn usage() {
         "  {0}-r{1}, {0}--read-only{1}        Set read-only mode",
         csi_option, csi_reset
     );
+}
+
+#[test_case]
+fn test_join_path() {
+    assert_eq!(join_path("/foo/", "/bar/"), "/foo/bar");
+    assert_eq!(join_path("/foo/", "/bar"), "/foo/bar");
+    assert_eq!(join_path("/foo/", "/"), "/foo");
+    assert_eq!(join_path("/foo", "/bar/"), "/foo/bar");
+    assert_eq!(join_path("/foo", "/bar"), "/foo/bar");
+    assert_eq!(join_path("/foo", "/"), "/foo");
+    assert_eq!(join_path("/", "/bar/"), "/bar");
+    assert_eq!(join_path("/", "/bar"), "/bar");
+    assert_eq!(join_path("/", "/"), "/");
 }


### PR DESCRIPTION
Sometimes a call to `socket.recv()` doesn't return the whole receive buffer and some HTTP requests are not correctly parsed. This PR fixes this issue by rebuilding the whole buffer before parsing the request. It also fixes how the server join its root directory and the request path.