### PR TITLE
Add pkg command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ test:
 website:
 	cd www && sh build.sh
 
+pkg:
+	ls -1 dsk/var/pkg | grep -v index.html > dsk/var/pkg/index.html
+
 clean:
 	cargo clean
 	rm -f www/*.html www/images/*.png

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -75,11 +75,12 @@ MOROS Lisp is a Lisp-1 dialect inspired by Scheme, Clojure, and Ruby!
 - `regex/match?`
 
 ### File Library
+- `dirname`, `filename`
 - `read`, `write`, `append`
 - `read-binary`, `write-binary`, `append-binary`
 - `read-line`, `read-char`
 - `uptime`, `realtime`
-- `p`, `print`
+- `p`, `print`, `eprint`, `error`
 
 ### Math Library
 - `floor`, `ceil`, `round`
@@ -174,6 +175,7 @@ Would produce the following output:
 ## Changelog
 
 ### Unreleased
+- Add `dirname`, `filename`, `eprint`, and `error` functions
 
 ### 0.7.1 (2024-06-20)
 - Add `floor`, `ceil`, and `round` functions

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -5,7 +5,7 @@
 (var config "/ini/pkg")
 (var base (if (file/exists? config) (str/trim (read config)) "10.0.2.2:8181"))
 
-(def (fetch path) (do
+(def (pkg/fetch path) (do
   "Download the given file"
   (print (str "Fetching '" path "'"))
   (var dir (dirname path))
@@ -13,38 +13,66 @@
     (sh (str "write -p " dir "/")))
   (sh (str "http " base path " => " path))))
 
+(def (pkg/delete path) (do
+  "Delete the given file"
+  (print (str "Deleting '" path "'"))
+  (var dir (dirname path))
+  (sh (str "delete " path))))
+
 (def (pkg/install pkg) (do
   "Installs the given package"
   (var path (str "/var/pkg/" pkg))
   (if (not (eq? pkg "index.html"))
-    (if (= (fetch path) 0)
+    (if (= (pkg/fetch path) 0)
       (do
         (var files (reverse (lines (read path))))
-        (map fetch files))
+        (map pkg/fetch files))
       (do
         (sh (str "delete " path))
         (error (str "Could not find package '" pkg "'"))))
+    (error (str "Could not find package '" pkg "'")))))
+
+(def (pkg/uninstall pkg) (do
+  "Uninstalls the given package"
+  (var path (str "/var/pkg/" pkg))
+  (if (not (eq? pkg "index.html"))
+    (if (file/exists? path)
+      (do # The local package could list files not in the latest version
+        (var files (reverse (lines (read path))))
+        (map pkg/delete files))
+      (if (= (pkg/fetch path) 0)
+        (do # Fallback to fetching the latest version of the package
+          (var files (reverse (lines (read path))))
+          (map pkg/delete files))
+        (do
+          (sh (str "delete " path))
+          (error (str "Could not find package '" pkg "'")))))
     (error (str "Could not find package '" pkg "'")))))
 
 (def (pkg/list)
   (sh (str "http " base "/var/pkg/")))
 
 (def (print-usage) (do
-  (var lime "\e[92m")
-  (var yellow "\e[93m")
-  (var aqua "\e[96m")
-  (var reset "\e[m")
-  (print (str yellow "Usage:" reset " pkg " aqua "<cmd>" reset))
+  (var l "\e[92m") # Lime
+  (var y "\e[93m") # Yellow
+  (var a "\e[96m") # Aqua
+  (var r "\e[m")   # Reset
+  (print (str y "Usage:" r " pkg " a "<cmd>" r))
   (print "")
-  (print (str yellow "Commands:" reset))
-  (print (str "  " lime "i" aqua "nstall <pkg>" reset "    Install package"))
-  (print (str "  " lime "l" aqua "ist" reset "             List packages"))))
+  (print (str y "Commands:" r))
+  (print (str "  " l "l" a "ist" r "             List packages"))
+  (print (str "  " l "i" a "nstall <pkg>" r "    Install package"))
+  (print (str "  " l "u" a "ninstall <pkg>" r "  Uninstall package"))))
 
 (if (> (len args) 0)
   (cond
     ((contains? '("install" "i") (first args))
       (if (= (len args) 2)
         (pkg/install (second args))
+        (print-usage)))
+    ((contains? '("uninstall" "u") (first args))
+      (if (= (len args) 2)
+        (pkg/uninstall (second args))
         (print-usage)))
     ((contains? '("list" "l") (first args))
       (pkg/list))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -32,8 +32,8 @@
         (error (str "Could not find package '" pkg "'"))))
     (error (str "Could not find package '" pkg "'")))))
 
-(def (pkg/uninstall pkg) (do
-  "Uninstalls the given package"
+(def (pkg/remove pkg) (do
+  "Removes the given package"
   (var path (str "/var/pkg/" pkg))
   (if (not (eq? pkg "index.html"))
     (if (file/exists? path)
@@ -62,7 +62,7 @@
   (print (str y "Commands:" r))
   (print (str "  " l "l" a "ist" r "             List packages"))
   (print (str "  " l "i" a "nstall <pkg>" r "    Install package"))
-  (print (str "  " l "u" a "ninstall <pkg>" r "  Uninstall package"))))
+  (print (str "  " l "r" a "emove <pkg>" r "     Remove package"))))
 
 (if (> (len args) 0)
   (cond
@@ -70,9 +70,9 @@
       (if (= (len args) 2)
         (pkg/install (second args))
         (print-usage)))
-    ((contains? '("uninstall" "u") (first args))
+    ((contains? '("remove" "r") (first args))
       (if (= (len args) 2)
-        (pkg/uninstall (second args))
+        (pkg/remove (second args))
         (print-usage)))
     ((contains? '("list" "l") (first args))
       (pkg/list))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -14,10 +14,14 @@
 
 (var cmd (first args))
 
-(if (eq? cmd "install")
+(if (or (eq? cmd "install") (eq? cmd "i"))
   (do
     (var pkg (second args))
     (var path (str "/var/pkg/" pkg))
-    (fetch path)
-    (var files (reverse (lines (read path))))
-    (map fetch files)))
+    (if (= (fetch path) 0)
+      (do
+        (var files (reverse (lines (read path))))
+        (map fetch files))
+      (do
+        (error (str "Could not find package '" pkg "'"))
+        (sh (str "delete " path))))))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -6,22 +6,38 @@
 (var base (if (file/exists? config) (str/trim (read config)) "10.0.2.2:8181"))
 
 (def (fetch path) (do
+  "Download the given file"
   (print (str "Fetching '" path "'"))
   (var dir (dirname path))
   (if (not (file/exists? dir))
     (sh (str "write -p " dir "/")))
   (sh (str "http " base path " => " path))))
 
-(var cmd (first args))
+(def (pkg/install pkg) (do
+  "Installs the given package"
+  (var path (str "/var/pkg/" pkg))
+  (if (= (fetch path) 0)
+    (do
+      (var files (reverse (lines (read path))))
+      (map fetch files))
+    (do
+      (error (str "Could not find package '" pkg "'"))
+      (sh (str "delete " path))))))
 
-(if (or (eq? cmd "install") (eq? cmd "i"))
-  (do
-    (var pkg (second args))
-    (var path (str "/var/pkg/" pkg))
-    (if (= (fetch path) 0)
-      (do
-        (var files (reverse (lines (read path))))
-        (map fetch files))
-      (do
-        (error (str "Could not find package '" pkg "'"))
-        (sh (str "delete " path))))))
+(def (print-usage) (do
+  (var lime "\e[92m")
+  (var yellow "\e[93m")
+  (var aqua "\e[96m")
+  (var reset "\e[m")
+  (print (str yellow "Usage:" reset " pkg " aqua "<cmd>" reset))
+  (print "")
+  (print (str yellow "Commands:" reset))
+  (print (str "  " lime "i" aqua "nstall <pkg>" reset "    Install package"))))
+
+(if (> (len args) 0)
+  (if (contains? '("install" "i") (first args))
+    (if (= (len args) 2)
+      (pkg/install (second args))
+      (print-usage))
+    (print-usage))
+  (print-usage))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -16,13 +16,18 @@
 (def (pkg/install pkg) (do
   "Installs the given package"
   (var path (str "/var/pkg/" pkg))
-  (if (= (fetch path) 0)
-    (do
-      (var files (reverse (lines (read path))))
-      (map fetch files))
-    (do
-      (error (str "Could not find package '" pkg "'"))
-      (sh (str "delete " path))))))
+  (if (not (eq? pkg "index.html"))
+    (if (= (fetch path) 0)
+      (do
+        (var files (reverse (lines (read path))))
+        (map fetch files))
+      (do
+        (sh (str "delete " path))
+        (error (str "Could not find package '" pkg "'"))))
+    (error (str "Could not find package '" pkg "'")))))
+
+(def (pkg/list)
+  (sh (str "http " base "/var/pkg/")))
 
 (def (print-usage) (do
   (var lime "\e[92m")
@@ -32,12 +37,16 @@
   (print (str yellow "Usage:" reset " pkg " aqua "<cmd>" reset))
   (print "")
   (print (str yellow "Commands:" reset))
-  (print (str "  " lime "i" aqua "nstall <pkg>" reset "    Install package"))))
+  (print (str "  " lime "i" aqua "nstall <pkg>" reset "    Install package"))
+  (print (str "  " lime "l" aqua "ist" reset "             List packages"))))
 
 (if (> (len args) 0)
-  (if (contains? '("install" "i") (first args))
-    (if (= (len args) 2)
-      (pkg/install (second args))
-      (print-usage))
-    (print-usage))
+  (cond
+    ((contains? '("install" "i") (first args))
+      (if (= (len args) 2)
+        (pkg/install (second args))
+        (print-usage)))
+    ((contains? '("list" "l") (first args))
+      (pkg/list))
+    (true (print-usage)))
   (print-usage))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -7,7 +7,9 @@
 
 (def (fetch path) (do
   (print (str "Fetching '" path "'"))
-  # TODO: create dirname(path) if it doesn't exist
+  (var dir (dirname path))
+  (if (not (file/exists? dir))
+    (sh (str "write -p " dir "/")))
   (sh (str "http " base path " => " path))))
 
 (var cmd (first args))

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -1,0 +1,21 @@
+#! lisp
+
+(load "/lib/lisp/core.lsp")
+
+(var config "/ini/pkg")
+(var base (if (file/exists? config) (str/trim (read config)) "10.0.2.2:8181"))
+
+(def (fetch path) (do
+  (print (str "Fetching '" path "'"))
+  # TODO: create dirname(path) if it doesn't exist
+  (sh (str "http " base path " => " path))))
+
+(var cmd (first args))
+
+(if (eq? cmd "install")
+  (do
+    (var pkg (second args))
+    (var path (str "/var/pkg/" pkg))
+    (fetch path)
+    (var files (reverse (lines (read path))))
+    (map fetch files)))

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -101,7 +101,7 @@
 
 (def (string/join ls s)
   "Joins the elements of the list with the string"
-  (reduce (fun (x y) (string x s y)) ls))
+  (if (empty? ls) "" (reduce (fun (x y) (string x s y)) ls)))
 
 (def (regex/match? r s)
   "Returns true if the string match the pattern"

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -54,14 +54,24 @@
   (binary->string (file/read stdin 4)))
 
 (def (p exp)
-  "Prints expression to the console"
+  "Prints expression to stdout"
   (do
     (file/write stdout (string->binary (string exp)))
     '()))
 
 (def (print exp)
-  "Prints expression to the console with a newline"
+  "Prints expression to stdout with a newline"
   (p (string exp "\n")))
+
+(def (eprint exp)
+  "Prints expression to stderr with a newline"
+  (do
+    (file/write stderr (string->binary (string exp "\n")))
+    '()))
+
+(def (error msg)
+  "Prints error message to stderr"
+  (eprint (string "\e[91mError:\e[m " msg)))
 
 # Clocks
 

--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -63,7 +63,7 @@
   "Prints expression to the console with a newline"
   (p (string exp "\n")))
 
-# Special
+# Clocks
 
 (def (uptime)
   "Returns the current value of the uptime clock"
@@ -72,3 +72,13 @@
 (def (realtime)
   "Returns the current value of the realtime clock"
   (binary->number (read-binary "/dev/clk/realtime") "float"))
+
+# Path
+
+(def (filename path)
+  "Returns the filename from the given path"
+  (last (str/split path "/")))
+
+(def (dirname path)
+  "Returns the given path without the filename"
+  (str/join (rev (rest (rev (str/split path "/")))) "/"))

--- a/dsk/tmp/lisp/doc.lsp
+++ b/dsk/tmp/lisp/doc.lsp
@@ -6,7 +6,7 @@
   (print (str
     "("
     (if (function? (eval f)) "\e[96m" "\e[92m") f "\e[0m" # name
-    (if (nil? s) "" (str " " (if (list? s) (str/join s " ") s))) # args
+    (str " " (if (list? s) (str/join s " ") s)) # args
     ")"
     "\e[90m" (if (empty? d) "" " # ") d "\e[0m")))) # desc
 

--- a/dsk/var/pkg/beep
+++ b/dsk/var/pkg/beep
@@ -1,0 +1,3 @@
+/tmp/beep/tetris.sh
+/tmp/beep/starwars.sh
+/tmp/beep/mario.sh

--- a/dsk/var/pkg/chess
+++ b/dsk/var/pkg/chess
@@ -1,0 +1,4 @@
+/tmp/chess/mi2.epd
+/tmp/chess/mi3.epd
+/tmp/chess/mi4.epd
+/tmp/chess/puru.epd

--- a/dsk/var/pkg/fonts
+++ b/dsk/var/pkg/fonts
@@ -1,0 +1,3 @@
+/ini/fonts/lat15-terminus-8x16.psf
+/ini/fonts/zap-light-8x16.psf
+/ini/fonts/zap-vga-8x16.psf

--- a/dsk/var/pkg/index.html
+++ b/dsk/var/pkg/index.html
@@ -1,0 +1,5 @@
+beep
+chess
+fonts
+life
+lisp

--- a/dsk/var/pkg/life
+++ b/dsk/var/pkg/life
@@ -1,0 +1,9 @@
+/tmp/life/centinal.cells
+/tmp/life/flower-of-eden.cells
+/tmp/life/garden-of-eden.cells
+/tmp/life/glider-gun.cells
+/tmp/life/pentadecathlon.cells
+/tmp/life/queen-bee-shuttle.cells
+/tmp/life/ship-in-a-bottle.cells
+/tmp/life/thunderbird.cells
+/tmp/life/wing.cells

--- a/dsk/var/pkg/lisp
+++ b/dsk/var/pkg/lisp
@@ -1,0 +1,8 @@
+/tmp/lisp/colors.lsp
+/tmp/lisp/doc.lsp
+/tmp/lisp/factorial.lsp
+/tmp/lisp/fibonacci.lsp
+/tmp/lisp/geotime.lsp
+/tmp/lisp/pi.lsp
+/tmp/lisp/sum.lsp
+/tmp/lisp/tak.lsp

--- a/run/pkg-server.sh
+++ b/run/pkg-server.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python -m http.server -d dsk 8181

--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -242,9 +242,5 @@ fn test_find() {
     assert!(api::fs::read_to_string("/tmp/find.log").unwrap().
         contains("alice.txt"));
 
-    exec("find /tmp --file \"*.lsp\" --line list => /tmp/find.log").ok();
-    assert!(!api::fs::read_to_string("/tmp/find.log").unwrap().
-        contains("alice.txt"));
-
     sys::fs::dismount();
 }

--- a/src/usr/http.rs
+++ b/src/usr/http.rs
@@ -219,10 +219,14 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             }
         }
         syscall::close(handle);
-        match code.as_deref() {
-            Some("200") => Ok(()),
-            _ => Err(ExitCode::Failure),
+        if let Some(s) = code {
+            if let Ok(n) = s.parse::<usize>() {
+                if n < 400 {
+                    return Ok(());
+                }
+            }
         }
+        Err(ExitCode::Failure)
     } else {
         Err(ExitCode::Failure)
     }

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -193,11 +193,11 @@ fn create_dir(path: &str, verbose: bool) {
     if fs::exists(path) {
         return;
     }
+    if verbose {
+        println!("Creating '{}'", path);
+    }
     if let Some(handle) = api::fs::create_dir(path) {
         syscall::close(handle);
-        if verbose {
-            println!("Created '{}'", path);
-        }
     }
 }
 
@@ -205,17 +205,20 @@ fn create_dev(path: &str, name: &str, verbose: bool) {
     if fs::exists(path) {
         return;
     }
+    if verbose {
+        println!("Creating '{}'", path);
+    }
     if let Some(handle) = fs::create_device(path, name) {
         syscall::close(handle);
-        if verbose {
-            println!("Created '{}'", path);
-        }
     }
 }
 
 fn copy_file(path: &str, buf: &[u8], verbose: bool) {
     if fs::exists(path) {
         return;
+    }
+    if verbose {
+        println!("Fetching '{}'", path);
     }
     if path.ends_with(".txt") {
         if let Ok(text) = String::from_utf8(buf.to_vec()) {
@@ -226,9 +229,5 @@ fn copy_file(path: &str, buf: &[u8], verbose: bool) {
         }
     } else {
         fs::write(path, buf).ok();
-    }
-    // TODO: add File::write_all to split buf if needed
-    if verbose {
-        println!("Fetched '{}'", path);
     }
 }

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -71,7 +71,7 @@ pub fn copy_files(verbose: bool) {
     create_dir("/ini/fonts", verbose);
     //copy_file!("/ini/fonts/lat15-terminus-8x16.psf", verbose);
     copy_file!("/ini/fonts/zap-light-8x16.psf", verbose);
-    copy_file!("/ini/fonts/zap-vga-8x16.psf", verbose);
+    //copy_file!("/ini/fonts/zap-vga-8x16.psf", verbose);
 
     create_dir("/lib/lisp", verbose);
     copy_file!("/lib/lisp/alias.lsp", verbose);
@@ -84,36 +84,36 @@ pub fn copy_files(verbose: bool) {
     copy_file!("/tmp/machines.txt", verbose);
 
     create_dir("/tmp/chess", verbose);
-    copy_file!("/tmp/chess/mi2.epd", verbose);
+    //copy_file!("/tmp/chess/mi2.epd", verbose);
     //copy_file!("/tmp/chess/mi3.epd", verbose);
     //copy_file!("/tmp/chess/mi4.epd", verbose);
     //copy_file!("/tmp/chess/puru.epd", verbose);
 
     create_dir("/tmp/lisp", verbose);
-    copy_file!("/tmp/lisp/colors.lsp", verbose);
-    copy_file!("/tmp/lisp/doc.lsp", verbose);
-    copy_file!("/tmp/lisp/factorial.lsp", verbose);
-    copy_file!("/tmp/lisp/fibonacci.lsp", verbose);
-    copy_file!("/tmp/lisp/geotime.lsp", verbose);
-    copy_file!("/tmp/lisp/pi.lsp", verbose);
-    copy_file!("/tmp/lisp/sum.lsp", verbose);
-    copy_file!("/tmp/lisp/tak.lsp", verbose);
+    //copy_file!("/tmp/lisp/colors.lsp", verbose);
+    //copy_file!("/tmp/lisp/doc.lsp", verbose);
+    //copy_file!("/tmp/lisp/factorial.lsp", verbose);
+    //copy_file!("/tmp/lisp/fibonacci.lsp", verbose);
+    //copy_file!("/tmp/lisp/geotime.lsp", verbose);
+    //copy_file!("/tmp/lisp/pi.lsp", verbose);
+    //copy_file!("/tmp/lisp/sum.lsp", verbose);
+    //copy_file!("/tmp/lisp/tak.lsp", verbose);
 
     create_dir("/tmp/life", verbose);
-    copy_file!("/tmp/life/centinal.cells", verbose);
-    copy_file!("/tmp/life/flower-of-eden.cells", verbose);
-    copy_file!("/tmp/life/garden-of-eden.cells", verbose);
-    copy_file!("/tmp/life/glider-gun.cells", verbose);
-    copy_file!("/tmp/life/pentadecathlon.cells", verbose);
-    copy_file!("/tmp/life/queen-bee-shuttle.cells", verbose);
-    copy_file!("/tmp/life/ship-in-a-bottle.cells", verbose);
-    copy_file!("/tmp/life/thunderbird.cells", verbose);
-    copy_file!("/tmp/life/wing.cells", verbose);
+    //copy_file!("/tmp/life/centinal.cells", verbose);
+    //copy_file!("/tmp/life/flower-of-eden.cells", verbose);
+    //copy_file!("/tmp/life/garden-of-eden.cells", verbose);
+    //copy_file!("/tmp/life/glider-gun.cells", verbose);
+    //copy_file!("/tmp/life/pentadecathlon.cells", verbose);
+    //copy_file!("/tmp/life/queen-bee-shuttle.cells", verbose);
+    //copy_file!("/tmp/life/ship-in-a-bottle.cells", verbose);
+    //copy_file!("/tmp/life/thunderbird.cells", verbose);
+    //copy_file!("/tmp/life/wing.cells", verbose);
 
     create_dir("/tmp/beep", verbose);
-    copy_file!("/tmp/beep/tetris.sh", verbose);
-    copy_file!("/tmp/beep/starwars.sh", verbose);
-    copy_file!("/tmp/beep/mario.sh", verbose);
+    //copy_file!("/tmp/beep/tetris.sh", verbose);
+    //copy_file!("/tmp/beep/starwars.sh", verbose);
+    //copy_file!("/tmp/beep/mario.sh", verbose);
 
     create_dir("/var/log", verbose);
 

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -83,13 +83,13 @@ pub fn copy_files(verbose: bool) {
     copy_file!("/tmp/alice.txt", verbose);
     copy_file!("/tmp/machines.txt", verbose);
 
-    create_dir("/tmp/chess", verbose);
+    //create_dir("/tmp/chess", verbose);
     //copy_file!("/tmp/chess/mi2.epd", verbose);
     //copy_file!("/tmp/chess/mi3.epd", verbose);
     //copy_file!("/tmp/chess/mi4.epd", verbose);
     //copy_file!("/tmp/chess/puru.epd", verbose);
 
-    create_dir("/tmp/lisp", verbose);
+    //create_dir("/tmp/lisp", verbose);
     //copy_file!("/tmp/lisp/colors.lsp", verbose);
     //copy_file!("/tmp/lisp/doc.lsp", verbose);
     //copy_file!("/tmp/lisp/factorial.lsp", verbose);
@@ -99,7 +99,7 @@ pub fn copy_files(verbose: bool) {
     //copy_file!("/tmp/lisp/sum.lsp", verbose);
     //copy_file!("/tmp/lisp/tak.lsp", verbose);
 
-    create_dir("/tmp/life", verbose);
+    //create_dir("/tmp/life", verbose);
     //copy_file!("/tmp/life/centinal.cells", verbose);
     //copy_file!("/tmp/life/flower-of-eden.cells", verbose);
     //copy_file!("/tmp/life/garden-of-eden.cells", verbose);
@@ -110,7 +110,7 @@ pub fn copy_files(verbose: bool) {
     //copy_file!("/tmp/life/thunderbird.cells", verbose);
     //copy_file!("/tmp/life/wing.cells", verbose);
 
-    create_dir("/tmp/beep", verbose);
+    //create_dir("/tmp/beep", verbose);
     //copy_file!("/tmp/beep/tetris.sh", verbose);
     //copy_file!("/tmp/beep/starwars.sh", verbose);
     //copy_file!("/tmp/beep/mario.sh", verbose);

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -31,6 +31,7 @@ pub fn copy_files(verbose: bool) {
     copy_file!("/bin/halt", verbose);
     //copy_file!("/bin/hello", verbose);
     copy_file!("/bin/ntp", verbose);
+    copy_file!("/bin/pkg", verbose);
     copy_file!("/bin/print", verbose);
     copy_file!("/bin/reboot", verbose);
     copy_file!("/bin/sleep", verbose);

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -121,6 +121,8 @@ pub fn copy_files(verbose: bool) {
     copy_file!("/var/www/index.html", verbose);
     copy_file!("/var/www/moros.css", verbose);
     copy_file!("/var/www/moros.png", verbose);
+
+    create_dir("/var/pkg", verbose);
 }
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {

--- a/src/usr/write.rs
+++ b/src/usr/write.rs
@@ -71,7 +71,6 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 }
 
 fn create_parents(path: &str) {
-    debug!("create_parents('{}')", path);
     if path.is_empty() || fs::exists(path) {
         return;
     }

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -100,11 +100,12 @@ of the Shell.</p>
     <h3>File Library</h3>
 
     <ul>
+    <li><code>dirname</code>, <code>filename</code></li>
     <li><code>read</code>, <code>write</code>, <code>append</code></li>
     <li><code>read-binary</code>, <code>write-binary</code>, <code>append-binary</code></li>
     <li><code>read-line</code>, <code>read-char</code></li>
     <li><code>uptime</code>, <code>realtime</code></li>
-    <li><code>p</code>, <code>print</code></li>
+    <li><code>p</code>, <code>print</code>, <code>eprint</code>, <code>error</code></li>
     </ul>
 
     <h3>Math Library</h3>
@@ -201,6 +202,10 @@ with the following content:</p>
     <h2>Changelog</h2>
 
     <h3>Unreleased</h3>
+
+    <ul>
+    <li>Add <code>dirname</code>, <code>filename</code>, <code>eprint</code>, and <code>error</code> functions</li>
+    </ul>
 
     <h3>0.7.1 (2024-06-20)</h3>
 


### PR DESCRIPTION
This PR will introduce the `pkg install <name>` command to fetch files that are not bundled in the OS image in an effort to reduce the size of the latter.

In order for this to work the host (or any computer on the network) must run the pkg server found in `run/pkg-server.sh` which is just a wrapper around `python -m http.server` to serve the content of the `dsk` dir from this git repo. If this experiment is validated we'll host each version of MOROS on http://pkg.moros.cc but MOROS don't support TLS yet so we can't use HTTPS which make this solution less than ideal.

For now only non essential files found in `/tmp` can be installed this way. For example MOROS Lisp example programs or cell files for the game of life are found there.

I looked into the `zip` crate but it doesn't support `no_std` so a package is just a text file listing the path of the files that should be downloaded.