### PR TITLE
Fix block bitmap area calculation

### DIFF
--- a/doc/filesystem.md
+++ b/doc/filesystem.md
@@ -10,9 +10,9 @@ A hard drive is separated in blocks of 512 bytes, grouped into 4 areas:
     +------------+
     | Superblock | (2 blocks)
     +------------+
-    | Bitmap     | (n / (8 * 512) blocks)
+    | Bitmap     | (n blocks)
     +------------+
-    | Data       | (n blocks)
+    | Data       | (n * 512 * 8 blocks)
     +------------+
 
 The first area contains the bootloader and the kernel, the second is a

--- a/src/sys/fs/bitmap_block.rs
+++ b/src/sys/fs/bitmap_block.rs
@@ -42,6 +42,10 @@ impl BitmapBlock {
 
     pub fn next_free_addr() -> Option<u32> {
         let sb = SuperBlock::read();
+        if sb.alloc_count() == sb.block_count() - 1 {
+            return None;
+        }
+
         let n = sb.block_size();
         let m = sb.block_count() / n / 8;
         for i in 0..m {

--- a/src/sys/fs/bitmap_block.rs
+++ b/src/sys/fs/bitmap_block.rs
@@ -42,7 +42,7 @@ impl BitmapBlock {
 
     pub fn next_free_addr() -> Option<u32> {
         let sb = SuperBlock::read();
-        if sb.alloc_count() == sb.block_count() - 1 {
+        if sb.alloc_count() == sb.block_count() {
             return None;
         }
 

--- a/src/sys/fs/dir.rs
+++ b/src/sys/fs/dir.rs
@@ -120,15 +120,18 @@ impl Dir {
         if entry_len > space_left {
             match entries.block.alloc_next() {
                 None => return None, // Disk is full
-                Some(new_block) => {
-                    entries.block = new_block;
+                Some(block) => {
+                    entries.block = block;
                     entries.block_offset = 0;
                 }
             }
         }
 
         // Create a new entry
-        let entry_block = LinkedBlock::alloc().unwrap();
+        let entry_block = match LinkedBlock::alloc() {
+            None => return None,
+            Some(block) => block,
+        };
         let entry_kind = kind as u8;
         let entry_addr = entry_block.addr();
         let entry_size = 0u32;

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -26,7 +26,7 @@ use super_block::SuperBlock;
 
 use alloc::string::{String, ToString};
 
-pub const VERSION: u8 = 1;
+pub const VERSION: u8 = 2;
 
 // TODO: Move that to API
 #[derive(Clone, Copy)]

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -157,11 +157,11 @@ pub fn canonicalize(path: &str) -> Result<String, ()> {
 }
 
 pub fn disk_size() -> usize {
-    (SuperBlock::read().block_count as usize) * BLOCK_SIZE
+    (SuperBlock::read().block_count() as usize) * BLOCK_SIZE
 }
 
 pub fn disk_used() -> usize {
-    (SuperBlock::read().alloc_count as usize) * BLOCK_SIZE
+    (SuperBlock::read().alloc_count() as usize) * BLOCK_SIZE
 }
 
 pub fn disk_free() -> usize {

--- a/src/sys/fs/super_block.rs
+++ b/src/sys/fs/super_block.rs
@@ -83,6 +83,10 @@ impl SuperBlock {
         self.block_count
     }
 
+    pub fn alloc_count(&self) -> u32 {
+        self.alloc_count
+    }
+
     pub fn bitmap_area(&self) -> u32 {
         SUPERBLOCK_ADDR + 2
     }

--- a/src/sys/fs/super_block.rs
+++ b/src/sys/fs/super_block.rs
@@ -12,8 +12,8 @@ pub struct SuperBlock {
     signature: &'static [u8; 8],
     version: u8,
     block_size: u32,
-    pub block_count: u32, // TODO: Remove pub
-    pub alloc_count: u32, // TODO: Remove pub
+    block_count: u32,
+    alloc_count: u32,
 }
 
 impl SuperBlock {

--- a/src/sys/fs/super_block.rs
+++ b/src/sys/fs/super_block.rs
@@ -27,13 +27,18 @@ impl SuperBlock {
 
     pub fn new() -> Option<Self> {
         if let Some(ref dev) = *super::block_device::BLOCK_DEVICE.lock() {
-            Some(Self {
+            let mut sb = Self {
                 signature: SIGNATURE,
                 version: super::VERSION,
                 block_size: dev.block_size() as u32,
                 block_count: dev.block_count() as u32,
                 alloc_count: 0,
-            })
+            };
+
+            // Reserved blocks
+            sb.alloc_count = sb.data_area() - 1;
+
+            Some(sb)
         } else {
             None
         }

--- a/src/sys/fs/super_block.rs
+++ b/src/sys/fs/super_block.rs
@@ -36,7 +36,7 @@ impl SuperBlock {
             };
 
             // Reserved blocks
-            sb.alloc_count = sb.data_area() - 1;
+            sb.alloc_count = sb.data_area();
 
             Some(sb)
         } else {


### PR DESCRIPTION
The formula used to calculate the size of the block bitmap area was not correct, resulting in blocks that cannot be allocated. This issue surfaced after #637 when using about half of the disk.

One thing to note is that this PR will likely extend the size of the block bitmap area by one or more blocks so we must increase the version number of MFS to use the old formula on existing disks.