### PR TITLE
Add VgaFont device

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -288,8 +288,8 @@ You can also set the `TZ` environment variable to use your preferred timezone:
 Add `env TZ 7200` to `/ini/boot.sh` before `shell` to save the timezone:
 
     > read /ini/boot.sh
-    vga set font /ini/fonts/zap-light-8x16.psf
     shell /ini/palettes/gruvbox-dark.sh
+    read /ini/fonts/zap-light-8x16.psf => /dev/vga/font
     read /ini/banner.txt
     user login
     env TZ 7200

--- a/dsk/ini/boot.sh
+++ b/dsk/ini/boot.sh
@@ -1,5 +1,5 @@
-vga set font /ini/fonts/zap-light-8x16.psf
 shell /ini/palettes/gruvbox-dark.sh
+read /ini/fonts/zap-light-8x16.psf => /dev/vga/font
 read /ini/banner.txt
 user login
 shell

--- a/src/api/font.rs
+++ b/src/api/font.rs
@@ -41,10 +41,10 @@ impl TryFrom<&[u8]> for Font {
 #[test_case]
 fn parse_psf_font() {
     let buf = include_bytes!("../../dsk/ini/boot.sh");
-    assert!(Font::try_from(buf).is_err());
+    assert!(Font::try_from(&buf[..]).is_err());
 
     let buf = include_bytes!("../../dsk/ini/fonts/zap-light-8x16.psf");
-    let font = Font::try_from(buf).unwrap();
+    let font = Font::try_from(&buf[..]).unwrap();
     assert_eq!(font.height, 16);
     assert_eq!(font.size, 256);
     assert_eq!(font.data.len(), 256 * 16);

--- a/src/api/font.rs
+++ b/src/api/font.rs
@@ -7,39 +7,41 @@ pub struct Font {
     pub data: Vec<u8>,
 }
 
-// http://www.fifi.org/doc/console-tools-dev/file-formats/psf
-pub fn from_bytes(buf: &[u8]) -> Result<Font, ()> {
-    // Header
-    if buf.len() < 4 || buf[0] != 0x36 || buf[1] != 0x04 {
-        return Err(());
+impl Font {
+    // http://www.fifi.org/doc/console-tools-dev/file-formats/psf
+    pub fn from_bytes(buf: &[u8]) -> Result<Font, ()> {
+        // Header
+        if buf.len() < 4 || buf[0] != 0x36 || buf[1] != 0x04 {
+            return Err(());
+        }
+        let mode = buf[2];
+        let height = buf[3];
+        let size = match mode {
+            0 | 2 => 256,
+            1 | 3 => 512,
+            _ => return Err(()),
+        };
+
+        // Data
+        let n = (4 + size * height as u16) as usize;
+        if buf.len() < n {
+            return Err(());
+        }
+        let data = buf[4..n].to_vec();
+
+        // TODO: Unicode Table
+
+        Ok(Font { height, size, data })
     }
-    let mode = buf[2];
-    let height = buf[3];
-    let size = match mode {
-        0 | 2 => 256,
-        1 | 3 => 512,
-        _ => return Err(()),
-    };
-
-    // Data
-    let n = (4 + size * height as u16) as usize;
-    if buf.len() < n {
-        return Err(());
-    }
-    let data = buf[4..n].to_vec();
-
-    // TODO: Unicode Table
-
-    Ok(Font { height, size, data })
 }
 
 #[test_case]
 fn parse_psf_font() {
-    assert!(from_bytes(include_bytes!("../../dsk/ini/boot.sh")).is_err());
+    let buf = include_bytes!("../../dsk/ini/boot.sh");
+    assert!(Font::from_bytes(buf).is_err());
 
-    let font = from_bytes(
-        include_bytes!("../../dsk/ini/fonts/zap-light-8x16.psf")
-    ).unwrap();
+    let buf = include_bytes!("../../dsk/ini/fonts/zap-light-8x16.psf");
+    let font = Font::from_bytes(buf).unwrap();
     assert_eq!(font.height, 16);
     assert_eq!(font.size, 256);
     assert_eq!(font.data.len(), 256 * 16);

--- a/src/api/font.rs
+++ b/src/api/font.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 #[derive(Clone)]
 pub struct Font {
@@ -7,9 +8,11 @@ pub struct Font {
     pub data: Vec<u8>,
 }
 
-impl Font {
-    // http://www.fifi.org/doc/console-tools-dev/file-formats/psf
-    pub fn from_bytes(buf: &[u8]) -> Result<Font, ()> {
+impl TryFrom<&[u8]> for Font {
+    type Error = ();
+
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+        // See: http://www.fifi.org/doc/console-tools-dev/file-formats/psf
         // Header
         if buf.len() < 4 || buf[0] != 0x36 || buf[1] != 0x04 {
             return Err(());
@@ -38,10 +41,10 @@ impl Font {
 #[test_case]
 fn parse_psf_font() {
     let buf = include_bytes!("../../dsk/ini/boot.sh");
-    assert!(Font::from_bytes(buf).is_err());
+    assert!(Font::try_from(buf).is_err());
 
     let buf = include_bytes!("../../dsk/ini/fonts/zap-light-8x16.psf");
-    let font = Font::from_bytes(buf).unwrap();
+    let font = Font::try_from(buf).unwrap();
     assert_eq!(font.height, 16);
     assert_eq!(font.size, 256);
     assert_eq!(font.data.len(), 256 * 16);

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -213,25 +213,6 @@ pub fn write(path: &str, buf: &[u8]) -> Result<usize, ()> {
     Err(())
 }
 
-pub fn append(path: &str, buf: &[u8]) -> Result<usize, ()> {
-    let res = if let Some(info) = syscall::info(path) {
-        if info.is_device() {
-            open_device(path)
-        } else {
-            append_file(path)
-        }
-    } else {
-        create_file(path)
-    };
-    if let Some(handle) = res {
-        if let Some(bytes) = syscall::write(handle, buf) {
-            syscall::close(handle);
-            return Ok(bytes);
-        }
-    }
-    Err(())
-}
-
 pub fn reopen(path: &str, handle: usize, append: bool) -> Result<usize, ()> {
     let res = if let Some(info) = syscall::info(path) {
         if info.is_device() {

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -144,6 +144,7 @@ fn device_type(name: &str) -> Result<DeviceType, ()> {
         "rtc"      => Ok(DeviceType::RTC),
         "tcp"      => Ok(DeviceType::TcpSocket),
         "udp"      => Ok(DeviceType::UdpSocket),
+        "font"     => Ok(DeviceType::VgaFont),
         "ata"      => Ok(DeviceType::Drive),
         _          => Err(()),
     }

--- a/src/sys/fs/device.rs
+++ b/src/sys/fs/device.rs
@@ -10,6 +10,7 @@ use crate::sys::console::Console;
 use crate::sys::net::socket::tcp::TcpSocket;
 use crate::sys::net::socket::udp::UdpSocket;
 use crate::sys::rng::Random;
+use crate::sys::vga::VgaFont;
 
 use alloc::vec;
 use alloc::vec::Vec;
@@ -29,6 +30,7 @@ pub enum DeviceType {
     TcpSocket = 7,
     UdpSocket = 8,
     Drive     = 9,
+    VgaFont   = 10,
 }
 
 impl TryFrom<&[u8]> for DeviceType {
@@ -36,17 +38,18 @@ impl TryFrom<&[u8]> for DeviceType {
 
     fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
         match buf.first().ok_or(())? {
-            0 => Ok(DeviceType::Null),
-            1 => Ok(DeviceType::File),
-            2 => Ok(DeviceType::Console),
-            3 => Ok(DeviceType::Random),
-            4 => Ok(DeviceType::Uptime),
-            5 => Ok(DeviceType::Realtime),
-            6 => Ok(DeviceType::RTC),
-            7 => Ok(DeviceType::TcpSocket),
-            8 => Ok(DeviceType::UdpSocket),
-            9 => Ok(DeviceType::Drive),
-            _ => Err(()),
+             0 => Ok(DeviceType::Null),
+             1 => Ok(DeviceType::File),
+             2 => Ok(DeviceType::Console),
+             3 => Ok(DeviceType::Random),
+             4 => Ok(DeviceType::Uptime),
+             5 => Ok(DeviceType::Realtime),
+             6 => Ok(DeviceType::RTC),
+             7 => Ok(DeviceType::TcpSocket),
+             8 => Ok(DeviceType::UdpSocket),
+             9 => Ok(DeviceType::Drive),
+            10 => Ok(DeviceType::VgaFont),
+             _ => Err(()),
         }
     }
 }
@@ -83,6 +86,7 @@ pub enum Device {
     RTC(RTC),
     TcpSocket(TcpSocket),
     UdpSocket(UdpSocket),
+    VgaFont(VgaFont),
     Drive(Drive),
 }
 
@@ -100,6 +104,7 @@ impl TryFrom<&[u8]> for Device {
             DeviceType::RTC       => Ok(Device::RTC(RTC::new())),
             DeviceType::TcpSocket => Ok(Device::TcpSocket(TcpSocket::new())),
             DeviceType::UdpSocket => Ok(Device::UdpSocket(UdpSocket::new())),
+            DeviceType::VgaFont   => Ok(Device::VgaFont(VgaFont::new())),
             DeviceType::Drive if buf.len() > 2 => {
                 let bus = buf[1];
                 let dsk = buf[2];
@@ -158,6 +163,7 @@ impl FileIO for Device {
             Device::RTC(io)       => io.read(buf),
             Device::TcpSocket(io) => io.read(buf),
             Device::UdpSocket(io) => io.read(buf),
+            Device::VgaFont(io)   => io.read(buf),
             Device::Drive(io)     => io.read(buf),
         }
     }
@@ -173,6 +179,7 @@ impl FileIO for Device {
             Device::RTC(io)       => io.write(buf),
             Device::TcpSocket(io) => io.write(buf),
             Device::UdpSocket(io) => io.write(buf),
+            Device::VgaFont(io)   => io.write(buf),
             Device::Drive(io)     => io.write(buf),
         }
     }
@@ -188,6 +195,7 @@ impl FileIO for Device {
             Device::RTC(io)       => io.close(),
             Device::TcpSocket(io) => io.close(),
             Device::UdpSocket(io) => io.close(),
+            Device::VgaFont(io)   => io.close(),
             Device::Drive(io)     => io.close(),
         }
     }
@@ -203,6 +211,7 @@ impl FileIO for Device {
             Device::RTC(io)       => io.poll(event),
             Device::TcpSocket(io) => io.poll(event),
             Device::UdpSocket(io) => io.poll(event),
+            Device::VgaFont(io)   => io.poll(event),
             Device::Drive(io)     => io.poll(event),
         }
     }

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -479,7 +479,7 @@ impl FileIO for VgaFont {
     fn write(&mut self, buf: &[u8]) -> Result<usize, ()> {
         if let Ok(font) = Font::from_bytes(&buf) {
             set_font(&font);
-            Ok(buf.len())
+            Ok(buf.len()) // TODO: Use font.data.len() ?
         } else {
             Err(())
         }

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -6,6 +6,7 @@ use crate::sys;
 
 use alloc::string::String;
 use bit_field::BitField;
+use core::convert::TryFrom;
 use core::cmp;
 use core::fmt;
 use core::fmt::Write;
@@ -477,7 +478,7 @@ impl FileIO for VgaFont {
     }
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, ()> {
-        if let Ok(font) = Font::from_bytes(&buf) {
+        if let Ok(font) = Font::try_from(buf) {
             set_font(&font);
             Ok(buf.len()) // TODO: Use font.data.len() ?
         } else {

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -40,6 +40,7 @@ pub fn copy_files(verbose: bool) {
     create_dir("/dev/ata/1", verbose);
     create_dir("/dev/clk", verbose); // Clock
     create_dir("/dev/net", verbose); // Network
+    create_dir("/dev/vga", verbose);
 
     create_dev("/dev/ata/0/0", "ata-0-0", verbose);
     create_dev("/dev/ata/0/1", "ata-0-1", verbose);
@@ -53,6 +54,7 @@ pub fn copy_files(verbose: bool) {
     create_dev("/dev/console", "console", verbose);
     create_dev("/dev/net/tcp", "tcp", verbose);
     create_dev("/dev/net/udp", "udp", verbose);
+    create_dev("/dev/vga/font", "font", verbose);
 
     copy_file!("/ini/banner.txt", verbose);
     copy_file!("/ini/boot.sh", verbose);

--- a/src/usr/read.rs
+++ b/src/usr/read.rs
@@ -75,8 +75,8 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         }
     } else if let Some(info) = syscall::info(path) {
         if info.is_file() {
-            if let Ok(contents) = api::fs::read_to_string(path) {
-                print!("{}", contents);
+            if let Ok(buf) = api::fs::read_to_bytes(path) {
+                syscall::write(1, &buf);
                 Ok(())
             } else {
                 error!("Could not read '{}'", path);

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -5,6 +5,8 @@ use crate::api::font::Font;
 use crate::api::vga::palette;
 use crate::sys;
 
+use core::convert::TryFrom;
+
 // TODO: Remove this command in the next version of MOROS
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if args.len() == 1 {
@@ -21,7 +23,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             if args.len() == 4 && args[2] == "font" {
                 warning!("Use VGA font device");
                 if let Ok(buf) = fs::read_to_bytes(args[3]) {
-                    if let Ok(font) = Font::from_bytes(&buf) {
+                    if let Ok(font) = Font::try_from(buf.as_slice()) {
                         sys::vga::set_font(&font);
                         Ok(())
                     } else {

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -1,8 +1,9 @@
 use crate::api::console::Style;
 use crate::api::fs;
 use crate::api::process::ExitCode;
+use crate::api::font::Font;
 use crate::api::vga::palette;
-use crate::{api, sys};
+use crate::sys;
 
 // TODO: Remove this command when everything can be done from userspace
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
@@ -19,7 +20,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         "set" => {
             if args.len() == 4 && args[2] == "font" {
                 if let Ok(buf) = fs::read_to_bytes(args[3]) {
-                    if let Ok(font) = api::font::from_bytes(&buf) {
+                    if let Ok(font) = Font::from_bytes(&buf) {
                         sys::vga::set_font(&font);
                         Ok(())
                     } else {

--- a/src/usr/vga.rs
+++ b/src/usr/vga.rs
@@ -5,7 +5,7 @@ use crate::api::font::Font;
 use crate::api::vga::palette;
 use crate::sys;
 
-// TODO: Remove this command when everything can be done from userspace
+// TODO: Remove this command in the next version of MOROS
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if args.len() == 1 {
         help();
@@ -19,6 +19,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         }
         "set" => {
             if args.len() == 4 && args[2] == "font" {
+                warning!("Use VGA font device");
                 if let Ok(buf) = fs::read_to_bytes(args[3]) {
                     if let Ok(font) = Font::from_bytes(&buf) {
                         sys::vga::set_font(&font);

--- a/www/manual.html
+++ b/www/manual.html
@@ -310,8 +310,8 @@ file:</p>
     <p>Add <code>env TZ 7200</code> to <code>/ini/boot.sh</code> before <code>shell</code> to save the timezone:</p>
 
     <pre><code>&gt; read /ini/boot.sh
-vga set font /ini/fonts/zap-light-8x16.psf
 shell /ini/palettes/gruvbox-dark.sh
+read /ini/fonts/zap-light-8x16.psf =&gt; /dev/vga/font
 read /ini/banner.txt
 user login
 env TZ 7200


### PR DESCRIPTION
A new device in `/dev/vga/font` will allow setting the VGA font from userspace. After that we can deprecate the whole `vga` command and remove it in the next version of MOROS.