### PR TITLE
Add special alloc_error_handler for userspace

### DIFF
--- a/src/api/allocator.rs
+++ b/src/api/allocator.rs
@@ -1,3 +1,5 @@
+use crate::hlt_loop;
+use crate::api::process::ExitCode;
 use crate::api::syscall;
 
 use core::alloc::{GlobalAlloc, Layout};
@@ -17,3 +19,11 @@ unsafe impl GlobalAlloc for UserspaceAllocator {
 #[allow(dead_code)]
 #[cfg_attr(feature = "userspace", global_allocator)]
 static ALLOCATOR: UserspaceAllocator = UserspaceAllocator;
+
+#[allow(dead_code)]
+#[cfg_attr(feature = "userspace", alloc_error_handler)]
+fn alloc_error_handler(_layout: alloc::alloc::Layout) -> ! {
+    syscall::write(2, b"\x1b[91mError:\x1b[m Could not allocate\n");
+    syscall::exit(ExitCode::PageFaultError);
+    hlt_loop();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub fn init(boot_info: &'static BootInfo) {
     sys::clock::init(); // Require MEM
 }
 
-#[alloc_error_handler]
+#[allow(dead_code)]
+#[cfg_attr(not(feature = "userspace"), alloc_error_handler)]
 fn alloc_error_handler(layout: alloc::alloc::Layout) -> ! {
     let csi_color = api::console::Style::color("red");
     let csi_reset = api::console::Style::reset();


### PR DESCRIPTION
Userspace programs need their own version of `alloc_error_handler` to avoid using kernel functions to print the error.

This was discovered here: https://github.com/vinc/moros/pull/304#issuecomment-2380636887