### PR TITLE
Add shell operator shortcut

### DIFF
--- a/doc/shell.md
+++ b/doc/shell.md
@@ -116,9 +116,14 @@ It is possible to chain multiple redirections:
     > time read foo.txt [1]=> bar.txt [2]=> time.txt
 
 When the arrow point to the other direction the source and destination are
-swapped and the standard input is implied (TODO):
+swapped and the standard input is implied:
 
-    > write <= req.txt => /net/http/moros.cc
+    > http <= req.txt => res.txt
+
+Here we redirect `req.txt` to `stdin` and `stdout` to `res.txt`. If both files
+are the same we can use this shortcut:
+
+    > http <=> tmp.txt
 
 Redirections should be declared before piping (TODO):
 

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -421,6 +421,13 @@ fn exec_with_config(cmd: &str, config: &mut Config) -> Result<(), ExitCode> {
             // read foo.txt [2]-> write /dev/null
             is_thin_arrow = true;
             left_handle = 1;
+        } else if Regex::new("^<=*>+$").is_match(args[i]) {
+            is_fat_arrow = true;
+            left_handle = 0;
+            n += 2;
+            args.insert(i + 2, args[i + 1]);
+            args.insert(i + 2, args[i].trim_start_matches('<'));
+            args[i] = "<=";
         } else if Regex::new("^[?\\d*]?=*>+[?\\d*]?$").is_match(args[i]) {
             // Redirections to
             // read foo.txt ==> bar.txt

--- a/www/shell.html
+++ b/www/shell.html
@@ -139,9 +139,15 @@ possible to explicitly redirect a handle to another (TODO):</p>
 </code></pre>
 
     <p>When the arrow point to the other direction the source and destination are
-swapped and the standard input is implied (TODO):</p>
+swapped and the standard input is implied:</p>
 
-    <pre><code>&gt; write &lt;= req.txt =&gt; /net/http/moros.cc
+    <pre><code>&gt; http &lt;= req.txt =&gt; res.txt
+</code></pre>
+
+    <p>Here we redirect <code>req.txt</code> to <code>stdin</code> and <code>stdout</code> to <code>res.txt</code>. If both files
+are the same we can use this shortcut:</p>
+
+    <pre><code>&gt; http &lt;=&gt; tmp.txt
 </code></pre>
 
     <p>Redirections should be declared before piping (TODO):</p>


### PR DESCRIPTION
The pipe operator is not implemented yet so it's common to have this kind of pattern:

```
print "GET $url" => $tmp
socket $web <= $tmp => $tmp
view $tmp
```

Instead of writing `cmd <= foo.txt => foo.txt` we can now write `cmd <=> foo.txt` which let us rewrite the first example into this:

```
print "GET $url" => $tmp
socket $web <=> $tmp
view $tmp
```

This makes the code a bit more DRY.