### PR TITLE
Add IDT reset via triple fault

### DIFF
--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -3,7 +3,7 @@ use crate::api::process::ExitCode;
 use crate::sys::process::Registers;
 use crate::{api, hlt_loop, sys};
 
-use core::arch::naked_asm;
+use core::arch::{asm, naked_asm};
 use lazy_static::lazy_static;
 use spin::Mutex;
 use x86_64::instructions::interrupts;
@@ -14,10 +14,6 @@ use x86_64::structures::idt::{
 };
 use x86_64::structures::paging::OffsetPageTable;
 use x86_64::VirtAddr;
-
-pub fn init() {
-    IDT.load();
-}
 
 // Translate IRQ into system interrupt
 fn interrupt_index(irq: u8) -> u8 {
@@ -308,4 +304,17 @@ pub fn set_irq_handler(irq: u8, handler: fn()) {
 
         clear_irq_mask(irq);
     });
+}
+
+static NULL_IDT: InterruptDescriptorTable = InterruptDescriptorTable::new();
+
+pub fn reset() -> ! {
+    NULL_IDT.load(); // No exception handlers
+    unsafe {
+        asm!("int 0", options(noreturn)); // Division by zero --> Triple fault
+    }
+}
+
+pub fn init() {
+    IDT.load();
 }

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -311,7 +311,7 @@ static NULL_IDT: InterruptDescriptorTable = InterruptDescriptorTable::new();
 pub fn reset() -> ! {
     NULL_IDT.load(); // No exception handlers
     unsafe {
-        asm!("int 0", options(noreturn)); // Division by zero --> Triple fault
+        asm!("int 0", options(noreturn)); // Division by zero -> Triple fault
     }
 }
 

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -8,7 +8,6 @@ use crate::sys::process::Process;
 
 use alloc::vec;
 use core::alloc::Layout;
-use core::arch::asm;
 use smoltcp::wire::IpAddress;
 
 pub fn exit(code: ExitCode) -> ExitCode {
@@ -122,9 +121,8 @@ pub fn spawn(path: &str, args_ptr: usize, args_len: usize) -> ExitCode {
 pub fn stop(code: usize) -> usize {
     match code {
         0xCAFE => { // Reboot
-            unsafe {
-                asm!("xor rax, rax", "mov cr3, rax");
-            }
+            // TODO: Implement ACPI reset but keep IDT reset as fallback
+            sys::idt::reset();
         }
         0xDEAD => { // Halt
             sys::process::exit();


### PR DESCRIPTION
This PR add a `reset` function to the `idt` module to reboot by loading a null IDT without exception handlers then causing an interrupt leading to a triple fault.

Before that the kernel would reboot by setting CR3 to an invalid page table but the new method is more common and easier to understand when declared at the end of the `idt` module.