### PR TITLE
Limit prompt line to screen width

### DIFF
--- a/src/api/prompt.rs
+++ b/src/api/prompt.rs
@@ -21,15 +21,19 @@ impl Prompt {
             eol: true,
             offset: 0,
             cursor: 0,
-            line: Vec::with_capacity(80),
+            line: Vec::with_capacity(console::cols()),
         }
+    }
+
+    fn max(&self) -> usize {
+        console::cols() - self.offset
     }
 
     pub fn input(&mut self, prompt: &str) -> Option<String> {
         print!("{}", prompt);
         self.offset = offset_from_prompt(prompt);
         self.cursor = self.offset;
-        self.line = Vec::with_capacity(80);
+        self.line = Vec::with_capacity(self.max());
         let mut parser = Parser::new();
         while let Some(c) = io::stdin().read_char() {
             match c {
@@ -246,7 +250,7 @@ impl Prompt {
     fn handle_printable_key(&mut self, c: char) {
         self.update_completion();
         self.update_history();
-        if console::is_printable(c) {
+        if console::is_printable(c) && self.line.len() < self.max() {
             let i = self.cursor - self.offset;
             self.line.insert(i, c);
             let s = &self.line[i..]; // UTF-32


### PR DESCRIPTION
There's currently no multiline support in the prompt library (see #343 for a WIP) and a lot of weird things happen when a line goes past the screen width so the simplest fix for now is to prevent that.

![prompt](https://github.com/user-attachments/assets/91584111-fb85-4ee0-a6b1-60116bfba99c)