### PR TITLE
Store frame bitmap in memory region

### DIFF
--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -79,8 +79,8 @@ impl BitmapFrameAllocator {
 
         // TODO: Sum the size of the usable regions only
         let highest_addr = memory_map.last().unwrap().range.end_addr();
-        let max_frames = (highest_addr / 4096) as usize;
-        let bitmap_size = (max_frames + 63) / 64 * 8;
+        let frames_count = (highest_addr / 4096) as usize;
+        let bitmap_size = ((frames_count + 63) / 64) * 8;
 
         let mut allocator = Self {
             bitmap: &mut [],

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -1,4 +1,5 @@
 use bootloader::bootinfo::{MemoryMap, MemoryRegionType};
+use core::{cmp, slice};
 use spin::{Once, Mutex};
 use bit_field::BitField;
 use x86_64::structures::paging::{
@@ -7,19 +8,33 @@ use x86_64::structures::paging::{
 };
 use x86_64::PhysAddr;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 struct UsableRegion {
-    start_frame: PhysFrame,
+    first_frame: PhysFrame,
     frame_count: usize,
 }
 
 impl UsableRegion {
-    pub fn start_frame(&self) -> PhysFrame {
-        self.start_frame
+    // NOTE: end_addr is exclusive
+    pub fn new(start_addr: u64, end_addr: u64) -> Self {
+        let first_frame = frame_at(start_addr);
+        let last_frame = frame_at(end_addr - 1);
+        let a = first_frame.start_address();
+        let b = last_frame.start_address();
+        let frame_count = ((b - a) / 4096) as usize + 1;
+
+        Self {
+            first_frame,
+            frame_count
+        }
     }
 
-    pub fn end_frame(&self) -> PhysFrame {
-        self.start_frame + (self.frame_count - 1) as u64
+    pub fn first_frame(&self) -> PhysFrame {
+        self.first_frame
+    }
+
+    pub fn last_frame(&self) -> PhysFrame {
+        self.first_frame + (self.frame_count - 1) as u64
     }
 
     pub fn len(&self) -> usize {
@@ -27,11 +42,12 @@ impl UsableRegion {
     }
 
     pub fn contains(&self, frame: PhysFrame) -> bool {
-        self.start_frame() <= frame && frame <= self.end_frame()
+        self.first_frame() <= frame && frame <= self.last_frame()
     }
 
-    pub fn offset(&self, frame: PhysFrame) -> u64 {
-        (frame.start_address() - self.start_frame.start_address()) / 4096
+    pub fn offset(&self, frame: PhysFrame) -> usize {
+        let addr = frame.start_address() - self.first_frame.start_address();
+        (addr / 4096) as usize
     }
 }
 
@@ -39,9 +55,6 @@ fn frame_at(addr: u64) -> PhysFrame<Size4KiB> {
     PhysFrame::containing_address(PhysAddr::new(addr))
 }
 
-const MAX_REGIONS: usize = 32;
-const MAX_FRAMES: usize = super::MAX_MEMORY_SIZE / 4096;
-const BITMAP_SIZE: usize = MAX_FRAMES / 64;
 static FRAME_ALLOCATOR: Once<Mutex<BitmapFrameAllocator>> = Once::new();
 
 pub fn init_frame_allocator(memory_map: &'static MemoryMap) {
@@ -50,40 +63,84 @@ pub fn init_frame_allocator(memory_map: &'static MemoryMap) {
     });
 }
 
+const MAX_REGIONS: usize = 32;
+
 pub struct BitmapFrameAllocator {
+    bitmap: &'static mut [u64],
+    next_free_index: usize,
     usable_regions: [Option<UsableRegion>; MAX_REGIONS],
     regions_count: usize,
-    allocated_bitmap: [u64; BITMAP_SIZE],
-    next_free_index: usize,
     frames_count: usize,
 }
 
 impl BitmapFrameAllocator {
     pub fn init(memory_map: &'static MemoryMap) -> Self {
+        let mut bitmap_addr = None;
+
+        // TODO: Sum the size of the usable regions only
+        let highest_addr = memory_map.last().unwrap().range.end_addr();
+        let max_frames = (highest_addr / 4096) as usize;
+        let bitmap_size = (max_frames + 63) / 64 * 8;
+
         let mut allocator = Self {
+            bitmap: &mut [],
+            next_free_index: 0,
             usable_regions: [None; MAX_REGIONS],
             regions_count: 0,
-            allocated_bitmap: [0; BITMAP_SIZE],
-            next_free_index: 0,
             frames_count: 0,
         };
 
-        let usable_regions = memory_map.iter().filter(|r| {
-            r.region_type == MemoryRegionType::Usable
-        });
-        for region in usable_regions {
-            let start_frame = frame_at(region.range.start_addr());
-            let end_frame = frame_at(region.range.end_addr() - 1);
-            let size = end_frame.start_address() - start_frame.start_address();
-            let frame_count = 1 + (size / 4096) as usize;
+        for region in memory_map.iter() {
+            if region.region_type != MemoryRegionType::Usable {
+                continue;
+            }
 
-            debug_assert!(allocator.regions_count < MAX_REGIONS);
-            let desc = UsableRegion { start_frame, frame_count };
-            allocator.usable_regions[allocator.regions_count] = Some(desc);
-            allocator.regions_count += 1;
-            allocator.frames_count += frame_count;
+            let region_start = region.range.start_addr();
+            let region_end = region.range.end_addr();
+            let region_size = (region_end - region_start) as usize;
+
+            // Try to place the bitmap in the region
+            if bitmap_addr.is_none() && region_size >= bitmap_size {
+                bitmap_addr = Some(region_start);
+
+                // TODO: Check alignment
+                let addr = super::phys_to_virt(PhysAddr::new(region_start));
+                let ptr = addr.as_mut_ptr();
+                let len = bitmap_size / 8;
+                unsafe {
+                    allocator.bitmap = slice::from_raw_parts_mut(ptr, len);
+                    allocator.bitmap.fill(0);
+                }
+            }
+
+            // Calculate usable portion
+            let (usable_start, usable_end) = match bitmap_addr {
+                Some(addr) if region_start == addr => {
+                    let bitmap_end = region_start + bitmap_size as u64;
+                    if bitmap_end >= region_end {
+                        continue; // Entire region consumed by the bitmap
+                    }
+                    (bitmap_end, region_end)
+                },
+                _ => (region_start, region_end)
+            };
+
+            if usable_end - usable_start >= 4096 {
+                if allocator.regions_count >= MAX_REGIONS {
+                    debug!("MEM: Could not add usable region");
+                    break;
+                }
+                let r = UsableRegion::new(usable_start, usable_end);
+                allocator.usable_regions[allocator.regions_count] = Some(r);
+                allocator.regions_count += 1;
+                allocator.frames_count += r.len();
+            }
         }
-        allocator.frames_count = allocator.frames_count.min(MAX_FRAMES);
+
+        if bitmap_addr.is_none() {
+            panic!("MEM: No usable region large enough to host bitmap");
+        }
+
         allocator
     }
 
@@ -97,7 +154,7 @@ impl BitmapFrameAllocator {
             if let Some(region) = self.usable_regions[i] {
                 if index < base + region.len() {
                     let frame_offset = index - base;
-                    return Some(region.start_frame() + frame_offset as u64);
+                    return Some(region.first_frame() + frame_offset as u64);
                 }
                 base += region.len();
             }
@@ -111,7 +168,7 @@ impl BitmapFrameAllocator {
             if let Some(region) = self.usable_regions[i] {
                 if region.contains(frame) {
                     let frame_offset = region.offset(frame);
-                    return Some(base + frame_offset as usize);
+                    return Some(base + frame_offset);
                 }
                 base += region.len();
             }
@@ -122,13 +179,13 @@ impl BitmapFrameAllocator {
     fn is_frame_allocated(&self, index: usize) -> bool {
         let word_index = index / 64;
         let bit_index = index % 64;
-        self.allocated_bitmap[word_index].get_bit(bit_index)
+        self.bitmap[word_index].get_bit(bit_index)
     }
 
     fn set_frame_allocated(&mut self, index: usize, allocated: bool) {
         let word_index = index / 64;
         let bit_index = index % 64;
-        self.allocated_bitmap[word_index].set_bit(bit_index, allocated);
+        self.bitmap[word_index].set_bit(bit_index, allocated);
     }
 }
 
@@ -151,7 +208,7 @@ impl FrameDeallocator<Size4KiB> for BitmapFrameAllocator {
         if let Some(index) = self.frame_to_index(frame) {
             if self.is_frame_allocated(index) {
                 self.set_frame_allocated(index, false);
-                self.next_free_index = self.next_free_index.min(index);
+                self.next_free_index = cmp::min(self.next_free_index, index);
             } else {
                 //panic!("Double free detected");
             }
@@ -171,4 +228,25 @@ where
 {
     let mut allocator = frame_allocator().lock();
     f(&mut allocator)
+}
+
+#[test_case]
+fn test_usable_region() {
+    let region = UsableRegion {
+        first_frame: frame_at(4096),
+        frame_count: 10,
+    };
+
+    assert_eq!(region, UsableRegion::new(4096, 4096 * 11));
+
+    assert_eq!(region.len(), 10);
+
+    assert_eq!(region.first_frame(), frame_at(4096));
+    assert_eq!(region.last_frame(), frame_at(4096 * 10));
+
+    assert!(!region.contains(frame_at(0)));
+    assert!(region.contains(frame_at(4096)));
+    assert!(region.contains(frame_at(4096 * 3)));
+    assert!(region.contains(frame_at(4096 * 10)));
+    assert!(!region.contains(frame_at(4096 * 11)));
 }

--- a/src/sys/mem/bitmap.rs
+++ b/src/sys/mem/bitmap.rs
@@ -77,9 +77,15 @@ impl BitmapFrameAllocator {
     pub fn init(memory_map: &'static MemoryMap) -> Self {
         let mut bitmap_addr = None;
 
-        // TODO: Sum the size of the usable regions only
-        let highest_addr = memory_map.last().unwrap().range.end_addr();
-        let frames_count = (highest_addr / 4096) as usize;
+        let frames_count: usize = memory_map.iter().map(|region| {
+            if region.region_type == MemoryRegionType::Usable {
+                let size = region.range.end_addr() - region.range.start_addr();
+                debug_assert_eq!(size % 4096, 0);
+                (size / 4096) as usize
+            } else {
+                0
+            }
+        }).sum();
         let bitmap_size = ((frames_count + 63) / 64) * 8;
 
         let mut allocator = Self {

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -10,7 +10,6 @@ pub use phys::{phys_addr, PhysBuf};
 use crate::sys;
 
 use bootloader::bootinfo::{BootInfo, MemoryMap};
-use core::cmp;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Once;
 use x86_64::structures::paging::{
@@ -24,7 +23,6 @@ static mut MAPPER: Once<OffsetPageTable<'static>> = Once::new();
 static PHYS_MEM_OFFSET: Once<u64> = Once::new();
 static MEMORY_MAP: Once<&MemoryMap> = Once::new();
 static MEMORY_SIZE: AtomicUsize = AtomicUsize::new(0);
-static MAX_MEMORY_SIZE: usize = 4 << 30; // 4 GB
 
 pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
@@ -45,14 +43,14 @@ pub fn init(boot_info: &'static BootInfo) {
                 last_end_addr, start_addr - 1, "Unmapped" //, hole >> 10
             );
             if start_addr < (1 << 20) {
-                memory_size += hole; // BIOS memory
+                memory_size += hole as usize; // BIOS memory
             }
         }
         log!(
             "MEM [{:#016X}-{:#016X}] {:?}", // "({} KB)"
             start_addr, end_addr - 1, region.region_type //, size >> 10
         );
-        memory_size += size;
+        memory_size += size as usize;
         last_end_addr = end_addr;
     }
 
@@ -62,7 +60,6 @@ pub fn init(boot_info: &'static BootInfo) {
     // system. It doesn't affect the count in megabytes.
     log!("RAM {} MB", memory_size >> 20);
 
-    let memory_size = cmp::min(memory_size as usize, MAX_MEMORY_SIZE);
     MEMORY_SIZE.store(memory_size, Ordering::Relaxed);
 
     #[allow(static_mut_refs)]


### PR DESCRIPTION
This PR stores the frame bitmap directly in memory in the first usable region big enough for it, instead of using a static array as implemented in #771 that forced us to limit the maximum amount of RAM to 4 GB in #775 to be able to boot MOROS with 16 or 32 MB of RAM in QEMU and still have enough memory left for userspace.

This is similar to what we do for the block bitmap in the filesystem.