### PR TITLE
Free unused blocks after rewrite

### DIFF
--- a/src/sys/fs/dir.rs
+++ b/src/sys/fs/dir.rs
@@ -158,7 +158,7 @@ impl Dir {
         ))
     }
 
-    // Deleting an entry is done by setting the entry address to 0
+    // FIXME: Deleting an entry is done by setting the entry address to 0
     // TODO: If the entry is a directory, remove its entries recursively
     pub fn delete_entry(&mut self, name: &str) -> Result<(), ()> {
         let mut entries = self.entries();
@@ -175,11 +175,11 @@ impl Dir {
                 self.update_size();
 
                 // Freeing entry blocks
-                let mut entry_block = LinkedBlock::read(entry.addr());
+                let mut free_block = LinkedBlock::read(entry.addr());
                 loop {
-                    BitmapBlock::free(entry_block.addr());
-                    match entry_block.next() {
-                        Some(next_block) => entry_block = next_block,
+                    BitmapBlock::free(free_block.addr());
+                    match free_block.next() { // FIXME: read after free?
+                        Some(next_block) => free_block = next_block,
                         None => break,
                     }
                 }

--- a/src/sys/fs/file.rs
+++ b/src/sys/fs/file.rs
@@ -1,3 +1,4 @@
+use super::bitmap_block::BitmapBlock;
 use super::block::LinkedBlock;
 use super::dir::Dir;
 use super::dir_entry::DirEntry;
@@ -173,7 +174,15 @@ impl FileIO for File {
                     if bytes < buf_len {
                         next_block.addr()
                     } else {
-                        // TODO: Free the next block(s)
+                        // Free next block(s)
+                        let mut free_block = next_block;
+                        loop {
+                            BitmapBlock::free(free_block.addr());
+                            match free_block.next() { // FIXME: read after free?
+                                Some(next_block) => free_block = next_block,
+                                None => break,
+                            }
+                        }
                         0
                     }
                 }


### PR DESCRIPTION
After installing MOROS to memory, downloading the same file to the same location repetitively would always crash after a while at the same point:

```
~
> dhcp
[32.797006] NET IP 10.0.2.15/24
[32.800005] NET GW 10.0.2.2
[32.804005] NET DNS 10.0.2.3

~
> time http 10.0.2.2:8000/100kb.txt => 100kb.txt
Executed 'http 10.0.2.2:8000/100kb.txt' in 2.900863s

~
> time http 10.0.2.2:8000/100kb.txt => 100kb.txt
Executed 'http 10.0.2.2:8000/100kb.txt' in 1.901015s

~
> time http 10.0.2.2:8000/100kb.txt => 100kb.txt
Executed 'http 10.0.2.2:8000/100kb.txt' in 1.900015s

~
> time http 10.0.2.2:8000/100kb.txt => 100kb.txt
Executed 'http 10.0.2.2:8000/100kb.txt' in 1.898016s

~
> time http 10.0.2.2:8000/100kb.txt => 100kb.txt
DEBUG: panicked at src/sys/fs/block_device.rs:69:43:
index out of bounds: the len is 16360 but the index is 4294967295
```

This issue can be fixed by freeing unused blocks after rewriting a file. This was marked with a TODO comment in the code.