### PR TITLE
Free process memory on exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,12 @@ user-nasm:
 
 user-cargo-opts = --no-default-features --features userspace --release
 
-# FIXME: Userspace alloc panic when the default `lld` linker is used, but the
-# resulting binaries are much larger with `ld`
-linker-opts = -C linker-flavor=ld -C link-args="-Ttext=650000 -Trodata=670000"
+# FIXME: Userspace alloc panic when the default `lld` linker is used because it
+# sets the entry point 0x200000 which is used by the kernel, so we use `ld` to
+# set it at 0x800000 that is free. With `ld` the resulting binaries are much
+# larger though. This is useful only for programs that allocate memory.
+ld-opts = -Ttext=800000 -Trodata=900000 -Tbss=950000
+linker-opts = -C linker-flavor=ld -C link-args="$(ld-opts)"
 
 user-rust:
 	basename -s .rs src/bin/*.rs | xargs -I {} \

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -12,7 +12,7 @@ use x86_64::structures::idt::{
     InterruptDescriptorTable, InterruptStackFrame, InterruptStackFrameValue,
     PageFaultErrorCode,
 };
-use x86_64::structures::paging::{OffsetPageTable, Translate};
+use x86_64::structures::paging::OffsetPageTable;
 use x86_64::VirtAddr;
 
 const PIC1: u16 = 0x21;
@@ -154,10 +154,6 @@ extern "x86-interrupt" fn page_fault_handler(
         // longer a simple clone of the kernel page table. Currently a process
         // is executed from its kernel address that is shared with the process.
         let start = (addr / 4096) * 4096;
-        // FIXME: This should not be needed anymore
-        if mapper.translate_addr(VirtAddr::new(start)).is_some() {
-            sys::allocator::free_pages(&mut mapper, start, 4096);
-        }
         if sys::allocator::alloc_pages(&mut mapper, start, 4096).is_ok() {
             if sys::process::is_userspace(start) {
                 let code_addr = sys::process::code_addr();

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -154,15 +154,12 @@ extern "x86-interrupt" fn page_fault_handler(
         // longer a simple clone of the kernel page table. Currently a process
         // is executed from its kernel address that is shared with the process.
         let start = (addr / 4096) * 4096;
+        // FIXME: This should not be needed anymore
         if mapper.translate_addr(VirtAddr::new(start)).is_some() {
-            // FIXME: This should not be needed anymore
             sys::allocator::free_pages(&mut mapper, start, 4096);
-            //debug!("Page Fault: {:#X} freed", start);
         }
         if sys::allocator::alloc_pages(&mut mapper, start, 4096).is_ok() {
-            //debug!("Page Fault: {:#X} allocated", start);
             if sys::process::is_userspace(start) {
-                //debug!("Page Fault: {:#X} copied", start);
                 let code_addr = sys::process::code_addr();
                 let src = (code_addr + start) as *mut u8;
                 let dst = start as *mut u8;
@@ -170,8 +167,6 @@ extern "x86-interrupt" fn page_fault_handler(
                     core::ptr::copy_nonoverlapping(src, dst, 4096);
                 }
             }
-        } else {
-            //debug!("Page Fault: {:#X} cannot allocate", start);
         }
     } else {
         printk!(

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -32,7 +32,11 @@ const MAX_HANDLES: usize = 64;
 const MAX_PROCS: usize = 4; // TODO: Increase this
 const MAX_PROC_SIZE: usize = 10 << 20; // 10 MB
 
+// TODO: Remove this when the kernel is no longer at 0x200000 in userspace.
+// Currently this address must be used by the linker for user programs that
+// need to allocate memory to avoid using kernel memory.
 static USER_ADDR: u64 = 0x800000;
+
 static CODE_ADDR: AtomicU64 = AtomicU64::new(0);
 pub static PID: AtomicUsize = AtomicUsize::new(0);
 pub static MAX_PID: AtomicUsize = AtomicUsize::new(1);

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -32,7 +32,7 @@ const MAX_HANDLES: usize = 64;
 const MAX_PROCS: usize = 4; // TODO: Increase this
 const MAX_PROC_SIZE: usize = 10 << 20; // 10 MB
 
-static ENTRY_ADDR: u64 = 0x800000;
+static USER_ADDR: u64 = 0x800000;
 static CODE_ADDR: AtomicU64 = AtomicU64::new(0);
 pub static PID: AtomicUsize = AtomicUsize::new(0);
 pub static MAX_PID: AtomicUsize = AtomicUsize::new(1);
@@ -227,7 +227,7 @@ pub fn set_stack_frame(stack_frame: InterruptStackFrameValue) {
 
 // TODO: Remove this when the kernel is no longer at 0x200000 in userspace
 pub fn is_userspace(addr: u64) -> bool {
-    ENTRY_ADDR <= addr && addr <= ENTRY_ADDR + MAX_PROC_SIZE as u64
+    USER_ADDR <= addr && addr <= USER_ADDR + MAX_PROC_SIZE as u64
 }
 
 pub fn exit() {
@@ -506,7 +506,7 @@ impl Process {
         let size = MAX_PROC_SIZE;
         sys::allocator::free_pages(&mut mapper, self.code_addr, size);
 
-        let addr = ENTRY_ADDR;
+        let addr = USER_ADDR;
         match mapper.translate(VirtAddr::new(addr)) {
             TranslateResult::Mapped { frame: _, offset: _, flags } => {
                 if flags.contains(PageTableFlags::USER_ACCESSIBLE) {


### PR DESCRIPTION
Still improving the workaround (see #681 #680 #679 #677 #676 #675 #674 #673) to allow user memory allocation without bugs.

This PR moves the program binary above 0x800000 instead of 0x600000 and don't forget about the `.bss` section used by Rust programs containing a call to the `format!` macro. The workaround in the page fault exception handler now look for addresses in that region of the memory originating from userspace, then allocate a page for it and copy the corresponding content of the binary high in memory where it was loaded originally. This is only needed for programs that allocate memory. Finally we take care of freeing everything in that region when the program exit, including the `.bss` section to allow a different program to load after it.

We can now run different programs allocating memory like `geodate` and `geocal` multiple times without issues, and we can use
programs containing calls to the `format!` macro (which should allow us to refactor the code responsible for printing to the console in `geocal` that is quite ugly without it).

This is a temporary solution because having to link every programs at 0x800000 and having this workaround in the page fault exception handler is not the right way to go in the long term, but it's progress!