### PR TITLE
Fix userspace heap address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ user-rust:
 		touch dsk/bin/{}
 	basename -s .rs src/bin/*.rs | xargs -I {} \
 		cargo rustc --no-default-features --features userspace --release --bin {}
+	cargo rustc --no-default-features --features userspace --release --bin hello -- -C linker-flavor=ld
+	cargo rustc --no-default-features --features userspace --release --bin exec -- -C linker-flavor=ld
 	basename -s .rs src/bin/*.rs | xargs -I {} \
 		cp target/x86_64-moros/release/{} dsk/bin/{}
 	basename -s .rs src/bin/*.rs | xargs -I {} \

--- a/dsk/var/pkg/exec
+++ b/dsk/var/pkg/exec
@@ -1,0 +1,1 @@
+/bin/exec

--- a/dsk/var/pkg/hello
+++ b/dsk/var/pkg/hello
@@ -1,0 +1,1 @@
+/bin/hello

--- a/src/bin/exec.rs
+++ b/src/bin/exec.rs
@@ -20,10 +20,9 @@ fn main(_args: &[&str]) {
         if cmd == "quit" {
             syscall::exit(process::ExitCode::Success);
         } else {
-            //let args: Vec<&str> = cmd.split(' ').collect();
-            let args = Vec::new();
+            let args: Vec<&str> = cmd.split(' ').collect();
             let mut path = String::from("/bin/");
-            path.push_str(cmd);
+            path.push_str(args[0]);
             let _ = process::spawn(&path, &args);
         }
     }

--- a/src/bin/hello.rs
+++ b/src/bin/hello.rs
@@ -11,17 +11,10 @@ entry_point!(main);
 
 fn main(args: &[&str]) {
     if args.len() > 1 {
-        syscall::write(1, args[1].as_bytes()); // FIXME: this is needed
-        syscall::write(1, "\n".as_bytes());
-
-        let mut hello = "Hello, ".to_string();
-        hello.push_str(args[1]); // FIXME: for that to work
-        hello.push_str("!\n");
-        syscall::write(1, hello.as_bytes());
-
-        if args.len() > 2 {
+        let n = args.len();
+        for i in 1..n {
             let mut hello = "Hello, ".to_string();
-            hello.push_str(args[2]); // FIXME: not working
+            hello.push_str(args[i]);
             hello.push_str("!\n");
             syscall::write(1, hello.as_bytes());
         }

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -460,7 +460,7 @@ impl Process {
         };
         let args_ptr = args.as_ptr() as u64;
 
-        let heap_addr = addr;
+        let heap_addr = addr + 4096;
         let heap_size = ((self.stack_addr - heap_addr) / 2) as usize;
         unsafe {
             self.allocator.lock().init(heap_addr as *mut u8, heap_size);


### PR DESCRIPTION
There was an issue with userspace alloc for a very long time when trying to push a program argument in a string allocated in userspace. The arguments are allocated just below the heap, turns out we needed to start the heap one page above.

Before we had to print an arg first (weird) to be able to push it to the string:

```
> hello alice bob
alice
Hello, alice!
Hello, !
```

Now we don't need to do that anymore:

```
> hello alice bob
alice
Hello, alice!
Hello, bob!
```

But we still need to use `ld` as a linker instead of `lld` to avoid another (weird) bug:

```
> hello.rust-lld alice bob
alice
DEBUG: Could not map Page[4KiB](0x207000) to PhysFrame[4KiB](0x15ba000)
DEBUG: Aleardy mapped to PhysFrame[4KiB](0x407000)
Error: Could not allocate address 0x207790
```

This address is the beginning of the `.bss` segment that is only present when the code need the userspace allocator.