### PR TITLE
Fix max memory size to 4 GB

### DIFF
--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -40,7 +40,7 @@ fn frame_at(addr: u64) -> PhysFrame<Size4KiB> {
 }
 
 const MAX_REGIONS: usize = 32;
-const MAX_FRAMES: usize = (4 << 30) / 4096; // 4 GB of RAM
+const MAX_FRAMES: usize = super::MAX_MEMORY_SIZE / 4096;
 const BITMAP_SIZE: usize = MAX_FRAMES / 64;
 static FRAME_ALLOCATOR: Once<Mutex<BitmapFrameAllocator>> = Once::new();
 

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -10,6 +10,7 @@ pub use phys::{phys_addr, PhysBuf};
 use crate::sys;
 
 use bootloader::bootinfo::{BootInfo, MemoryMap};
+use core::cmp;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Once;
 use x86_64::structures::paging::{
@@ -23,6 +24,7 @@ static mut MAPPER: Once<OffsetPageTable<'static>> = Once::new();
 static PHYS_MEM_OFFSET: Once<u64> = Once::new();
 static MEMORY_MAP: Once<&MemoryMap> = Once::new();
 static MEMORY_SIZE: AtomicUsize = AtomicUsize::new(0);
+static MAX_MEMORY_SIZE: usize = 4 << 30; // 4 GB
 
 pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
@@ -59,7 +61,9 @@ pub fn init(boot_info: &'static BootInfo) {
     // their sizes and location vary depending on the amount of RAM on the
     // system. It doesn't affect the count in megabytes.
     log!("RAM {} MB", memory_size >> 20);
-    MEMORY_SIZE.store(memory_size as usize, Ordering::Relaxed);
+
+    let memory_size = cmp::min(memory_size as usize, MAX_MEMORY_SIZE);
+    MEMORY_SIZE.store(memory_size, Ordering::Relaxed);
 
     #[allow(static_mut_refs)]
     unsafe {


### PR DESCRIPTION
The bitmap frame allocator implement in #771 cannot handle more than 4 GB of RAM. We could increase that limit but this will use up a lot of memory when running with just 32 MB of RAM on QEMU, so it's more practical to cap the usable memory at 4 GB which is plenty for now.