### PR TITLE
Replace fetch by get

### DIFF
--- a/dsk/bin/get
+++ b/dsk/bin/get
@@ -1,0 +1,12 @@
+#! shell
+
+set url "$1"
+set tmp "/tmp/web.txt"
+
+http $url => $tmp
+
+# set web "10.0.2.2:8888"
+# print "GET $url" => $tmp
+# socket $web <=> $tmp
+
+view $tmp

--- a/dsk/bin/ntp
+++ b/dsk/bin/ntp
@@ -1,4 +1,4 @@
-#!lisp
+#! lisp
 
 (load "/lib/lisp/core.lsp")
 

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -27,6 +27,7 @@ pub fn copy_files(verbose: bool) {
 
     copy_file!("/bin/clear", verbose);
     //copy_file!("/bin/exec", verbose);
+    copy_file!("/bin/get", verbose);
     copy_file!("/bin/halt", verbose);
     //copy_file!("/bin/hello", verbose);
     copy_file!("/bin/ntp", verbose);
@@ -83,7 +84,6 @@ pub fn copy_files(verbose: bool) {
     copy_file!("/tmp/lisp/colors.lsp", verbose);
     copy_file!("/tmp/lisp/doc.lsp", verbose);
     copy_file!("/tmp/lisp/factorial.lsp", verbose);
-    //copy_file!("/tmp/lisp/fetch.lsp", verbose);
     copy_file!("/tmp/lisp/fibonacci.lsp", verbose);
     copy_file!("/tmp/lisp/geotime.lsp", verbose);
     copy_file!("/tmp/lisp/pi.lsp", verbose);


### PR DESCRIPTION
The `get` shell script is more convenient than the `fetch` lisp script.