### PR TITLE
Fix line iterators

### DIFF
--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -317,8 +317,8 @@ impl History {
     }
 
     pub fn load(&mut self, path: &str) {
-        if let Ok(lines) = fs::read_to_string(path) {
-            self.entries = lines.lines().map(|s| s.to_string()).collect();
+        if let Ok(contents) = fs::read_to_string(path) {
+            self.entries = contents.lines().map(|s| s.to_string()).collect();
         }
     }
 

--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -318,7 +318,7 @@ impl History {
 
     pub fn load(&mut self, path: &str) {
         if let Ok(lines) = fs::read_to_string(path) {
-            self.entries = lines.split('\n').map(|s| s.to_string()).collect();
+            self.entries = lines.lines().map(|s| s.to_string()).collect();
         }
     }
 

--- a/src/api/vga/palette.rs
+++ b/src/api/vga/palette.rs
@@ -33,7 +33,7 @@ impl Palette {
 
 // TODO: Remove this
 pub fn from_csv(s: &str) -> Result<Palette, ()> {
-    let colors: Vec<_> = s.split('\n').filter_map(|line| {
+    let colors: Vec<_> = s.lines().filter_map(|line| {
         let line = line.split('#').next().unwrap(); // Remove comments
         let color: Vec<u8> = line.split(',').filter_map(|value| {
             let radix = if value.contains("0x") { 16 } else { 10 };

--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -53,7 +53,7 @@ impl Editor {
 
         match fs::read_to_string(pathname) {
             Ok(contents) => {
-                for line in contents.split('\n') {
+                for line in contents.lines() {
                     lines.push(line.into());
                 }
             }

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -132,9 +132,9 @@ fn print_matching_lines(path: &str, options: &mut Options) {
     let reset = Style::reset();
 
     let re = Regex::new(&options.line);
-    if let Ok(lines) = fs::read_to_string(path) {
+    if let Ok(contents) = fs::read_to_string(path) {
         let mut matches = Vec::new();
-        for (i, line) in lines.lines().enumerate() {
+        for (i, line) in contents.lines().enumerate() {
             let line: Vec<char> = line.chars().collect();
             let mut l = String::new();
             let mut j = 0;

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -134,7 +134,7 @@ fn print_matching_lines(path: &str, options: &mut Options) {
     let re = Regex::new(&options.line);
     if let Ok(lines) = fs::read_to_string(path) {
         let mut matches = Vec::new();
-        for (i, line) in lines.split('\n').enumerate() {
+        for (i, line) in lines.lines().enumerate() {
             let line: Vec<char> = line.chars().collect();
             let mut l = String::new();
             let mut j = 0;

--- a/src/usr/life.rs
+++ b/src/usr/life.rs
@@ -38,8 +38,8 @@ impl Game {
     }
 
     pub fn load_file(&mut self, path: &str) {
-        if let Ok(lines) = fs::read_to_string(path) {
-            for (y, line) in lines.lines().enumerate() {
+        if let Ok(contents) = fs::read_to_string(path) {
+            for (y, line) in contents.lines().enumerate() {
                 for (x, c) in line.chars().enumerate() {
                     let cell = (x as i64, y as i64);
                     match c {

--- a/src/usr/life.rs
+++ b/src/usr/life.rs
@@ -39,7 +39,7 @@ impl Game {
 
     pub fn load_file(&mut self, path: &str) {
         if let Ok(lines) = fs::read_to_string(path) {
-            for (y, line) in lines.split('\n').enumerate() {
+            for (y, line) in lines.lines().enumerate() {
                 for (x, c) in line.chars().enumerate() {
                     let cell = (x as i64, y as i64);
                     match c {

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -648,8 +648,8 @@ pub fn exec(cmd: &str) -> Result<(), ExitCode> {
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let mut config = Config::new();
 
-    if let Ok(rc) = fs::read_to_string("/ini/shell.sh") {
-        for cmd in rc.lines() {
+    if let Ok(contents) = fs::read_to_string("/ini/shell.sh") {
+        for cmd in contents.lines() {
             exec_with_config(cmd, &mut config).ok();
         }
     }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -649,7 +649,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let mut config = Config::new();
 
     if let Ok(rc) = fs::read_to_string("/ini/shell.sh") {
-        for cmd in rc.split('\n') {
+        for cmd in rc.lines() {
             exec_with_config(cmd, &mut config).ok();
         }
     }
@@ -671,7 +671,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 
         let path = args[1];
         if let Ok(contents) = api::fs::read_to_string(path) {
-            for line in contents.split('\n') {
+            for line in contents.lines() {
                 if !line.is_empty() {
                     exec_with_config(line, &mut config).ok();
                 }

--- a/src/usr/user.rs
+++ b/src/usr/user.rs
@@ -191,7 +191,7 @@ pub fn hash(password: &str) -> String {
 fn read_hashed_passwords() -> BTreeMap<String, String> {
     let mut hashed_passwords = BTreeMap::new();
     if let Ok(csv) = api::fs::read_to_string(USERS) {
-        for line in csv.split('\n') {
+        for line in csv.lines() {
             let mut rows = line.split(',');
             if let Some(username) = rows.next() {
                 if let Some(hash) = rows.next() {

--- a/src/usr/user.rs
+++ b/src/usr/user.rs
@@ -190,8 +190,8 @@ pub fn hash(password: &str) -> String {
 
 fn read_hashed_passwords() -> BTreeMap<String, String> {
     let mut hashed_passwords = BTreeMap::new();
-    if let Ok(csv) = api::fs::read_to_string(USERS) {
-        for line in csv.lines() {
+    if let Ok(contents) = api::fs::read_to_string(USERS) {
+        for line in contents.lines() {
             let mut rows = line.split(',');
             if let Some(username) = rows.next() {
                 if let Some(hash) = rows.next() {
@@ -212,12 +212,12 @@ fn save_hashed_password(username: &str, hash: &str) -> Result<usize, ()> {
     hashed_passwords.remove(username);
     hashed_passwords.insert(username.into(), hash.into());
 
-    let mut csv = String::new();
+    let mut contents = String::new();
     for (u, h) in hashed_passwords {
-        csv.push_str(&format!("{},{}\n", u, h));
+        contents.push_str(&format!("{},{}\n", u, h));
     }
 
-    fs::write(USERS, csv.as_bytes())
+    fs::write(USERS, contents.as_bytes())
 }
 
 fn help() {

--- a/src/usr/view.rs
+++ b/src/usr/view.rs
@@ -38,7 +38,7 @@ impl Viewer {
         let mut width = 0;
         match fs::read_to_string(pathname) {
             Ok(contents) => {
-                for line in contents.split('\n') {
+                for line in contents.lines() {
                     lines.push(line.into());
                     width = cmp::max(width, line.chars().count());
                 }


### PR DESCRIPTION
Now that we can get files from the net it is better to split lines with `lines()` instead of `split('\n')` for better interoperability because some documents use `\r\n` instead of `\n` as line terminator.