### PR TITLE
Fix usage of CSI sequences for scrolling the scrollback buffer

### DIFF
--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -191,11 +191,11 @@ impl Prompt {
     }
 
     fn handle_page_up_key(&mut self) {
-        print!("\x1b[25S");
+        print!("\x1b[5~");
     }
 
     fn handle_page_down_key(&mut self) {
-        print!("\x1b[25T");
+        print!("\x1b[6~");
     }
 
     fn handle_forward_key(&mut self) {

--- a/src/sys/vga.rs
+++ b/src/sys/vga.rs
@@ -339,6 +339,16 @@ impl Writer {
         }
     }
 
+    fn scroll_up(&mut self, n: usize) {
+        self.scroll_reader = self.scroll_reader.saturating_sub(n);
+        self.scroll();
+    }
+
+    fn scroll_down(&mut self, n: usize) {
+        self.scroll_reader = cmp::min(self.scroll_reader + n, self.scroll_bottom - SCREEN_HEIGHT);
+        self.scroll();
+    }
+
     fn scroll(&mut self) {
         let dy = self.scroll_reader;
         for y in 0..SCREEN_HEIGHT {
@@ -500,22 +510,6 @@ impl Perform for Writer {
                 self.set_writer_position(x, y);
                 self.set_cursor_position(x, y);
             }
-            'S' => { // Scroll Up
-                let mut n = 0;
-                for param in params.iter() {
-                    n = param[0] as usize;
-                }
-                self.scroll_reader = self.scroll_reader.saturating_sub(n);
-                self.scroll();
-            }
-            'T' => { // Scroll Down
-                let mut n = 0;
-                for param in params.iter() {
-                    n = param[0] as usize;
-                }
-                self.scroll_reader = cmp::min(self.scroll_reader + n, self.scroll_bottom - SCREEN_HEIGHT);
-                self.scroll();
-            }
             'h' => { // Enable
                 for param in params.iter() {
                     match param[0] {
@@ -531,6 +525,15 @@ impl Perform for Writer {
                         12 => self.disable_echo(),
                         25 => self.disable_cursor(),
                         _ => return,
+                    }
+                }
+            }
+            '~' => {
+                for param in params.iter() {
+                    match param[0] {
+                        5 => self.scroll_up(SCREEN_HEIGHT),
+                        6 => self.scroll_down(SCREEN_HEIGHT),
+                        _ => continue,
                     }
                 }
             }


### PR DESCRIPTION
The ANSI control sequences for scrolling (`CSI n S` and `CSI n T`) were not designed for the scrollback buffer, using them affect the console when serial is used instead of VGA. Instead we can just send the `PAGE UP` and `PAGE DOWN` sequences and let the VGA driver interpret them.