### PR TITLE
Replace bump frame allocator with bitmap frame allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ qemu:
 
 test:
 	cargo test --release --lib --no-default-features --features serial -- \
-		-m $(memory) -display none -serial stdio \
+		-m $(memory) -cpu core2duo -display none -serial stdio \
 		-device isa-debug-exit,iobase=0xF4,iosize=0x04
 
 website:

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ setup:
 	cargo install bootimage
 
 # Compilation options
-memory = 32
 output = video# video, serial
 keyboard = qwerty# qwerty, azerty, dvorak
 mode = release
 
 # Emulation options
+memory = 32
 smp = 2
 nic = rtl8139# rtl8139, pcnet, e1000
 audio = sdl# sdl, coreaudio
@@ -23,7 +23,6 @@ trace = false# e1000
 monitor = false
 
 export MOROS_VERSION = $(shell git describe --tags | sed "s/^v//")
-export MOROS_MEMORY = $(memory)
 export MOROS_KEYBOARD = $(keyboard)
 
 # Build userspace binaries

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -69,7 +69,7 @@ impl BitmapFrameAllocator {
         });
         for region in usable_regions {
             let start_frame = frame_at(region.range.start_addr());
-            let end_frame = frame_at(region.range.end_addr());
+            let end_frame = frame_at(region.range.end_addr() - 1);
             let size = end_frame.start_address() - start_frame.start_address();
             let frame_count = 1 + (size / 4096) as usize;
 

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -1,0 +1,125 @@
+use bootloader::bootinfo::{MemoryMap, MemoryRegionType};
+use spin::{Once, Mutex};
+use x86_64::structures::paging::{
+    FrameAllocator, FrameDeallocator,
+    PhysFrame, Size4KiB
+};
+use x86_64::PhysAddr;
+
+const MAX_FRAMES: usize = (4 << 30) / 4096; // 4 GB of RAM
+const BITMAP_SIZE: usize = MAX_FRAMES / 64;
+static FRAME_ALLOCATOR: Once<Mutex<BitmapFrameAllocator>> = Once::new();
+
+pub fn init_frame_allocator() {
+    FRAME_ALLOCATOR.call_once(|| {
+        Mutex::new(unsafe {
+            BitmapFrameAllocator::init(super::MEMORY_MAP.get_unchecked())
+        })
+    });
+}
+
+pub struct BitmapFrameAllocator {
+    memory_map: &'static MemoryMap,
+    allocated_bitmap: [u64; BITMAP_SIZE],
+}
+
+impl BitmapFrameAllocator {
+    pub unsafe fn init(memory_map: &'static MemoryMap) -> Self {
+        Self {
+            memory_map,
+            allocated_bitmap: [0; BITMAP_SIZE],
+        }
+    }
+
+    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
+        let regions = self.memory_map.iter();
+        let usable_regions = regions.filter(|r|
+            r.region_type == MemoryRegionType::Usable
+        );
+        let addr_ranges = usable_regions.map(|r|
+            r.range.start_addr()..r.range.end_addr()
+        );
+        let frame_addresses = addr_ranges.flat_map(|r|
+            r.step_by(4096)
+        );
+        frame_addresses.map(|addr|
+            PhysFrame::containing_address(PhysAddr::new(addr))
+        )
+    }
+
+    fn frame_to_bitmap_index(&self, frame: PhysFrame) -> Option<usize> {
+        for (i, usable_frame) in self.usable_frames().enumerate() {
+            if usable_frame.start_address() == frame.start_address() {
+                return if i < MAX_FRAMES { Some(i) } else { None };
+            }
+            if i >= MAX_FRAMES {
+                break;
+            }
+        }
+
+        None
+    }
+
+    fn is_frame_allocated(&self, index: usize) -> bool {
+        if index >= MAX_FRAMES {
+            return false;
+        }
+        let word_index = index / 64;
+        let bit_index = index % 64;
+        (self.allocated_bitmap[word_index] & (1 << bit_index)) != 0
+    }
+
+    fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
+        if index >= MAX_FRAMES {
+            return;
+        }
+        let word_index = index / 64;
+        let bit_index = index % 64;
+        if allocated {
+            self.allocated_bitmap[word_index] |= 1 << bit_index;
+        } else {
+            self.allocated_bitmap[word_index] &= !(1 << bit_index);
+        }
+    }
+
+    pub fn total_usable_frames(&self) -> usize {
+        self.usable_frames().take(MAX_FRAMES).count()
+    }
+}
+
+unsafe impl FrameAllocator<Size4KiB> for BitmapFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+        for (i, frame) in self.usable_frames().enumerate() {
+            if i >= MAX_FRAMES {
+                break;
+            }
+            if !self.is_frame_allocated(i) {
+                self.set_frame_allocated(i, true);
+                return Some(frame);
+            }
+        }
+        None
+    }
+}
+
+impl FrameDeallocator<Size4KiB> for BitmapFrameAllocator {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
+        if let Some(index) = self.frame_to_bitmap_index(frame) {
+            if self.is_frame_allocated(index) {
+                self.set_frame_allocated(index, false);
+            }
+        }
+    }
+}
+
+pub fn frame_allocator() -> &'static Mutex<BitmapFrameAllocator> {
+    FRAME_ALLOCATOR.get().expect("frame allocator not initialized")
+}
+
+pub fn with_frame_allocator<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut BitmapFrameAllocator) -> R,
+{
+    let mut allocator = frame_allocator().lock();
+    f(&mut *allocator)
+}

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -1,5 +1,6 @@
 use bootloader::bootinfo::{MemoryMap, MemoryRegionType};
 use spin::{Once, Mutex};
