### PR TITLE
Update hash command

### DIFF
--- a/src/usr/hash.rs
+++ b/src/usr/hash.rs
@@ -35,7 +35,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 help();
                 return Ok(());
             }
-            "--color" => {
+            "-c" | "--color" => {
                 conf.color = true;
             }
             "-s" | "--short" => {


### PR DESCRIPTION
The `hash` command can make use of #655 to display more abbreviated hashes on the console and the full hashes when redirected to a file. The command line options have to be modified to allow this change.