### PR TITLE
Reduce DHCP sleep time

### DIFF
--- a/src/usr/dhcp.rs
+++ b/src/usr/dhcp.rs
@@ -64,8 +64,9 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 Some(dhcpv4::Event::Deconfigured) => {}
             }
 
-            if let Some(d) = iface.poll_delay(time, &sockets) {
-                syscall::sleep((d.total_micros() as f64) / 1000000.0);
+            if let Some(duration) = iface.poll_delay(time, &sockets) {
+                let d = (duration.total_micros() as f64) / 1000000.0;
+                syscall::sleep(d.min(0.1)); // Don't sleep longer than 0.1s
             }
         }
     } else {

--- a/src/usr/dhcp.rs
+++ b/src/usr/dhcp.rs
@@ -64,8 +64,8 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 Some(dhcpv4::Event::Deconfigured) => {}
             }
 
-            if let Some(duration) = iface.poll_delay(time, &sockets) {
-                let d = (duration.total_micros() as f64) / 1000000.0;
+            if let Some(delay) = iface.poll_delay(time, &sockets) {
+                let d = (delay.total_micros() as f64) / 1000000.0;
                 syscall::sleep(d.min(0.1)); // Don't sleep longer than 0.1s
             }
         }

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -451,10 +451,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     send_queue.clear();
                 }
             }
-            if let Some(wait_duration) = iface.poll_delay(time, &sockets) {
-                let t = wait_duration.total_micros() / POLL_DELAY_DIV as u64;
-                if t > 0 {
-                    syscall::sleep((t as f64) / 1000000.0);
+            if let Some(delay) = iface.poll_delay(time, &sockets) {
+                let d = delay.total_micros() / POLL_DELAY_DIV as u64;
+                if d > 0 {
+                    syscall::sleep((d as f64) / 1000000.0);
                 }
             }
         }


### PR DESCRIPTION
The `dhcp` command is very fast on QEMU but slow on VirtualBox and real hardware.

After investigating I found that the `iface.poll_delay` was making it sleep for 10 seconds and then 5 seconds between calls to `poll`. But we can call this function more frequently, and when we do this we get the `DHCP Reply` much faster. See https://docs.rs/smoltcp/latest/smoltcp/iface/struct.Interface.html#method.poll_delay

Before:
![VirtualBox_MOROS_08_04_2024_12_28_13](https://github.com/vinc/moros/assets/305625/805f4593-df25-481e-8976-982925a887dc)

After:
![VirtualBox_MOROS_08_04_2024_12_27_09](https://github.com/vinc/moros/assets/305625/8bbae630-4529-4520-9789-e661ee7bf187)
