### PR TITLE
Optimize append in file::write

### DIFF
--- a/src/sys/fs/file.rs
+++ b/src/sys/fs/file.rs
@@ -153,6 +153,32 @@ impl FileIO for File {
         let mut addr = self.addr;
         let mut bytes = 0; // Number of bytes written
         let mut pos = 0; // Position in the file
+
+        // Optimization: when appending, skip to the last block
+        if self.offset == self.size && self.size > 0 {
+            let mut block = LinkedBlock::read(addr);
+            while let Some(next_block) = block.next() {
+                addr = next_block.addr();
+                block = LinkedBlock::read(addr);
+            }
+            // If last block is full, allocate a new one
+            let block_data_len = block.len() as u32;
+            if self.size % block_data_len == 0 {
+                match LinkedBlock::alloc() {
+                    Some(new_block) => {
+                        let mut last_block = LinkedBlock::read(addr);
+                        last_block.set_next_addr(new_block.addr());
+                        last_block.write();
+                        addr = new_block.addr();
+                        pos = self.size;
+                    }
+                    None => return Err(()),
+                }
+            } else {
+                pos = self.size - (self.size % block_data_len);
+            }
+        }
+
         while bytes < buf_len {
             let mut block = LinkedBlock::read(addr);
             let data = block.data_mut();


### PR DESCRIPTION
Before this change we couldn't download files larger than around 250 KB before reaching a socket timeout. When appending to a file, the `fs` driver now traverse the linked list of blocks only once to find the last block, then continue writing from there. Previously, every write operation would traverse from the beginning to find the write position.

Before:

```
> time http 10.0.2.2:8000/20kb.bin > 20kb.bin
Executed 'http 10.0.2.2:8000/20kb.bin' in 1.608060s

> time http 10.0.2.2:8000/200kb.bin > 200kb.bin
Executed 'http 10.0.2.2:8000/200kb.bin' in 47.841025s
```

After:

```
> time http 10.0.2.2:8000/20kb.bin > 20kb.bin
Executed 'http 10.0.2.2:8000/20kb.bin' in 0.991001s

> time http 10.0.2.2:8000/200kb.bin > 200kb.bin
Executed 'http 10.0.2.2:8000/200kb.bin' in 3.799031s
```

And on the host system:

```
$ dd if=/dev/zero of=20kb.bin bs=1024 count=20
20+0 records in
20+0 records out
20480 bytes transferred in 0.000684 secs (29941520 bytes/sec)

$ dd if=/dev/zero of=200kb.bin bs=1024 count=200
200+0 records in
200+0 records out
204800 bytes transferred in 0.001643 secs (124650030 bytes/sec)

$ python3 -m http.server 8000
```