+use bit_field::BitField;
 use x86_64::structures::paging::{
     FrameAllocator, FrameDeallocator,
     PhysFrame, Size4KiB
@@ -8,17 +9,21 @@ use x86_64::PhysAddr;
 
 #[derive(Debug, Clone, Copy)]
 struct UsableRegion {
-    base: PhysFrame,
+    start_frame: PhysFrame,
     frame_count: usize,
 }
 
 impl UsableRegion {
     pub fn start_frame(&self) -> PhysFrame {
-        self.base
+        self.start_frame
     }
 
     pub fn end_frame(&self) -> PhysFrame {
-        self.base + (self.frame_count - 1) as u64
+        self.start_frame + (self.frame_count - 1) as u64
+    }
+
+    pub fn len(&self) -> usize {
+        self.frame_count
     }
 
     pub fn contains(&self, frame: PhysFrame) -> bool {
@@ -26,7 +31,7 @@ impl UsableRegion {
     }
 
     pub fn offset(&self, frame: PhysFrame) -> u64 {
-        (frame.start_address() - self.base.start_address()) / 4096
+        (frame.start_address() - self.start_frame.start_address()) / 4096
     }
 }
 
@@ -63,8 +68,7 @@ impl BitmapFrameAllocator {
             frames_count: 0,
         };
 
-        let regions = memory_map.iter();
-        let usable_regions = regions.filter(|r| {
+        let usable_regions = memory_map.iter().filter(|r| {
             r.region_type == MemoryRegionType::Usable
         });
         for region in usable_regions {
@@ -74,7 +78,7 @@ impl BitmapFrameAllocator {
             let frame_count = 1 + (size / 4096) as usize;
 
             debug_assert!(allocator.regions_count < MAX_REGIONS);
-            let desc = UsableRegion { base: start_frame, frame_count };
+            let desc = UsableRegion { start_frame, frame_count };
             allocator.usable_regions[allocator.regions_count] = Some(desc);
             allocator.regions_count += 1;
             allocator.frames_count += frame_count;
@@ -88,28 +92,28 @@ impl BitmapFrameAllocator {
             return None;
         }
 
-        let mut current_base_index = 0;
+        let mut base = 0;
         for i in 0..self.regions_count {
             if let Some(region) = self.usable_regions[i] {
-                if index < current_base_index + region.frame_count {
-                    let frame_offset = index - current_base_index;
-                    return Some(region.base + frame_offset as u64);
+                if index < base + region.len() {
+                    let frame_offset = index - base;
+                    return Some(region.start_frame() + frame_offset as u64);
                 }
-                current_base_index += region.frame_count;
+                base += region.len();
             }
         }
         None
     }
 
     fn frame_to_index(&self, frame: PhysFrame) -> Option<usize> {
-        let mut current_base_index = 0;
+        let mut base = 0;
         for i in 0..self.regions_count {
             if let Some(region) = self.usable_regions[i] {
                 if region.contains(frame) {
                     let frame_offset = region.offset(frame);
-                    return Some(current_base_index + frame_offset as usize);
+                    return Some(base + frame_offset as usize);
                 }
-                current_base_index += region.frame_count;
+                base += region.len();
             }
         }
         None
@@ -118,21 +122,13 @@ impl BitmapFrameAllocator {
     fn is_frame_allocated(&self, index: usize) -> bool {
         let word_index = index / 64;
         let bit_index = index % 64;
-        (self.allocated_bitmap[word_index] & (1 << bit_index)) != 0
+        self.allocated_bitmap[word_index].get_bit(bit_index)
     }
 
     fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
         let word_index = index / 64;
         let bit_index = index % 64;
-        if allocated {
-            self.allocated_bitmap[word_index] |= 1 << bit_index;
-        } else {
-            self.allocated_bitmap[word_index] &= !(1 << bit_index);
-        }
-    }
-
-    pub fn total_usable_frames(&self) -> usize {
-        self.frames_count
+        self.allocated_bitmap[word_index].set_bit(bit_index, allocated);
     }
 }
 

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -6,73 +6,122 @@ use x86_64::structures::paging::{
 };
 use x86_64::PhysAddr;
 
+#[derive(Debug, Clone, Copy)]
+struct UsableRegion {
+    base: PhysFrame,
+    frame_count: usize,
+}
+
+impl UsableRegion {
+    pub fn start_frame(&self) -> PhysFrame {
+        self.base
+    }
+
+    pub fn end_frame(&self) -> PhysFrame {
+        self.base + (self.frame_count - 1) as u64
+    }
+
+    pub fn contains(&self, frame: PhysFrame) -> bool {
+        self.start_frame() <= frame && frame <= self.end_frame()
+    }
+
+    pub fn offset(&self, frame: PhysFrame) -> u64 {
+        (frame.start_address() - self.base.start_address()) / 4096
+    }
+}
+
+fn frame_at(addr: u64) -> PhysFrame<Size4KiB> {
+    PhysFrame::containing_address(PhysAddr::new(addr))
+}
+
+const MAX_REGIONS: usize = 32;
 const MAX_FRAMES: usize = (4 << 30) / 4096; // 4 GB of RAM
 const BITMAP_SIZE: usize = MAX_FRAMES / 64;
 static FRAME_ALLOCATOR: Once<Mutex<BitmapFrameAllocator>> = Once::new();
 
-pub fn init_frame_allocator() {
+pub fn init_frame_allocator(memory_map: &'static MemoryMap) {
     FRAME_ALLOCATOR.call_once(|| {
-        Mutex::new(unsafe {
-            BitmapFrameAllocator::init(super::MEMORY_MAP.get_unchecked())
-        })
+        Mutex::new(BitmapFrameAllocator::init(memory_map))
     });
 }
 
 pub struct BitmapFrameAllocator {
-    memory_map: &'static MemoryMap,
+    usable_regions: [Option<UsableRegion>; MAX_REGIONS],
+    regions_count: usize,
     allocated_bitmap: [u64; BITMAP_SIZE],
+    next_free_index: usize,
+    frames_count: usize,
 }
 
 impl BitmapFrameAllocator {
-    pub unsafe fn init(memory_map: &'static MemoryMap) -> Self {
-        Self {
-            memory_map,
+    pub fn init(memory_map: &'static MemoryMap) -> Self {
+        let mut allocator = Self {
+            usable_regions: [None; MAX_REGIONS],
+            regions_count: 0,
             allocated_bitmap: [0; BITMAP_SIZE],
-        }
-    }
+            next_free_index: 0,
+            frames_count: 0,
+        };
 
-    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
-        let regions = self.memory_map.iter();
-        let usable_regions = regions.filter(|r|
+        let regions = memory_map.iter();
+        let usable_regions = regions.filter(|r| {
             r.region_type == MemoryRegionType::Usable
-        );
-        let addr_ranges = usable_regions.map(|r|
-            r.range.start_addr()..r.range.end_addr()
-        );
-        let frame_addresses = addr_ranges.flat_map(|r|
-            r.step_by(4096)
-        );
-        frame_addresses.map(|addr|
-            PhysFrame::containing_address(PhysAddr::new(addr))
-        )
+        });
+        for region in usable_regions {
+            let start_frame = frame_at(region.range.start_addr());
+            let end_frame = frame_at(region.range.end_addr());
+            let size = end_frame.start_address() - start_frame.start_address();
+            let frame_count = 1 + (size / 4096) as usize;
+
+            debug_assert!(allocator.regions_count < MAX_REGIONS);
+            let desc = UsableRegion { base: start_frame, frame_count };
+            allocator.usable_regions[allocator.regions_count] = Some(desc);
+            allocator.regions_count += 1;
+            allocator.frames_count += frame_count;
+        }
+        allocator.frames_count = allocator.frames_count.min(MAX_FRAMES);
+        allocator
     }
 
-    fn frame_to_bitmap_index(&self, frame: PhysFrame) -> Option<usize> {
-        for (i, usable_frame) in self.usable_frames().enumerate() {
-            if usable_frame.start_address() == frame.start_address() {
-                return if i < MAX_FRAMES { Some(i) } else { None };
-            }
-            if i >= MAX_FRAMES {
-                break;
-            }
+    fn index_to_frame(&self, index: usize) -> Option<PhysFrame> {
+        if index >= self.frames_count {
+            return None;
         }
 
+        let mut current_base_index = 0;
+        for i in 0..self.regions_count {
+            if let Some(region) = self.usable_regions[i] {
+                if index < current_base_index + region.frame_count {
+                    let frame_offset = index - current_base_index;
+                    return Some(region.base + frame_offset as u64);
+                }
+                current_base_index += region.frame_count;
+            }
+        }
+        None
+    }
+
+    fn frame_to_index(&self, frame: PhysFrame) -> Option<usize> {
+        let mut current_base_index = 0;
+        for i in 0..self.regions_count {
+            if let Some(region) = self.usable_regions[i] {
+                if region.contains(frame) {
+                    let frame_offset = region.offset(frame);
+                    return Some(current_base_index + frame_offset as usize);
+                }
+                current_base_index += region.frame_count;
+            }
+        }
         None
     }
 
     fn is_frame_allocated(&self, index: usize) -> bool {
-        if index >= MAX_FRAMES {
-            return false;
-        }
         let word_index = index / 64;
         let bit_index = index % 64;
         (self.allocated_bitmap[word_index] & (1 << bit_index)) != 0
     }
 
     fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
-        if index >= MAX_FRAMES {
-            return;
-        }
         let word_index = index / 64;
         let bit_index = index % 64;
         if allocated {
@@ -83,31 +132,35 @@ impl BitmapFrameAllocator {
     }
 
     pub fn total_usable_frames(&self) -> usize {
-        self.usable_frames().take(MAX_FRAMES).count()
+        self.frames_count
     }
 }
 
 unsafe impl FrameAllocator<Size4KiB> for BitmapFrameAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        for (i, frame) in self.usable_frames().enumerate() {
-            if i >= MAX_FRAMES {
-                break;
-            }
-            if !self.is_frame_allocated(i) {
-                self.set_frame_allocated(i, true);
-                return Some(frame);
+        for i in 0..self.frames_count {
+            let index = (self.next_free_index + i) % self.frames_count;
+            if !self.is_frame_allocated(index) {
+                self.set_frame_allocated(index, true);
+                self.next_free_index = index + 1;
+                return self.index_to_frame(index);
             }
         }
-        None
+        None // No free frames
     }
 }
 
 impl FrameDeallocator<Size4KiB> for BitmapFrameAllocator {
     unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
-        if let Some(index) = self.frame_to_bitmap_index(frame) {
+        if let Some(index) = self.frame_to_index(frame) {
             if self.is_frame_allocated(index) {
                 self.set_frame_allocated(index, false);
+                self.next_free_index = self.next_free_index.min(index);
+            } else {
+                //panic!("Double free detected");
             }
+        } else {
+            //panic!("Deallocating a frame not managed by the allocator");
         }
     }
 }

--- a/src/sys/mem/heap.rs
+++ b/src/sys/mem/heap.rs
@@ -1,3 +1,5 @@
+use super::with_frame_allocator;
+
 use crate::sys;
 
 use core::cmp;
@@ -14,7 +16,6 @@ pub const HEAP_START: u64 = 0x4444_4444_0000;
 
 pub fn init_heap() -> Result<(), MapToError<Size4KiB>> {
     let mapper = super::mapper();
-    let mut frame_allocator = super::frame_allocator();
 
     // Use half of the memory for the heap caped to 16 MB by default
     // because the allocator is slow.
@@ -31,13 +32,16 @@ pub fn init_heap() -> Result<(), MapToError<Size4KiB>> {
 
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
 
-    for page in pages {
-        let err = MapToError::FrameAllocationFailed;
-        let frame = frame_allocator.allocate_frame().ok_or(err)?;
-        unsafe {
-            mapper.map_to(page, frame, flags, &mut frame_allocator)?.flush();
+    with_frame_allocator(|frame_allocator| -> Result<(), MapToError<Size4KiB>> {
+        for page in pages {
+            let err = MapToError::FrameAllocationFailed;
+            let frame = frame_allocator.allocate_frame().ok_or(err)?;
+            unsafe {
+                mapper.map_to(page, frame, flags, frame_allocator)?.flush();
+            }
         }
-    }
+        Ok(())
+    })?;
 
     unsafe {
         ALLOCATOR.lock().init(heap_start.as_mut_ptr(), heap_size as usize);

--- a/src/sys/mem/heap.rs
+++ b/src/sys/mem/heap.rs
@@ -2,7 +2,6 @@ use super::with_frame_allocator;
 
 use crate::sys;
 
-use core::cmp;
 use linked_list_allocator::LockedHeap;
 use x86_64::structures::paging::{
     mapper::MapToError, FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB
@@ -17,9 +16,8 @@ pub const HEAP_START: u64 = 0x4444_4444_0000;
 pub fn init_heap() -> Result<(), MapToError<Size4KiB>> {
     let mapper = super::mapper();
 
-    // Use half of the memory for the heap caped to 16 MB by default
-    // because the allocator is slow.
-    let heap_size = (cmp::min(super::memory_size(), heap_max()) / 2) as u64;
+    // Use half of the memory for the heap
+    let heap_size = (super::memory_size() / 2) as u64;
     let heap_start = VirtAddr::new(HEAP_START);
     sys::process::init_process_addr(HEAP_START + heap_size);
 
@@ -48,11 +46,6 @@ pub fn init_heap() -> Result<(), MapToError<Size4KiB>> {
     }
 
     Ok(())
-}
-
-fn heap_max() -> usize {
-    // Default to 32 MB
-    option_env!("MOROS_MEMORY").unwrap_or("32").parse::<usize>().unwrap() << 20
 }
 
 pub fn heap_size() -> usize {

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -71,7 +71,7 @@ pub fn init(boot_info: &'static BootInfo) {
 
     PHYS_MEM_OFFSET.call_once(|| boot_info.physical_memory_offset);
     MEMORY_MAP.call_once(|| &boot_info.memory_map);
-    bitmap::init_frame_allocator();
+    bitmap::init_frame_allocator(&boot_info.memory_map);
     heap::init_heap().expect("heap initialization failed");
 
     sys::idt::clear_irq_mask(1);

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -1,18 +1,19 @@
+mod bitmap;
 mod heap;
 mod paging;
 mod phys;
 
+pub use bitmap::{frame_allocator, with_frame_allocator};
 pub use paging::{alloc_pages, free_pages, active_page_table, create_page_table};
 pub use phys::{phys_addr, PhysBuf};
 
 use crate::sys;
 
-use bootloader::bootinfo::{BootInfo, MemoryMap, MemoryRegionType};
+use bootloader::bootinfo::{BootInfo, MemoryMap};
 use core::sync::atomic::{AtomicUsize, Ordering};
-use spin::{Once, Mutex};
+use spin::Once;
 use x86_64::structures::paging::{
-    FrameAllocator, FrameDeallocator,
-    OffsetPageTable, PhysFrame, Size4KiB, Translate,
+    OffsetPageTable, Translate,
 };
 use x86_64::{PhysAddr, VirtAddr};
 
@@ -22,7 +23,6 @@ static mut MAPPER: Once<OffsetPageTable<'static>> = Once::new();
 static PHYS_MEM_OFFSET: Once<u64> = Once::new();
 static MEMORY_MAP: Once<&MemoryMap> = Once::new();
 static MEMORY_SIZE: AtomicUsize = AtomicUsize::new(0);
-static FRAME_ALLOCATOR: Once<Mutex<BootInfoFrameAllocator>> = Once::new();
 
 pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
@@ -71,11 +71,7 @@ pub fn init(boot_info: &'static BootInfo) {
 
     PHYS_MEM_OFFSET.call_once(|| boot_info.physical_memory_offset);
     MEMORY_MAP.call_once(|| &boot_info.memory_map);
-    FRAME_ALLOCATOR.call_once(|| {
-        Mutex::new(unsafe {
-            BootInfoFrameAllocator::init(MEMORY_MAP.get_unchecked())
-        })
-    });
+    bitmap::init_frame_allocator();
     heap::init_heap().expect("heap initialization failed");
 
     sys::idt::clear_irq_mask(1);
@@ -110,111 +106,3 @@ pub fn virt_to_phys(addr: VirtAddr) -> Option<PhysAddr> {
     mapper().translate_addr(addr)
 }
 
-const MAX_FRAMES: usize = (4 << 30) / 4096; // 4 GB of RAM
-const BITMAP_SIZE: usize = MAX_FRAMES / 64;
-
-pub struct BootInfoFrameAllocator {
-    memory_map: &'static MemoryMap,
-    allocated_bitmap: [u64; BITMAP_SIZE],
-}
-
-impl BootInfoFrameAllocator {
-    pub unsafe fn init(memory_map: &'static MemoryMap) -> Self {
-        Self {
-            memory_map,
-            allocated_bitmap: [0; BITMAP_SIZE],
-        }
-    }
-
-    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
-        let regions = self.memory_map.iter();
-        let usable_regions = regions.filter(|r|
-            r.region_type == MemoryRegionType::Usable
-        );
-        let addr_ranges = usable_regions.map(|r|
-            r.range.start_addr()..r.range.end_addr()
-        );
-        let frame_addresses = addr_ranges.flat_map(|r|
-            r.step_by(4096)
-        );
-        frame_addresses.map(|addr|
-            PhysFrame::containing_address(PhysAddr::new(addr))
-        )
-    }
-
-    fn frame_to_bitmap_index(&self, frame: PhysFrame) -> Option<usize> {
-        for (i, usable_frame) in self.usable_frames().enumerate() {
-            if usable_frame.start_address() == frame.start_address() {
-                return if i < MAX_FRAMES { Some(i) } else { None };
-            }
-            if i >= MAX_FRAMES {
-                break;
-            }
-        }
-
-        None
-    }
-
-    fn is_frame_allocated(&self, index: usize) -> bool {
-        if index >= MAX_FRAMES {
-            return false;
-        }
-        let word_index = index / 64;
-        let bit_index = index % 64;
-        (self.allocated_bitmap[word_index] & (1 << bit_index)) != 0
-    }
-
-    fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
-        if index >= MAX_FRAMES {
-            return;
-        }
-        let word_index = index / 64;
-        let bit_index = index % 64;
-        if allocated {
-            self.allocated_bitmap[word_index] |= 1 << bit_index;
-        } else {
-            self.allocated_bitmap[word_index] &= !(1 << bit_index);
-        }
-    }
-
-    pub fn total_usable_frames(&self) -> usize {
-        self.usable_frames().take(MAX_FRAMES).count()
-    }
-}
-
-unsafe impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
-    fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        for (i, frame) in self.usable_frames().enumerate() {
-            if i >= MAX_FRAMES {
-                break;
-            }
-            if !self.is_frame_allocated(i) {
-                self.set_frame_allocated(i, true);
-                return Some(frame);
-            }
-        }
-        None
-    }
-}
-
-impl FrameDeallocator<Size4KiB> for BootInfoFrameAllocator {
-    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
-        if let Some(index) = self.frame_to_bitmap_index(frame) {
-            if self.is_frame_allocated(index) {
-                self.set_frame_allocated(index, false);
-            }
-        }
-    }
-}
-
-pub fn frame_allocator() -> &'static Mutex<BootInfoFrameAllocator> {
-    FRAME_ALLOCATOR.get().expect("frame allocator not initialized")
-}
-
-pub fn with_frame_allocator<F, R>(f: F) -> R
-where
-    F: FnOnce(&mut BootInfoFrameAllocator) -> R,
-{
-    let mut allocator = frame_allocator().lock();
-    f(&mut *allocator)
-}

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -11,7 +11,8 @@ use bootloader::bootinfo::{BootInfo, MemoryMap, MemoryRegionType};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::{Once, Mutex};
 use x86_64::structures::paging::{
-    FrameAllocator, OffsetPageTable, PhysFrame, Size4KiB, Translate,
+    FrameAllocator, FrameDeallocator,
+    OffsetPageTable, PhysFrame, Size4KiB, Translate,
 };
 use x86_64::{PhysAddr, VirtAddr};
 
@@ -194,6 +195,20 @@ unsafe impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
         }
         None
     }
+}
+
+impl FrameDeallocator<Size4KiB> for BootInfoFrameAllocator {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
+        if let Some(index) = self.frame_to_bitmap_index(frame) {
+            if self.is_frame_allocated(index) {
+                self.set_frame_allocated(index, false);
+            }
+        }
+    }
+}
+
+pub unsafe fn deallocate_frame(frame: PhysFrame) {
+    frame_allocator().lock().deallocate_frame(frame);
 }
 
 pub fn frame_allocator() -> &'static Mutex<BootInfoFrameAllocator> {

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -207,10 +207,6 @@ impl FrameDeallocator<Size4KiB> for BootInfoFrameAllocator {
     }
 }
 
-pub unsafe fn deallocate_frame(frame: PhysFrame) {
-    frame_allocator().lock().deallocate_frame(frame);
-}
-
 pub fn frame_allocator() -> &'static Mutex<BootInfoFrameAllocator> {
     FRAME_ALLOCATOR.get().expect("frame allocator not initialized")
 }

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -6,9 +6,10 @@ pub use paging::{alloc_pages, free_pages, active_page_table, create_page_table};
 pub use phys::{phys_addr, PhysBuf};
 
 use crate::sys;
+
 use bootloader::bootinfo::{BootInfo, MemoryMap, MemoryRegionType};
 use core::sync::atomic::{AtomicUsize, Ordering};
-use spin::Once;
+use spin::{Once, Mutex};
 use x86_64::structures::paging::{
     FrameAllocator, OffsetPageTable, PhysFrame, Size4KiB, Translate,
 };
@@ -20,7 +21,7 @@ static mut MAPPER: Once<OffsetPageTable<'static>> = Once::new();
 static PHYS_MEM_OFFSET: Once<u64> = Once::new();
 static MEMORY_MAP: Once<&MemoryMap> = Once::new();
 static MEMORY_SIZE: AtomicUsize = AtomicUsize::new(0);
-static ALLOCATED_FRAMES: AtomicUsize = AtomicUsize::new(0);
+static FRAME_ALLOCATOR: Once<Mutex<BootInfoFrameAllocator>> = Once::new();
 
 pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
@@ -69,7 +70,11 @@ pub fn init(boot_info: &'static BootInfo) {
 
     PHYS_MEM_OFFSET.call_once(|| boot_info.physical_memory_offset);
     MEMORY_MAP.call_once(|| &boot_info.memory_map);
-
+    FRAME_ALLOCATOR.call_once(|| {
+        Mutex::new(unsafe {
+            BootInfoFrameAllocator::init(MEMORY_MAP.get_unchecked())
+        })
+    });
     heap::init_heap().expect("heap initialization failed");
 
     sys::idt::clear_irq_mask(1);
@@ -104,13 +109,20 @@ pub fn virt_to_phys(addr: VirtAddr) -> Option<PhysAddr> {
     mapper().translate_addr(addr)
 }
 
+const MAX_FRAMES: usize = (4 << 30) / 4096; // 4 GB of RAM
+const BITMAP_SIZE: usize = MAX_FRAMES / 64;
+
 pub struct BootInfoFrameAllocator {
     memory_map: &'static MemoryMap,
+    allocated_bitmap: [u64; BITMAP_SIZE],
 }
 
 impl BootInfoFrameAllocator {
     pub unsafe fn init(memory_map: &'static MemoryMap) -> Self {
-        BootInfoFrameAllocator { memory_map }
+        Self {
+            memory_map,
+            allocated_bitmap: [0; BITMAP_SIZE],
+        }
     }
 
     fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
@@ -128,17 +140,70 @@ impl BootInfoFrameAllocator {
             PhysFrame::containing_address(PhysAddr::new(addr))
         )
     }
+
+    fn frame_to_bitmap_index(&self, frame: PhysFrame) -> Option<usize> {
+        for (i, usable_frame) in self.usable_frames().enumerate() {
+            if usable_frame.start_address() == frame.start_address() {
+                return if i < MAX_FRAMES { Some(i) } else { None };
+            }
+            if i >= MAX_FRAMES {
+                break;
+            }
+        }
+
+        None
+    }
+
+    fn is_frame_allocated(&self, index: usize) -> bool {
+        if index >= MAX_FRAMES {
+            return false;
+        }
+        let word_index = index / 64;
+        let bit_index = index % 64;
+        (self.allocated_bitmap[word_index] & (1 << bit_index)) != 0
+    }
+
+    fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
+        if index >= MAX_FRAMES {
+            return;
+        }
+        let word_index = index / 64;
+        let bit_index = index % 64;
+        if allocated {
+            self.allocated_bitmap[word_index] |= 1 << bit_index;
+        } else {
+            self.allocated_bitmap[word_index] &= !(1 << bit_index);
+        }
+    }
+
+    pub fn total_usable_frames(&self) -> usize {
+        self.usable_frames().take(MAX_FRAMES).count()
+    }
 }
 
 unsafe impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        let next = ALLOCATED_FRAMES.fetch_add(1, Ordering::SeqCst);
-        // FIXME: When the heap is larger than a few megabytes,
-        // creating an iterator for each allocation become very slow.
-        self.usable_frames().nth(next)
+        for (i, frame) in self.usable_frames().enumerate() {
+            if i >= MAX_FRAMES {
+                break;
+            }
+            if !self.is_frame_allocated(i) {
+                self.set_frame_allocated(i, true);
+                return Some(frame);
+            }
+        }
+        None
     }
 }
 
-pub fn frame_allocator() -> BootInfoFrameAllocator {
-    unsafe { BootInfoFrameAllocator::init(MEMORY_MAP.get_unchecked()) }
+pub fn frame_allocator() -> &'static Mutex<BootInfoFrameAllocator> {
+    FRAME_ALLOCATOR.get().expect("frame allocator not initialized")
+}
+
+pub fn with_frame_allocator<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut BootInfoFrameAllocator) -> R,
+{
+    let mut allocator = frame_allocator().lock();
+    f(&mut *allocator)
 }

--- a/src/sys/mem/paging.rs
+++ b/src/sys/mem/paging.rs
@@ -2,6 +2,7 @@ use super::with_frame_allocator;
 
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::{
+    mapper::CleanUp,
     page::PageRangeInclusive,
     OffsetPageTable, PageTable, PhysFrame, Size4KiB,
     Page, PageTableFlags, Mapper, FrameAllocator,
@@ -76,6 +77,9 @@ pub fn free_pages(mapper: &mut OffsetPageTable, addr: u64, size: usize) {
         if let Ok((frame, mapping)) = mapper.unmap(page) {
             mapping.flush();
             unsafe {
+                with_frame_allocator(|frame_allocator| {
+                    mapper.clean_up(frame_allocator);
+                });
                 super::deallocate_frame(frame);
             }
         } else {

--- a/src/sys/mem/paging.rs
+++ b/src/sys/mem/paging.rs
@@ -5,7 +5,7 @@ use x86_64::structures::paging::{
     mapper::CleanUp,
     page::PageRangeInclusive,
     OffsetPageTable, PageTable, PhysFrame, Size4KiB,
-    Page, PageTableFlags, Mapper, FrameAllocator,
+    Page, PageTableFlags, Mapper, FrameAllocator, FrameDeallocator
 };
 use x86_64::VirtAddr;
 
@@ -77,10 +77,10 @@ pub fn free_pages(mapper: &mut OffsetPageTable, addr: u64, size: usize) {
         if let Ok((frame, mapping)) = mapper.unmap(page) {
             mapping.flush();
             unsafe {
-                with_frame_allocator(|frame_allocator| {
-                    mapper.clean_up(frame_allocator);
+                with_frame_allocator(|allocator| {
+                    mapper.clean_up(allocator);
+                    allocator.deallocate_frame(frame);
                 });
-                super::deallocate_frame(frame);
             }
         } else {
             //debug!("Could not unmap {:?}", page);

--- a/src/sys/mem/paging.rs
+++ b/src/sys/mem/paging.rs
@@ -1,3 +1,5 @@
+use super::with_frame_allocator;
+
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::{
     page::PageRangeInclusive,
@@ -25,7 +27,6 @@ pub fn alloc_pages(
     mapper: &mut OffsetPageTable, addr: u64, size: usize
 ) -> Result<(), ()> {
     let size = size.saturating_sub(1) as u64;
-    let mut frame_allocator = super::frame_allocator();
 
     let pages = {
         let start_page = Page::containing_address(VirtAddr::new(addr));
@@ -37,28 +38,28 @@ pub fn alloc_pages(
               | PageTableFlags::WRITABLE
               | PageTableFlags::USER_ACCESSIBLE;
 
-    for page in pages {
-        if let Some(frame) = frame_allocator.allocate_frame() {
-            let res = unsafe {
-                mapper.map_to(page, frame, flags, &mut frame_allocator)
-            };
-            if let Ok(mapping) = res {
-                //debug!("Mapped {:?} to {:?}", page, frame);
-                mapping.flush();
-            } else {
-                debug!("Could not map {:?} to {:?}", page, frame);
-                if let Ok(old_frame) = mapper.translate_page(page) {
-                    debug!("Already mapped to {:?}", old_frame);
+    with_frame_allocator(|frame_allocator| {
+        for page in pages {
+            if let Some(frame) = frame_allocator.allocate_frame() {
+                let res = unsafe {
+                    mapper.map_to(page, frame, flags, frame_allocator)
+                };
+                if let Ok(mapping) = res {
+                    mapping.flush();
+                } else {
+                    debug!("Could not map {:?} to {:?}", page, frame);
+                    if let Ok(old_frame) = mapper.translate_page(page) {
+                        debug!("Already mapped to {:?}", old_frame);
+                    }
+                    return Err(());
                 }
+            } else {
+                debug!("Could not allocate frame for {:?}", page);
                 return Err(());
             }
-        } else {
-            debug!("Could not allocate frame for {:?}", page);
-            return Err(());
         }
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 // TODO: Replace `free` by `dealloc`

--- a/src/sys/mem/paging.rs
+++ b/src/sys/mem/paging.rs
@@ -73,8 +73,11 @@ pub fn free_pages(mapper: &mut OffsetPageTable, addr: u64, size: usize) {
     };
 
     for page in pages {
-        if let Ok((_, mapping)) = mapper.unmap(page) {
+        if let Ok((frame, mapping)) = mapper.unmap(page) {
             mapping.flush();
+            unsafe {
+                super::deallocate_frame(frame);
+            }
         } else {
             //debug!("Could not unmap {:?}", page);
         }

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -332,8 +332,9 @@ impl Process {
             return Err(());
         }
 
-        let page_table_frame = sys::mem::frame_allocator().allocate_frame().
-            expect("frame allocation failed");
+        let page_table_frame = sys::mem::with_frame_allocator(|frame_allocator| {
+            frame_allocator.allocate_frame().expect("frame allocation failed")
+        });
 
         let page_table = unsafe {
             sys::mem::create_page_table(page_table_frame)

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -3,7 +3,7 @@ use crate::sys::console::Console;
 use crate::sys::fs::{Device, Resource};
 use crate::sys;
 use crate::sys::gdt::GDT;
-use crate::sys::mem::phys_mem_offset;
+use crate::sys::mem::{phys_mem_offset, with_frame_allocator};
 
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
@@ -20,7 +20,7 @@ use spin::RwLock;
 use x86_64::registers::control::Cr3;
 use x86_64::structures::idt::InterruptStackFrameValue;
 use x86_64::structures::paging::{
-    FrameAllocator, OffsetPageTable, PageTable, PhysFrame,
+    FrameAllocator, FrameDeallocator, OffsetPageTable, PageTable, PhysFrame,
     Translate, PageTableFlags, // Page, Size4KiB,
     mapper::TranslateResult
 };
@@ -246,10 +246,10 @@ pub fn exit() {
     unsafe {
         let (_, flags) = Cr3::read();
         Cr3::write(page_table_frame(), flags);
-    }
 
-    unsafe {
-        sys::mem::deallocate_frame(proc.page_table_frame);
+        with_frame_allocator(|allocator| {
+            allocator.deallocate_frame(proc.page_table_frame);
+        });
     }
 }
 

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -242,12 +242,15 @@ pub fn exit() {
     MAX_PID.fetch_sub(1, Ordering::SeqCst);
     set_id(proc.parent_id);
 
+    proc.free_pages();
     unsafe {
         let (_, flags) = Cr3::read();
         Cr3::write(page_table_frame(), flags);
     }
 
-    proc.free_pages();
+    unsafe {
+        sys::mem::deallocate_frame(proc.page_table_frame);
+    }
 }
 
 unsafe fn page_table_frame() -> PhysFrame {


### PR DESCRIPTION
With this new frame allocator, we can now deallocate frames when they are no longer needed, fixing the memory leaks that occurred after process termination.

- [x] Replace bump frame allocator with bitmap frame allocator
- [x] Add frame deallocator
- [x] Deallocate process page table frame
- [x] Deallocate frame after unmap
- [x] Clean up page table after unmap
- [x] Compute usable frames once during init