### PR TITLE
Fix interrupts issue in RTL8139 network driver

### DIFF
--- a/doc/hardware.md
+++ b/doc/hardware.md
@@ -4,15 +4,17 @@
 
 - [x] QEMU
   - [x] CPU: Intel Core 2 Duo T7700
-  - [x] NIC: Intel PRO/1000 MT Desktop
-  - [x] NIC: Realtek RTL8139C
-  - [x] NIC: AMD PCnet-FAST III
+  - [x] DSK: ATA
+  - [x] NET: Intel PRO/1000 MT Desktop
+  - [x] NET: Realtek RTL8139C
+  - [x] NET: AMD PCnet-FAST III
 
 - [x] VirtualBox
-  - [x] NIC: Intel PRO/1000 MT Desktop (82540EM)
-  - [x] NIC: Intel PRO/1000 MT Server (82545EM)
-  - [x] NIC: Intel PRO/1000 T Server (82543GC)
-  - [x] NIC: AMD PCnet-FAST III
+  - [x] DSK: ATA
+  - [x] NET: Intel PRO/1000 MT Desktop (82540EM)
+  - [x] NET: Intel PRO/1000 MT Server (82545EM)
+  - [x] NET: Intel PRO/1000 T Server (82543GC)
+  - [x] NET: AMD PCnet-FAST III
 
 - [x] Bochs
 
@@ -20,43 +22,67 @@
 
 ### Desktops
 
-- [x] Homebuilt (2007)
+- [x] Custom (2004)
+  - [x] MB: MSI RS482M
+  - [x] DSK: ATA
+  - [x] CPU: AMD Athlon 64 3200+ (2.0 GHz)
+  - [x] NET: Realtek RTL8100C
+  - [ ] SND: AC97
+
+- [x] Custom (2007)
   - [x] MB: Asus P5K
-  - [x] CPU: Intel Core 2 Duo E6850
-  - [x] NIC: Intel PRO/1000 GT Desktop
-  - [x] NIC: Realtek RTL8139B
-  - [x] NIC: Realtek RTL8139C
-  - [x] NIC: Realtek RTL8139D
+  - [x] DSK: ATA
+  - [x] CPU: Intel Core 2 Duo E6850 (3.0 GHz)
+  - [x] NET: Intel PRO/1000 GT Desktop (PCI)
+  - [x] NET: Realtek RTL8139B (PCI)
+  - [x] NET: Realtek RTL8139C (PCI)
+  - [x] NET: Realtek RTL8139D (PCI)
 
 - [x] HP ProLiant MicroServer N40L (2012)
   - [x] CPU: AMD Athlon II Dual Core
-  - [ ] NIC: HP NC107i
+  - [ ] NET: HP NC107i
 
 - [x] Lenovo ThinkCentre M83 SFF (2014)
-  - [x] CPU: Intel Pentium G3220
-  - [x] NIC: Intel I217-LM
+  - [x] CPU: Intel Pentium G3220 (3.0 GHz)
+  - [x] NET: Intel I217-LM
 
 - [x] Intel NUC 5CPYH (2015)
-  - [x] CPU: Intel Celeron N3050
-  - [ ] NIC: Realtek RTL8111HN
+  - [x] CPU: Intel Celeron N3050 (1.6 - 2.16 GHz)
+  - [ ] DSK: AHCI
+  - [ ] NET: Realtek RTL8111HN
 
 ### Laptops
 
 - [x] Dell Latitude E6400 (2008)
-  - [x] CPU: Intel Core 2 Duo P8600
-  - [x] NIC: Intel 82567LM
+  - [x] CPU: Intel Core 2 Duo P8600 (2.4 GHz)
+  - [x] DSK: ATA / AHCI
+  - [x] NET: Intel 82567LM
 
 - [x] Lenovo ThinkPad X200 (2008)
-  - [x] CPU: Intel Core 2 Duo P8600
-  - [x] NIC: Intel 82567LM
+  - [x] CPU: Intel Core 2 Duo P8600 (2.4 GHz)
+  - [x] DSK: ATA / AHCI
+  - [x] NET: Intel 82567LM
 
 - [x] Lenovo ThinkPad T440p (2013)
