### PR TITLE
Fix shell autocomplete command path

### DIFF
--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -61,6 +61,10 @@ pub fn realpath(pathname: &str) -> String {
     }
 }
 
+pub fn is_absolute_path(path: &str) -> bool {
+    path.starts_with('/') || path.starts_with('~')
+}
+
 pub fn exists(path: &str) -> bool {
     syscall::info(path).is_some()
 }
@@ -291,6 +295,14 @@ fn test_dirname() {
     assert_eq!(dirname("path/to"), "path");
     assert_eq!(dirname("/"), "/");
     assert_eq!(dirname(""), "");
+}
+
+#[test_case]
+fn test_is_absolute_path() {
+    assert_eq!(is_absolute_path("/path/to/binary"), true);
+    assert_eq!(is_absolute_path("~/path/to/binary"), true);
+    assert_eq!(is_absolute_path("path/to/binary"), false);
+    assert_eq!(is_absolute_path("binary"), false);
 }
 
 #[test_case]

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -72,22 +72,24 @@ fn shell_completer(line: &str) -> Vec<String> {
     }
 
     // Autocomplete path
-    let path = fs::realpath(&args[i]);
-    let (dirname, filename) = if path.len() > 1 && path.ends_with('/') {
-        // List files in dir (/path/to/ -> /path/to/file.txt)
-        (path.trim_end_matches('/'), "")
-    } else {
-        // List matching files (/path/to/fi -> /path/to/file.txt)
-        (fs::dirname(&path), fs::filename(&path))
-    };
-    let sep = if dirname.ends_with('/') { "" } else { "/" };
-    if let Ok(files) = fs::read_dir(dirname) {
-        for file in files {
-            let name = file.name();
-            if name.starts_with(filename) {
-                let end = if file.is_dir() { "/" } else { "" };
-                let entry = format!("{}{}{}{}", dirname, sep, name, end);
-                entries.push(entry[path.len()..].into());
+    if (i == 0 && fs::is_absolute_path(&args[i])) || i > 0 {
+        let path = fs::realpath(&args[i]);
+        let (dirname, filename) = if path.len() > 1 && path.ends_with('/') {
+            // List files in dir (/path/to/ -> /path/to/file.txt)
+            (path.trim_end_matches('/'), "")
+        } else {
+            // List matching files (/path/to/fi -> /path/to/file.txt)
+            (fs::dirname(&path), fs::filename(&path))
+        };
+        let sep = if dirname.ends_with('/') { "" } else { "/" };
+        if let Ok(files) = fs::read_dir(dirname) {
+            for file in files {
+                let name = file.name();
+                if name.starts_with(filename) {
+                    let end = if file.is_dir() { "/" } else { "" };
+                    let entry = format!("{}{}{}{}", dirname, sep, name, end);
+                    entries.push(entry[path.len()..].into());
+                }
             }
         }
     }

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -63,7 +63,7 @@ fn shell_completer(line: &str) -> Vec<String> {
     let i = args.len() - 1;
 
     // Autocomplete command
-    if i == 0 && !args[i].starts_with('/') && !args[i].starts_with('~') {
+    if i == 0 && !fs::is_absolute_path(&args[i]) {
         for cmd in autocomplete_commands() {
             if let Some(entry) = cmd.strip_prefix(&args[i]) {
                 entries.push(entry.into());

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -85,14 +85,7 @@ fn shell_completer(line: &str) -> Vec<String> {
         for file in files {
             let name = file.name();
             if name.starts_with(filename) {
-                if args.len() == 1 && !file.is_dir() {
-                    continue;
-                }
-                let end = if args.len() != 1 && file.is_dir() {
-                    "/"
-                } else {
-                    ""
-                };
+                let end = if file.is_dir() { "/" } else { "" };
                 let entry = format!("{}{}{}{}", dirname, sep, name, end);
                 entries.push(entry[path.len()..].into());
             }


### PR DESCRIPTION
There was a special case in path autocompletion of the shell for the first arg when it a path to a binary, but it doesn't seem to be useful anymore, because every file can be a script now, so this code can be simplified.