### PR TITLE
Update clipboard behavior in editor

### DIFF
--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -636,7 +636,7 @@ impl Editor {
             self.lines.insert(i + 1, line);
             self.cursor.x = 0;
             self.offset.x = 0;
-            self.print_screen();
+            self.handle_arrow_down(); // Move cursor to pasted line
         }
     }
 

--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -613,16 +613,7 @@ impl Editor {
         if self.lines.is_empty() {
             self.lines.push(String::new());
         }
-        if i >= self.lines.len() { // Move cursor up to the previous line
-            if self.cursor.y > 0 {
-                self.cursor.y -= 1;
-            } else if self.offset.y > 0 {
-                self.offset.y -= 1;
-            }
-        }
-        self.cursor.x = 0;
-        self.offset.x = 0;
-        self.print_screen();
+        self.handle_arrow_up(); // Move cursor to previous line
     }
 
     fn copy_line(&mut self) {

--- a/src/usr/edit.rs
+++ b/src/usr/edit.rs
@@ -28,7 +28,7 @@ struct Coords {
 
 pub struct Editor {
     pathname: String,
-    clipboard: Vec<String>,
+    clipboard: Option<String>,
     lines: Vec<String>,
     cursor: Coords,
     offset: Coords,
@@ -45,7 +45,7 @@ impl Editor {
         let cursor = Coords { x: 0, y: 0 };
         let offset = Coords { x: 0, y: 0 };
         let highlighted = Vec::new();
-        let clipboard = Vec::new();
+        let clipboard = None;
         let mut lines = Vec::new();
         let config = EditorConfig { tab_size: 4 };
 
@@ -461,7 +461,7 @@ impl Editor {
                 }
                 '\x04' => { // Ctrl D -> Delete (cut) line
                     let i = self.offset.y + self.cursor.y;
-                    self.clipboard.push(self.lines.remove(i));
+                    self.clipboard = Some(self.lines.remove(i));
                     if self.lines.is_empty() {
                         self.lines.push(String::new());
                     }
@@ -481,11 +481,11 @@ impl Editor {
                 }
                 '\x19' => { // Ctrl Y -> Yank (copy) line
                     let i = self.offset.y + self.cursor.y;
-                    self.clipboard.push(self.lines[i].clone());
+                    self.clipboard = Some(self.lines[i].clone());
                 }
                 '\x10' => { // Ctrl P -> Put (paste) line
                     let i = self.offset.y + self.cursor.y;
-                    if let Some(line) = self.clipboard.pop() {
+                    if let Some(line) = self.clipboard.clone() {
                         self.lines.insert(i + 1, line);
                     }
                     self.cursor.x = 0;


### PR DESCRIPTION
The clipboard in the editor was a stack, leading to unexpected behavior. It will now be a single line buffer acting like the usual cut/copy/paste features. For example it will now be possible to copy a line and paste it multiple times.