-  - [x] CPU: Intel Core i5-4300M
-  - [x] NIC: Intel I217-LM
+  - [x] CPU: Intel Core i5-4300M (2.6 - 3.3 GHz)
+  - [ ] DSK: AHCI
+  - [x] NET: Intel I217-LM
+
+- [x] Lenovo ThinkPad X260 (2016)
+  - [x] CPU: Intel i3-6100U (2.3 GHz)
+  - [ ] DSK: AHCI
+  - [x] NET: Intel I219-V
 
 - [x] ASUS EeeBook E202SA (2017)
-  - [x] CPU: Intel Pentium N3710
+  - [x] CPU: Intel Pentium N3710 (1.6 - 2.56 GHz)
+  - [ ] DSK: AHCI
+
+- [x] Lenovo ThinkPad X270 (2017)
+  - [x] CPU: Intel i3-6100U (2.6 - 3.3 GHz)
+  - [ ] DSK: AHCI
+  - [x] NET: Intel I219-V
 
 - [x] Lenovo ThinkPad T480 (2018)
-  - [x] CPU: Intel Core i5-8350U
-  - [ ] NIC: Intel I219-LM
+  - [x] CPU: Intel Core i5-8350U (1.7 - 3.6 GHz)
+  - [ ] DSK: AHCI
+  - [ ] NET: Intel I219-LM

--- a/src/sys/net/nic/rtl8139.rs
+++ b/src/sys/net/nic/rtl8139.rs
@@ -60,8 +60,8 @@ const TCR_MXDMA1: u32 = 1 << 9;
 const TCR_MXDMA2: u32 = 1 << 10;
 
 // Interrupt Mask Register
-//const IMR_TOK: u16 = 1 << 2; // Transmit OK Interrupt
-//const IMR_ROK: u16 = 1 << 0; // Receive OK Interrupt
+const IMR_TOK: u16 = 1 << 2; // Transmit OK Interrupt
+const IMR_ROK: u16 = 1 << 0; // Receive OK Interrupt
 
 //const CRS: u32 = 1 << 31; // Carrier Sense Lost
 //const TAB: u32 = 1 << 30; // Transmit Abort
@@ -98,10 +98,10 @@ pub struct Ports {
     pub cmd: Port<u8>,
 
     // Interrupt Mask Register (IMR)
-    //pub imr: Port<u16>,
+    pub imr: Port<u16>,
 
     // Interrupt Status Register (ISR)
-    //pub isr: Port<u16>,
+    pub isr: Port<u16>,
 
     // Transmit (Tx) Configuration Register (TCR)
     pub tx_config: Port<u32>,
@@ -138,8 +138,8 @@ impl Ports {
             capr: Port::new(io_base + 0x38),
             cba: Port::new(io_base + 0x3A),
             cmd: Port::new(io_base + 0x37),
-            //imr: Port::new(io_base + 0x3C),
-            //isr: Port::new(io_base + 0x3E),
+            imr: Port::new(io_base + 0x3C),
+            isr: Port::new(io_base + 0x3E),
             tx_config: Port::new(io_base + 0x40),
             rx_config: Port::new(io_base + 0x44),
         }
@@ -194,6 +194,13 @@ impl Device {
         device
     }
 
+    fn clear_interrupts(&mut self) {
+        let isr = unsafe { self.ports.isr.read() };
+        if isr != 0 {
+            unsafe { self.ports.isr.write(isr) }
+        }
+    }
+
     fn init(&mut self) {
         // Power on
         unsafe { self.ports.config1.write(0) }
@@ -207,10 +214,12 @@ impl Device {
             }
         }
 
-        // Set interrupts
-        //unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
+        self.clear_interrupts();
 
-        // Enable Receive and Transmitter
+        // Enable interrupts
+        unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
+
+        // Enable receiver and transmitter
         unsafe { self.ports.cmd.write(CR_RE | CR_TE) }
 
         // Read MAC addr
@@ -255,6 +264,8 @@ impl EthernetDeviceIO for Device {
     // [packet   (length - 4 bytes)]
     // [crc               (4 bytes)]
     fn receive_packet(&mut self) -> Option<Vec<u8>> {
+        self.clear_interrupts();
+
         let cmd = unsafe { self.ports.cmd.read() };
         if (cmd & CR_BUFE) == CR_BUFE {
             return None;


### PR DESCRIPTION
I set up a new config to test MOROS on the very first generation of consumer 64-bit CPU with an AMD Athlon 64 3400+ on a MSI RS482M (MS-7145) motherboard with 1 GB of RAM.

It has an integrated RLT8100C but it would receive only a few network packets before stopping receiving anything. The issue is that its interrupts need to be cleared to keep receiving packets.