### PR TITLE
Fix final line ending

### DIFF
--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -56,6 +56,9 @@ impl Editor {
                 for line in contents.lines() {
                     lines.push(line.into());
                 }
+                if lines.is_empty() {
+                    lines.push(String::new());
+                }
             }
             Err(_) => {
                 lines.push(String::new());

--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -79,16 +79,10 @@ impl Editor {
     }
 
     pub fn save(&mut self) -> Result<(), ExitCode> {
-        let mut contents = String::new();
-        let n = self.lines.len();
-        for i in 0..n {
-            contents.push_str(&self.lines[i]);
-            if i < n - 1 {
-                contents.push('\n');
-            }
-        }
+        let contents = self.lines.join("\n") + "\n";
 
         if fs::write(&self.pathname, contents.as_bytes()).is_ok() {
+            let n = self.lines.len();
             let status = format!("Wrote {}L to '{}'", n, self.pathname);
             self.print_status(&status, "yellow");
             Ok(())

--- a/src/usr/view.rs
+++ b/src/usr/view.rs
@@ -42,6 +42,9 @@ impl Viewer {
                     lines.push(line.into());
                     width = cmp::max(width, line.chars().count());
                 }
+                if lines.is_empty() {
+                    lines.push(String::new());
+                }
             }
             Err(_) => {
                 lines.push(String::new());


### PR DESCRIPTION
The previous PR #632 introduced an issue on empty files, because `"".split('\n')` would produce `[""]` whereas `"".lines()` would produce `[]` resulting in a panic on the editor and the viewer.

We can add back an empty line if a file contains no lines, but it's also the occasion to deal with something that could be improved: in POSIX the last line of a file must end with a newline, and this make sense so MOROS follows this rule. But the editor would explicitely show an empty line at the end of every file to save this trailing newline chars. And when editing a file you'd have to remember to always leave an empty line at the end.

In general it seems better to make that final newline implicit and avoid displaying an empty line at the end of every files.

The only caveat is that on some occasions we might want to produce a file without a trailing newline. This will now be impossible, we'll see if it's needed in the future and revisit that decision then. It could just be an option in the editor.