### PR TITLE
Fix HTTP server keep alive

### DIFF
--- a/src/usr/copy.rs
+++ b/src/usr/copy.rs
@@ -29,7 +29,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let source = args[1];
     let dest = destination(args[1], args[2]);
 
-    if fs::is_dir(source) {
+    if fs::is_dir(source) { // TODO: Implement dir copy
         error!("Could not copy directory '{}'", source);
         return Err(ExitCode::Failure);
     }

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -370,17 +370,19 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     socket.listen(port).unwrap();
                     *keep_alive = true; // Reset to default
                 }
+
                 let endpoint = match socket.remote_endpoint() {
                     Some(endpoint) => endpoint,
                     None => continue,
                 };
+
                 if socket.may_recv() {
                     // The amount of octets queued in the receive buffer may be
                     // larger than the contiguous slice returned by `recv` so
                     // we need to loop over chunks of it until it is empty.
                     let recv_queue = socket.recv_queue();
-                    let mut receiving = true;
                     let mut buf = vec![];
+                    let mut receiving = true;
                     while receiving {
                         let res = socket.recv(|chunk| {
                             buf.extend_from_slice(chunk);
@@ -415,7 +417,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                                 println!("{}", res);
                                 (chunk.len(), Some(res))
                             } else {
-                                (0, None)
+                                (0, None) // (chunk.len(), None) // TODO?
                             }
                         });
                         if receiving {
@@ -428,11 +430,12 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                             }
                         }
                     }
+
                     if socket.can_send() {
                         if let Some(chunk) = send_queue.pop_front() {
-                            let sent = socket.send_slice(&chunk).
-                                expect("Could not send chunk");
-                            debug_assert!(sent == chunk.len());
+                            if socket.send_slice(&chunk).is_err() {
+                                // send_queue.push_front(chunk); // TODO?
+                            }
                         }
                     }
                     if send_queue.is_empty() && !*keep_alive {
@@ -440,9 +443,10 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                     }
                 } else if socket.may_send() {
                     socket.close();
-                    send_queue.clear();
+                    send_queue.clear(); // TODO: Remove this?
                 }
             }
+
             if let Some(delay) = iface.poll_delay(time, &sockets) {
                 let d = delay.total_micros() / POLL_DELAY_DIV as u64;
                 if d > 0 {

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -21,7 +21,7 @@ use smoltcp::socket::tcp;
 use smoltcp::time::Instant;
 use smoltcp::wire::IpAddress;
 
-const MAX_CONNECTIONS: usize = 32;
+const MAX_CONNECTIONS: usize = 32; // TODO: Add dynamic pooling
 const POLL_DELAY_DIV: usize = 128;
 const INDEX: [&str; 4] = ["", "/index.html", "/index.htm", "/index.txt"];
 

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -368,7 +368,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 
                 if !socket.is_open() {
                     socket.listen(port).unwrap();
-                    *keep_alive = true;
+                    *keep_alive = true; // Reset to default
                 }
                 let endpoint = match socket.remote_endpoint() {
                     Some(endpoint) => endpoint,

--- a/src/usr/httpd.rs
+++ b/src/usr/httpd.rs
@@ -368,6 +368,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
 
                 if !socket.is_open() {
                     socket.listen(port).unwrap();
+                    *keep_alive = true;
                 }
                 let endpoint = match socket.remote_endpoint() {
                     Some(endpoint) => endpoint,


### PR DESCRIPTION
If one instance of MOROS run the HTTP server:

```
> print aaa => aaa.txt

> print bbb => bbb.txt

> dhcp
[3.143521] NET IP 10.0.2.15/24
[3.146521] NET GW 10.0.2.2
[3.151520] NET DNS 10.0.2.3

> httpd
HTTP Server listening on 0.0.0.0:80
```

And another instance run the client, the first request will succeed `http <ip>/aaa.txt` but the next request to a different file `http <ip>/bbb.txt` might not receive any response, and each subsequent request will get the response for the previous request.

This can be fixed by reseting the keep alive value when opening a new connection.