### PR TITLE
List processors at boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ keyboard = qwerty# qwerty, azerty, dvorak
 mode = release
 
 # Emulation options
+smp = 2
 nic = rtl8139# rtl8139, pcnet, e1000
 audio = sdl# sdl, coreaudio
 signal = off# on
@@ -73,7 +74,7 @@ image: $(img)
 	cargo bootimage $(cargo-opts)
 	dd conv=notrunc if=$(bin) of=$(img)
 
-qemu-opts = -m $(memory) -drive file=$(img),format=raw \
+qemu-opts = -m $(memory) -smp $(smp) -drive file=$(img),format=raw \
 			 -audiodev $(audio),id=a0 -machine pcspk-audiodev=a0 \
 			 -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0
 ifeq ($(kvm),true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ pub fn init(boot_info: &'static BootInfo) {
     log!("SYS MOROS v{}", v);
 
     sys::mem::init(boot_info);
-    sys::acpi::init(); // Require MEM
     sys::cpu::init();
+    sys::acpi::init(); // Require MEM
     sys::rng::init();
     sys::pci::init(); // Require MEM
     sys::net::init(); // Require PCI


### PR DESCRIPTION
The CPU model is displayed at boot using CPUID and now we also list them using ACPI:

```
[0.367944] CPU GenuineIntel
[0.368944] CPU Intel(R) Core(TM)2 Duo CPU     T7700  @ 2.40GHz
[0.373943] CPU BP:0 running
[0.373943] CPU AP:1 waiting
```

This is a first step toward the idea of using the boot processor (BP) for interrupts and the first application processor (AP) available for userspace programs.