### PR TITLE
Add better shell scripting capabilities

### DIFF
--- a/src/usr/shell/lexer.rs
+++ b/src/usr/shell/lexer.rs
@@ -1,0 +1,64 @@
+use alloc::vec::Vec;
+use core::fmt;
+use chumsky::prelude::*;
+
+pub type Span = SimpleSpan;
+pub type Spanned<T> = (T, Span);
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Token<'src> {
+    Null,
+    Str(&'src str),
+    Ident(&'src str),
+    Def,
+    Do,
+    End,
+    If,
+    Else,
+}
+
+impl fmt::Display for Token<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Token::Null => write!(f, "null"),
+            Token::Str(s) => write!(f, "{s}"),
+            Token::Ident(s) => write!(f, "{s}"),
+            Token::Def => write!(f, "def"),
+            Token::Do => write!(f, "do"),
+            Token::End => write!(f, "end"),
+            Token::If => write!(f, "if"),
+            Token::Else => write!(f, "else"),
+        }
+    }
+}
+
+
+pub fn lexer<'a>() -> impl Parser<'a, &'a str, Vec<Spanned<Token<'a>>>, extra::Err<Rich<'a, char, Span>>> {
+    let string = just('"')
+        .ignore_then(none_of('"').repeated().to_slice())
+        .then_ignore(just('"'))
+        .map(Token::Str);
+
+    let identifier = text::ascii::ident().map(|ident: &str| match ident {
+        "def" => Token::Def,
+        "do" => Token::Do,
+        "end" => Token::End,
+        "if" => Token::If,
+        "else" => Token::Else,
+        "null" => Token::Null,
+        _ => Token::Ident(ident),
+    });
+
+    let token = string.or(identifier);
+
+    let comment = just('#')
+        .then(any().and_is(just('\n').not()).repeated())
+        .padded();
+
+    token.map_with(|t, e| (t, e.span()))
+        .padded_by(comment.repeated())
+        .padded()
+        .recover_with(skip_then_retry_until(any().ignored(), end()))
+        .repeated()
+        .collect()
+}

--- a/src/usr/shell/mod.rs
+++ b/src/usr/shell/mod.rs
@@ -680,8 +680,8 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
         }
 
         let path = args[1];
-        if let Ok(contents) = api::fs::read_to_string(path) {
-            for line in contents.lines() {
+        if let Ok(buf) = api::fs::read_to_string(path) {
+            for line in buf.lines() {
                 if !line.is_empty() {
                     exec_with_config(line, &mut config).ok();
                 }


### PR DESCRIPTION
At the moment we can only run one command at a time in the REPL and in any shell script, which is pretty limiting. This PR will evolve the shell into a proper scripting language inspired by Ruby allowing us to do much more with it:

- [ ] Add `;` to separate commands
- [ ] Add `and` operator
- [ ] Add `or` operator
- [ ] Add `not` operator
- [ ] Add `test` program
- [ ] Add `def <name> <args>* [do] <commands> end` (function definition)
- [ ] Add `if <condition> [do] <commands> [else <commands>] end` (conditional)
- [ ] Add `for <var> in <list> [do] <commands> end` (loop)
- [x] Add `$(<command>)` (command substitution)
- [ ] Add `<command> --> <command>` (pipe)

Example:

```ruby
def hello name
  print "Hello, $name!"
end

if test -e $USER
  hello World
else
  hello $USER
end

for file in $(list /tmp/*.tmp)
  drop $file
end
```

A real shell script could be a redefinition of `move` as `copy` + `drop` instead of being a dedicated Rust program:

```ruby
#! shell

def usage
  print "Usage: move <src> <dst>"
end

for arg in $*
  if test -e $arg "-h" or test -e $arg "--help"
    usage
    exit 0
  end
end

set src $1
set dst $2

if test -e $src "" or test -e $dst ""
  usage
  exit 1
end
        
copy $src $dst and drop $src
```