### PR TITLE
Upgrade base64 module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit_field"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ userspace = []
 [dependencies]
 acpi = "5.0.0"
 aml = "0.16.4"
-base64 = { version = "0.13.1", default-features = false }
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bit_field = "0.10.2"
 bootloader = { version = "0.9.29", features = ["map_physical_memory"] }
 lazy_static = { version = "1.5.0", features = ["spin_no_std"] }

--- a/src/api/base64.rs
+++ b/src/api/base64.rs
@@ -26,8 +26,13 @@ impl Base64 {
 
 #[test_case]
 fn test_base64() {
-    let decoded = b"Hello, World!";
-    let encoded = b"SGVsbG8sIFdvcmxkIQ";
-    assert_eq!(Base64::encode(decoded), encoded.to_vec());
-    assert_eq!(Base64::decode(encoded), Ok(decoded.to_vec()));
+    let tests = [
+        (b"abcdefghijklm", b"YWJjZGVmZ2hpamtsbQ"),
+        (b"Hello, World!", b"SGVsbG8sIFdvcmxkIQ"),
+        (b"~~~~~, ?????!", b"fn5+fn4sID8/Pz8/IQ"),
+    ];
+    for (decoded, encoded) in tests {
+        assert_eq!(Base64::encode(decoded), encoded.to_vec());
+        assert_eq!(Base64::decode(encoded), Ok(decoded.to_vec()));
+    }
 }

--- a/src/api/base64.rs
+++ b/src/api/base64.rs
@@ -1,26 +1,15 @@
 use alloc::vec::Vec;
+use base64::prelude::*;
 
 pub struct Base64;
 
 impl Base64 {
     pub fn encode(s: &[u8]) -> Vec<u8> {
-        let mut buf: Vec<u8> = Vec::new();
-        buf.resize(s.len() * 4 / 3 + 4, 0); // Resize to base64 + padding
-        let bytes_written = base64::encode_config_slice(
-            s, base64::STANDARD_NO_PAD, &mut buf
-        );
-        buf.resize(bytes_written, 0); // Resize back to actual size
-        buf
+        BASE64_STANDARD_NO_PAD.encode(s).as_bytes().to_vec()
     }
 
     pub fn decode(s: &[u8]) -> Result<Vec<u8>, ()> {
-        let mut buf: Vec<u8> = Vec::new();
-        buf.resize(s.len(), 0);
-        let bytes_written = base64::decode_config_slice(
-            s, base64::STANDARD_NO_PAD, &mut buf
-        ).map_err(|_| ())?;
-        buf.resize(bytes_written, 0);
-        Ok(buf)
+        BASE64_STANDARD_NO_PAD.decode(s).map_err(|_| ())
     }
 }
 


### PR DESCRIPTION
Newer versions of the `base64` crate have a `alloc` feature that simplify the code.

The test cases were also extended to include `+` and `/` chars.