### PR TITLE
Fix Lisp float underscore parsing

### DIFF
--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -433,6 +433,9 @@ fn test_lisp() {
     assert_eq!(eval!("-1.5"), "-1.5");
     assert_eq!(eval!("-0xff"), "-255");
     assert_eq!(eval!("-0b11"), "-3");
+    assert_eq!(eval!("123_456"), "123456");
+    assert_eq!(eval!("0x123_456"), "1193046");
+    assert_eq!(eval!("0.123_456"), "0.123456");
 
     // quote
     assert_eq!(eval!("(quote (1 2 3))"), "(1 2 3)");

--- a/src/usr/lisp/number.rs
+++ b/src/usr/lisp/number.rs
@@ -342,7 +342,7 @@ impl FromStr for Number {
 
 impl From<&str> for Number {
     fn from(s: &str) -> Self {
-        if let Ok(num) = s.parse() {
+        if let Ok(num) = s.replace("_", "").parse() {
             num
         } else {
             Number::Float(f64::NAN)


### PR DESCRIPTION
Numbers in MOROS Lisp can contains an underscore as separator, for example `123_456` is valid and equivalent to `123456`, but until now a float like `0.123_456` could not be parsed without error.