### PR TITLE
Add write --parents option

### DIFF
--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -23,16 +23,25 @@ pub trait FileIO {
 }
 
 pub fn dirname(pathname: &str) -> &str {
-    let n = pathname.len();
+    let pathname = if pathname.len() > 1 {
+        pathname.trim_end_matches('/')
+    } else {
+        pathname
+    };
     let i = match pathname.rfind('/') {
         Some(0) => 1,
         Some(i) => i,
-        None => n,
+        None => return "",
     };
     &pathname[0..i]
 }
 
 pub fn filename(pathname: &str) -> &str {
+    let pathname = if pathname.len() > 1 {
+        pathname.trim_end_matches('/')
+    } else {
+        pathname
+    };
     let n = pathname.len();
     let i = match pathname.rfind('/') {
         Some(i) => i + 1,
@@ -265,6 +274,23 @@ fn test_filename() {
     assert_eq!(filename("/path/to/file.txt"), "file.txt");
     assert_eq!(filename("/file.txt"), "file.txt");
     assert_eq!(filename("file.txt"), "file.txt");
+    assert_eq!(filename("/path/to/"), "to");
+    assert_eq!(filename("/path/to"), "to");
+    assert_eq!(filename("path/to"), "to");
+    assert_eq!(filename("/"), "");
+    assert_eq!(filename(""), "");
+}
+
+#[test_case]
+fn test_dirname() {
+    assert_eq!(dirname("/path/to/file.txt"), "/path/to");
+    assert_eq!(dirname("/file.txt"), "/");
+    assert_eq!(dirname("file.txt"), "");
+    assert_eq!(dirname("/path/to/"), "/path");
+    assert_eq!(dirname("/path/to"), "/path");
+    assert_eq!(dirname("path/to"), "path");
+    assert_eq!(dirname("/"), "/");
+    assert_eq!(dirname(""), "");
 }
 
 #[test_case]

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -72,9 +72,14 @@ fn shell_completer(line: &str) -> Vec<String> {
     }
 
     // Autocomplete path
-    let pathname = fs::realpath(&args[i]);
-    let dirname = fs::dirname(&pathname);
-    let filename = fs::filename(&pathname);
+    let path = fs::realpath(&args[i]);
+    let (dirname, filename) = if path.len() > 1 && path.ends_with('/') {
+        // List files in dir (/path/to/ -> /path/to/file.txt)
+        (path.trim_end_matches('/'), "")
+    } else {
+        // List matching files (/path/to/fi -> /path/to/file.txt)
+        (fs::dirname(&path), fs::filename(&path))
+    };
     let sep = if dirname.ends_with('/') { "" } else { "/" };
     if let Ok(files) = fs::read_dir(dirname) {
         for file in files {
@@ -88,8 +93,8 @@ fn shell_completer(line: &str) -> Vec<String> {
                 } else {
                     ""
                 };
-                let path = format!("{}{}{}{}", dirname, sep, name, end);
-                entries.push(path[pathname.len()..].into());
+                let entry = format!("{}{}{}{}", dirname, sep, name, end);
+                entries.push(entry[path.len()..].into());
             }
         }
     }

--- a/src/usr/write.rs
+++ b/src/usr/write.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let mut opt = Vec::new();
+    let mut parents = false;
     let mut dev = None;
     let mut i = 1;
     let n = args.len();
@@ -15,6 +16,9 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             "-h" | "--help" => {
                 help();
                 return Ok(());
+            }
+            "-p" | "--parents" => {
+                parents = true
             }
             "-d" | "--dev" => {
                 if i + 1 < n {
@@ -40,6 +44,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         return Err(ExitCode::Failure);
     }
 
+    if parents {
+        create_parents(fs::dirname(path.trim_end_matches('/')));
+    }
+
     // The command `write /usr/alice/` with a trailing slash will create
     // a directory, while the same command without a trailing slash will
     // create a file.
@@ -62,13 +70,32 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     }
 }
 
+fn create_parents(path: &str) {
+    debug!("create_parents('{}')", path);
+    if path.is_empty() || fs::exists(path) {
+        return;
+    }
+    create_parents(fs::dirname(path));
+    fs::create_dir(path);
+}
+
 fn help() {
     let csi_option = Style::color("aqua");
     let csi_title = Style::color("yellow");
     let csi_reset = Style::reset();
     println!(
-        "{}Usage:{} write {}<path>{}",
-        csi_title, csi_reset, csi_option, csi_reset
+        "{}Usage:{} write {}<options> <path>{1}",
+        csi_title, csi_reset, csi_option
+    );
+    println!();
+    println!("{}Options:{}", csi_title, csi_reset);
+    println!(
+        "  {0}-d{1}, {0}--device <type>{1}   {2}",
+        csi_option, csi_reset, "Set device type"
+    );
+    println!(
+        "  {0}-p{1}, {0}--parents{1}         {2}",
+        csi_option, csi_reset, "Create parent directories as needed"
     );
     println!();
     println!("{}Paths:{}", csi_title, csi_reset);


### PR DESCRIPTION
Add a new `--parents` option (shortened to `-p`) to the command `write` to create parent directories if needed:

    > write -p path/to/file.txt

Will create `file.txt` in `path/to` even if the parent directories didn't exist before.

The function `api::fs::dirname` had to be fixed to avoid an infinite loop in `write` because `dirname("path")` would return `"path"` instead of `""`. Note that on Linux this would return `"."` but MOROS don't have this concept (yet). File autocompletion in the shell had to be changed to support the new behavior of dirname.