### PR TITLE
Improve option parsing

### DIFF
--- a/src/usr/find.rs
+++ b/src/usr/find.rs
@@ -59,7 +59,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                 }
             }
             _ => {
-                if path.is_empty() {
+                if args[i].starts_with('-') {
+                    error!("Invalid option '{}'", args[i]);
+                    return Err(ExitCode::UsageError);
+                } else if path.is_empty() {
                     path = args[i].into();
                 } else {
                     error!("Multiple paths not supported");

--- a/src/usr/hash.rs
+++ b/src/usr/hash.rs
@@ -49,7 +49,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             }
             arg => {
                 if arg.starts_with('-') {
-                    error!("Unknown option '{}'", arg);
+                    error!("Invalid option '{}'", arg);
                     return Err(ExitCode::UsageError);
                 }
                 paths.push(arg);

--- a/src/usr/life.rs
+++ b/src/usr/life.rs
@@ -215,7 +215,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             }
             arg => {
                 if arg.starts_with('-') {
-                    error!("Unknown option '{}'", arg);
+                    error!("Invalid option '{}'", arg);
                     return Err(ExitCode::UsageError);
                 }
                 if i > 0 {


### PR DESCRIPTION
- [x] Show an meaningful error when `find` is called with an invalid option
- [x] Align invalid option warning to always display the same error for every commands