### PR TITLE
Add filetype syscall

### DIFF
--- a/doc/syscalls.md
+++ b/doc/syscalls.md
@@ -105,3 +105,9 @@ pub fn alloc(size: usize, align: usize) -> *mut u8
 ```rust
 pub fn free(ptr: *mut u8, size: usize, align: usize)
 ```
+
+## KIND (0x12)
+
+```rust
+pub fn kind(handle: usize) -> isize
+```

--- a/src/api/io.rs
+++ b/src/api/io.rs
@@ -1,4 +1,5 @@
 use crate::api::syscall;
+use crate::sys::fs::FileType;
 
 use alloc::string::{String, ToString};
 use alloc::vec;
@@ -65,4 +66,11 @@ pub fn stdout() -> Stdout {
 
 pub fn stderr() -> Stderr {
     Stderr::new()
+}
+
+pub fn is_redirected(handle: usize) -> bool {
+    match syscall::kind(handle) {
+        Some(FileType::File) => true,
+        _ => false,
+    }
 }

--- a/src/api/syscall.rs
+++ b/src/api/syscall.rs
@@ -1,9 +1,10 @@
 use crate::api::fs::IO;
 use crate::api::process::ExitCode;
-use crate::sys::fs::FileInfo;
+use crate::sys::fs::{FileInfo, FileType};
 use crate::sys::syscall::number::*;
 use crate::syscall;
 
+use core::convert::TryFrom;
 use smoltcp::wire::IpAddress;
 use smoltcp::wire::Ipv4Address;
 
@@ -34,6 +35,15 @@ pub fn info(path: &str) -> Option<FileInfo> {
     let res = unsafe { syscall!(INFO, path_ptr, path_len, stat_ptr) } as isize;
     if res >= 0 {
         Some(info)
+    } else {
+        None
+    }
+}
+
+pub fn kind(handle: usize) -> Option<FileType> {
+    let res = unsafe { syscall!(KIND, handle) } as isize;
+    if res >= 0 {
+        FileType::try_from(res as usize).ok()
     } else {
         None
     }

--- a/src/sys/fs/dir_entry.rs
+++ b/src/sys/fs/dir_entry.rs
@@ -180,13 +180,7 @@ impl FileInfo {
 
 impl From<&[u8]> for FileInfo {
     fn from(buf: &[u8]) -> Self {
-        let kind = match buf[0] {
-            // TODO: Add FileType::from(u8)
-            0 => FileType::Dir,
-            1 => FileType::File,
-            2 => FileType::Device,
-            _ => panic!(),
-        };
+        let kind = (buf[0] as usize).try_into().unwrap();
         let size = u32::from_be_bytes(buf[1..5].try_into().unwrap());
         let time = u64::from_be_bytes(buf[5..13].try_into().unwrap());
         let i = 14 + buf[13] as usize;

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -123,6 +123,16 @@ pub enum Resource {
     Device(Device),
 }
 
+impl Resource {
+    pub fn kind(&self) -> FileType {
+        match self {
+            Resource::Dir(_) => FileType::Dir,
+            Resource::File(_) => FileType::File,
+            Resource::Device(_) => FileType::Device,
+        }
+    }
+}
+
 impl FileIO for Resource {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
         match self {

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -25,6 +25,7 @@ use dir_entry::DirEntry;
 use super_block::SuperBlock;
 
 use alloc::string::{String, ToString};
+use core::convert::TryFrom;
 
 pub const VERSION: u8 = 2;
 
@@ -100,6 +101,19 @@ pub enum FileType {
     Dir = 0,
     File = 1,
     Device = 2,
+}
+
+impl TryFrom<usize> for FileType {
+    type Error = ();
+
+    fn try_from(num: usize) -> Result<Self, Self::Error> {
+        match num {
+             0 => Ok(FileType::Dir),
+             1 => Ok(FileType::File),
+             2 => Ok(FileType::Device),
+             _ => Err(()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sys/syscall/mod.rs
+++ b/src/sys/syscall/mod.rs
@@ -42,6 +42,10 @@ pub fn dispatcher(
             let info = unsafe { &mut *(arg3 as *mut FileInfo) };
             service::info(path, info) as usize
         }
+        number::KIND => {
+            let handle = arg1;
+            service::kind(handle) as usize
+        }
         number::OPEN => {
             let ptr = sys::process::ptr_from_addr(arg1 as u64);
             let len = arg2;

--- a/src/sys/syscall/number.rs
+++ b/src/sys/syscall/number.rs
@@ -15,3 +15,4 @@ pub const LISTEN:  usize = 0xE;
 pub const ACCEPT:  usize = 0xF;
 pub const ALLOC:   usize = 0x10;
 pub const FREE:    usize = 0x11;
+pub const KIND:    usize = 0x12;

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -41,6 +41,14 @@ pub fn info(path: &str, info: &mut FileInfo) -> isize {
     }
 }
 
+pub fn kind(handle: usize) -> isize {
+    if let Some(file) = sys::process::handle(handle) {
+        file.kind() as isize
+    } else {
+        -1
+    }
+}
+
 pub fn open(path: &str, flags: usize) -> isize {
     let path = match sys::fs::canonicalize(path) {
         Ok(path) => path,

--- a/www/syscalls.html
+++ b/www/syscalls.html
@@ -96,6 +96,11 @@
 
     <pre><code class="rust">pub fn free(ptr: *mut u8, size: usize, align: usize)
 </code></pre>
+
+    <h2>KIND (0x12)</h2>
+
+    <pre><code class="rust">pub fn kind(handle: usize) -&gt; isize
+</code></pre>
   <footer><p><a href="/">MOROS</a></footer>
   </body>
 </html>


### PR DESCRIPTION
This will add a new `KIND` syscall to get the `FileType` of a file handle. It will be used to detect IO redirections and allow some commands to disable colors when their output is redirected to a file.