### PR TITLE
Use string instead of float as clock device output format

### DIFF
--- a/dsk/lib/lisp/file.lsp
+++ b/dsk/lib/lisp/file.lsp
@@ -77,11 +77,11 @@
 
 (def (clock/boot)
   "Returns the number of seconds since boot"
-  (binary->number (read-binary "/dev/clk/boot") "float"))
+  (str->num (read "/dev/clk/boot")))
 
 (def (clock/epoch)
   "Returns the number of seconds since epoch"
-  (binary->number (read-binary "/dev/clk/epoch") "float"))
+  (str->num (read "/dev/clk/epoch")))
 
 # Path
 

--- a/src/sys/clk/boot.rs
+++ b/src/sys/clk/boot.rs
@@ -13,8 +13,7 @@ impl BootTime {
     }
 
     pub fn size() -> usize {
-        // Must be larger than 8 bytes to be readable as a block device
-        // Format: "<seconds>.<nanoseconds>" => at least 20 + 1 + 6 bytes
+        // Must be at least 20 + 1 + 6 bytes: "<seconds>.<nanoseconds>"
         32
     }
 }

--- a/src/sys/clk/boot.rs
+++ b/src/sys/clk/boot.rs
@@ -2,6 +2,8 @@ use super::timer;
 
 use crate::api::fs::{FileIO, IO};
 
+use alloc::format;
+
 #[derive(Debug, Clone)]
 pub struct BootTime;
 
@@ -11,16 +13,18 @@ impl BootTime {
     }
 
     pub fn size() -> usize {
-        core::mem::size_of::<f64>()
+        // Must be larger than 8 bytes to be readable as a block device
+        // Format: "<seconds>.<nanoseconds>" => at least 20 + 1 + 6 bytes
+        32
     }
 }
 
 impl FileIO for BootTime {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
-        let time = boot_time().to_be_bytes();
+        let time = format!("{:.6}", boot_time());
         let n = time.len();
         if buf.len() >= n {
-            buf[0..n].clone_from_slice(&time);
+            buf[0..n].clone_from_slice(time.as_bytes());
             Ok(n)
         } else {
             Err(())

--- a/src/sys/clk/epoch.rs
+++ b/src/sys/clk/epoch.rs
@@ -18,8 +18,7 @@ impl EpochTime {
     }
 
     pub fn size() -> usize {
-        // Must be larger than 8 bytes to be readable as a block device
-        // Format: "<seconds>.<nanoseconds>" => at least 20 + 1 + 6 bytes
+        // Must be at least 20 + 1 + 6 bytes: "<seconds>.<nanoseconds>"
         32
     }
 }

--- a/src/sys/vga/screen.rs
+++ b/src/sys/vga/screen.rs
@@ -197,7 +197,8 @@ impl VgaMode {
     }
 
     pub fn size() -> usize {
-        16 // Must be larger than 8 bytes to be readable as a block device
+        // Must be at least 4 + 1 + 4 bytes: "<width>x<height>"
+        16
     }
 }
 

--- a/src/usr/read.rs
+++ b/src/usr/read.rs
@@ -8,7 +8,6 @@ use crate::{api, usr};
 use alloc::borrow::ToOwned;
 use alloc::format;
 use alloc::vec::Vec;
-use core::convert::TryInto;
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     if args.len() != 2 {
@@ -94,7 +93,6 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
             // file.
             let n = info.size();
             let is_char_device = n == 4;
-            let is_float_device = n == 8;
             let is_block_device = n > 8;
             loop {
                 if console::end_of_text() || console::end_of_transmission() {
@@ -114,12 +112,6 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                             }
                             _ => {}
                         }
-                    }
-                    if is_float_device && bytes.len() == 8 {
-                        let f = f64::from_be_bytes(bytes[0..8].try_into().
-                            unwrap());
-                        println!("{:.6}", f);
-                        return Ok(());
                     }
                     for b in bytes {
                         print!("{}", b as char);


### PR DESCRIPTION
Until now reading `/dev/clk/boot` or `/dev/clk/epoch` would return 8 bytes containing a 64 bit float which was good in term of compactness but we might decide to use a different internal representation for those clocks like a 64 bit integer for the number of seconds and a 32 or 64 bit integer for the nanoseconds part.

It also introduced a special case for reading those device files. A better interface would be to use a plain text ASCII string instead, this way we can read those files like any other files. The bytes returned will need to be parsed from string to float but there was already a conversion needed from bytes to float.

It is another breaking change for the next release necessitating to delete the device files and the lisp library and install the new version but there was already a breaking change concerning them:

```
> delete /dev/clk/*

> delete /lib/lisp/file.lsp

> install
```