### PR TITLE
Add kernel package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,10 @@ spell:
 pkg:
 	ls -1 dsk/var/pkg | grep -v index.html > dsk/var/pkg/index.html
 
+pkg-kernel:
+	cp $(bin) dsk/ini/kernel.img
+	sh run/deflate.sh dsk/ini/kernel.img
+
 clean:
 	cargo clean
 	rm -f www/*.html www/images/*.png

--- a/dsk/bin/pkg
+++ b/dsk/bin/pkg
@@ -7,15 +7,15 @@
 
 (def (pkg/fetch path) (do
   "Download the given file"
-  (print (str "Fetching '" path "'"))
+  (print (str "Retrieving '" path "'"))
   (set dir (dirname path))
   (if (not (file/exists? dir))
     (sh (str "write -p " dir "/")))
   (set res (sh (str "http " base path " => " path)))
   (if (= res 0)
-    (if (regex/match? "\\.z" path)
+    (if (regex/match? "\\.z$" path)
       (do
-        (print (str "Inflating '" path "'"))
+        (print (str "Extracting '" (slice path 0 (- (len path) 2)) "'"))
         (sh (str "inflate " path)))
       res)
     res)))

--- a/dsk/var/pkg/kernel
+++ b/dsk/var/pkg/kernel
@@ -1,0 +1,1 @@
+/ini/kernel.img.z


### PR DESCRIPTION
With this package we can copy the kernel and its loader to the beginning of the disk to boot MOROS from an ATA drive instead of a USB drive:

```
~
> dhcp
[3.038537] NET IP 10.0.2.15/24
[3.043537] NET GW 10.0.2.2
[3.052535] NET DNS 10.0.2.3

~
> pkg i kernel
Fetching '/var/pkg/kernel'
Fetching '/ini/kernel.img.z'
Inflating '/ini/kernel.img.z'

~
> read /ini/kernel => /dev/ata/0/0
```
