### PR TITLE
Refactor syscall handler and add FileList, CreateDir, Version syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,81 +1,3 @@
-# USAGE GUIDE:
-# Use 'make image' to build the OS disk.
-# Use 'make qemu' to run the emulator with default settings.
-# Use 'make qemu cpu=athlon64 memory=128 smp=1' to override settings.
-# Use 'make qemu kvm=true' for hardware acceleration (Linux only).
-# Use 'make clean' to remove build artifacts.
-
-.PHONY: setup image qemu clean user-nasm user-rust
-.EXPORT_ALL_VARIABLES:
-
-# Default Hardware Settings
-cpu     ?= Skylake-Client
-memory  ?= 512
-smp     ?= 4
-kvm     ?= false
-output  ?= video
-mode    ?= release
-nic     ?= rtl8139
-
-# Internal Paths
-bin = target/x86_64-moros/$(mode)/bootimage-moros.bin
-img = disk.img
-
-# QEMU CPU Configuration
-ifeq ($(kvm),true)
-    QEMU_CPU = host -accel kvm
-else
-    QEMU_CPU = $(cpu)
-endif
-
-# MOROS Environment
-export MOROS_VERSION = $(shell git describe --tags 2>/dev/null || echo "0.0.0")
-export MOROS_KEYBOARD = qwerty
-
-setup:
-    curl https://rustup.rs -sSf | sh -s -- -y --default-toolchain none
-    rustup show
-    cargo install bootimage
-
-user-nasm:
-    @mkdir -p dsk/bin
-    basename -s .s dsk/src/bin/*.s | xargs -I {} \
-        nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
-    basename -s .s dsk/src/bin/*.s | xargs -I {} \
-        sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
-    rm -f dsk/bin/*.tmp
-
-user-rust:
-    @mkdir -p dsk/bin
-    basename -s .rs src/bin/*.rs | xargs -I {} \
-        cargo rustc --no-default-features --features userspace --release --bin {} \
-        -- -C linker-flavor=ld -C link-args="-Ttext=0x800000"
-    basename -s .rs src/bin/*.rs | xargs -I {} \
-        cp target/x86_64-moros/release/{} dsk/bin/{}
-
-image: $(img)
-    touch src/lib.rs
-    cargo bootimage --no-default-features --features $(output) --bin moros $(if $(filter release,$(mode)),--release,)
-    dd conv=notrunc if=$(bin) of=$(img)
-
-$(img):
-    qemu-img create $(img) 32M
-
-qemu:
-    qemu-system-x86_64 \
-        -name "MOROS v$(MOROS_VERSION)" \
-        -cpu $(QEMU_CPU) \
-        -m $(memory) \
-        -smp $(smp) \
-        -drive file=$(img),format=raw \
-        -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0 \
-        $(if $(filter serial,$(output)),-display none -serial stdio,) \
-        $(if $(filter debug,$(mode)),-s -S,)
-
-clean:
-    cargo clean
-    rm -f $(img)
-    rm -rf dsk/bin/*
 # =============================================================================
 # MOROS MAKEFILE USAGE GUIDE
 # =============================================================================
@@ -107,7 +29,7 @@ clean:
 .EXPORT_ALL_VARIABLES:
 
 # Default Hardware Settings
-cpu     ?= Skylake-Client
+cpu     ?= core2duo
 memory  ?= 512
 smp     ?= 4
 kvm     ?= false
@@ -121,9 +43,9 @@ img = disk.img
 
 # QEMU CPU Configuration
 ifeq ($(kvm),true)
-    QEMU_CPU = host -accel kvm
+	QEMU_CPU = host -accel kvm
 else
-    QEMU_CPU = $(cpu)
+	QEMU_CPU = $(cpu)
 endif
 
 # MOROS Environment
@@ -131,46 +53,46 @@ export MOROS_VERSION = $(shell git describe --tags 2>/dev/null || echo "0.0.0")
 export MOROS_KEYBOARD = qwerty
 
 setup:
-    curl https://rustup.rs -sSf | sh -s -- -y --default-toolchain none
-    rustup show
-    cargo install bootimage
+	curl https://rustup.rs -sSf | sh -s -- -y --default-toolchain none
+	rustup show
+	cargo install bootimage
 
 user-nasm:
-    @mkdir -p dsk/bin
-    basename -s .s dsk/src/bin/*.s | xargs -I {} \
-        nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
-    basename -s .s dsk/src/bin/*.s | xargs -I {} \
-        sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
-    rm -f dsk/bin/*.tmp
+	@mkdir -p dsk/bin
+	basename -s .s dsk/src/bin/*.s | xargs -I {} \
+		nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
+	basename -s .s dsk/src/bin/*.s | xargs -I {} \
+		sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
+	rm -f dsk/bin/*.tmp
 
 user-rust:
-    @mkdir -p dsk/bin
-    basename -s .rs src/bin/*.rs | xargs -I {} \
-        cargo rustc --no-default-features --features userspace --release --bin {} \
-        -- -C linker-flavor=ld -C link-args="-Ttext=0x800000"
-    basename -s .rs src/bin/*.rs | xargs -I {} \
-        cp target/x86_64-moros/release/{} dsk/bin/{}
+	@mkdir -p dsk/bin
+	basename -s .rs src/bin/*.rs | xargs -I {} \
+		cargo rustc --no-default-features --features userspace --release --bin {} \
+		-- -C linker-flavor=ld -C link-args="-Ttext=0x800000"
+	basename -s .rs src/bin/*.rs | xargs -I {} \
+		cp target/x86_64-moros/release/{} dsk/bin/{}
 
 image: $(img)
-    touch src/lib.rs
-    cargo bootimage --no-default-features --features $(output) --bin moros $(if $(filter release,$(mode)),--release,)
-    dd conv=notrunc if=$(bin) of=$(img)
+	touch src/lib.rs
+	cargo bootimage --no-default-features --features $(output) --bin moros $(if $(filter release,$(mode)),--release,)
+	dd conv=notrunc if=$(bin) of=$(img)
 
 $(img):
-    qemu-img create $(img) 32M
+	qemu-img create $(img) 32M
 
 qemu:
-    qemu-system-x86_64 \
-        -name "MOROS v$(MOROS_VERSION)" \
-        -cpu $(QEMU_CPU) \
-        -m $(memory) \
-        -smp $(smp) \
-        -drive file=$(img),format=raw \
-        -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0 \
-        $(if $(filter serial,$(output)),-display none -serial stdio,) \
-        $(if $(filter debug,$(mode)),-s -S,)
+	qemu-system-x86_64 \
+		-name "MOROS v$(MOROS_VERSION)" \
+		-cpu $(QEMU_CPU) \
+		-m $(memory) \
+		-smp $(smp) \
+		-drive file=$(img),format=raw \
+		-netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0 \
+		$(if $(filter serial,$(output)),-display none -serial stdio,) \
+		$(if $(filter debug,$(mode)),-s -S,)
 
 clean:
-    cargo clean
-    rm -f $(img)
-    rm -rf dsk/bin/*
+	cargo clean
+	rm -f $(img)
+	rm -rf dsk/bin/*

--- a/Makefile
+++ b/Makefile
@@ -1,131 +1,176 @@
-.PHONY: setup image qemu
+# USAGE GUIDE:
+# Use 'make image' to build the OS disk.
+# Use 'make qemu' to run the emulator with default settings.
+# Use 'make qemu cpu=athlon64 memory=128 smp=1' to override settings.
+# Use 'make qemu kvm=true' for hardware acceleration (Linux only).
+# Use 'make clean' to remove build artifacts.
+
+.PHONY: setup image qemu clean user-nasm user-rust
 .EXPORT_ALL_VARIABLES:
 
-setup:
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
-	rustup show
-	cargo install bootimage
+# Default Hardware Settings
+cpu     ?= Skylake-Client
+memory  ?= 512
+smp     ?= 4
+kvm     ?= false
+output  ?= video
+mode    ?= release
+nic     ?= rtl8139
 
-# Compilation options
-output = video# video, serial
-keyboard = qwerty# qwerty, azerty, dvorak
-mode = release
-
-# Emulation options
-memory = 32
-smp = 2
-nic = rtl8139# rtl8139, pcnet, e1000
-audio = sdl# sdl, coreaudio
-signal = off# on
-kvm = false
-pcap = false
-trace = false# e1000
-monitor = false
-
-export MOROS_VERSION = $(shell git describe --tags | sed "s/^v//")
-export MOROS_KEYBOARD = $(keyboard)
-
-user-nasm:
-	basename -s .s dsk/src/bin/*.s | xargs -I {} \
-    nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
-	basename -s .s dsk/src/bin/*.s | xargs -I {} \
-		sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
-	rm dsk/bin/*.tmp
-
-user-cargo-opts = --no-default-features --features userspace --release
-
-# FIXME: Userspace alloc panic when the default `lld` linker is used because it
-# sets the entry point 0x200000 which is used by the kernel, so we use `ld` to
-# set it at 0x800000 that is free. With `ld` the resulting binaries are much
-# larger though. This is useful only for programs that allocate memory.
-ld-opts = -Ttext=800000 -Trodata=900000 -Tbss=950000
-linker-opts = -C linker-flavor=ld -C link-args="$(ld-opts)"
-
-user-rust:
-	basename -s .rs src/bin/*.rs | xargs -I {} \
-		touch dsk/bin/{}
-	basename -s .rs src/bin/*.rs | xargs -I {} \
-		cargo rustc $(user-cargo-opts) --bin {} \
-			-- $(linker-opts)
-	basename -s .rs src/bin/*.rs | xargs -I {} \
-		cp target/x86_64-moros/release/{} dsk/bin/{}
-	basename -s .rs src/bin/*.rs | xargs -I {} \
-		strip dsk/bin/{}
-
+# Internal Paths
 bin = target/x86_64-moros/$(mode)/bootimage-moros.bin
 img = disk.img
 
-$(img):
-	qemu-img create $(img) 32M
-
-cargo-opts = --no-default-features --features $(output) --bin moros
-ifeq ($(mode),release)
-	cargo-opts += --release
-endif
-
-# Rebuild MOROS if the features list changed
-image: $(img)
-	touch src/lib.rs
-	env | grep MOROS
-	cargo bootimage $(cargo-opts)
-	dd conv=notrunc if=$(bin) of=$(img)
-
-qemu-opts = -name "MOROS $$MOROS_VERSION" \
-			 -m $(memory) -smp $(smp) -drive file=$(img),format=raw \
-			 -audiodev $(audio),id=a0 -machine pcspk-audiodev=a0 \
-			 -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0
+# QEMU CPU Configuration
 ifeq ($(kvm),true)
-	qemu-opts += -cpu host -accel kvm
+    QEMU_CPU = host -accel kvm
 else
-	qemu-opts += -cpu core2duo
+    QEMU_CPU = $(cpu)
 endif
 
-ifeq ($(pcap),true)
-	qemu-opts += -object filter-dump,id=f1,netdev=e0,file=/tmp/qemu.pcap
-endif
+# MOROS Environment
+export MOROS_VERSION = $(shell git describe --tags 2>/dev/null || echo "0.0.0")
+export MOROS_KEYBOARD = qwerty
 
-ifeq ($(monitor),true)
-	qemu-opts += -monitor telnet:127.0.0.1:7777,server,nowait
-endif
+setup:
+    curl https://rustup.rs -sSf | sh -s -- -y --default-toolchain none
+    rustup show
+    cargo install bootimage
 
-ifeq ($(output),serial)
-	qemu-opts += -display none
-	qemu-opts += -chardev stdio,id=s0,signal=$(signal) -serial chardev:s0
-endif
+user-nasm:
+    @mkdir -p dsk/bin
+    basename -s .s dsk/src/bin/*.s | xargs -I {} \
+        nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
+    basename -s .s dsk/src/bin/*.s | xargs -I {} \
+        sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
+    rm -f dsk/bin/*.tmp
 
-ifeq ($(mode),debug)
-	qemu-opts += -s -S
-endif
+user-rust:
+    @mkdir -p dsk/bin
+    basename -s .rs src/bin/*.rs | xargs -I {} \
+        cargo rustc --no-default-features --features userspace --release --bin {} \
+        -- -C linker-flavor=ld -C link-args="-Ttext=0x800000"
+    basename -s .rs src/bin/*.rs | xargs -I {} \
+        cp target/x86_64-moros/release/{} dsk/bin/{}
 
-ifeq ($(trace),e1000)
-	qemu-opts += -trace 'e1000*'
-endif
+image: $(img)
+    touch src/lib.rs
+    cargo bootimage --no-default-features --features $(output) --bin moros $(if $(filter release,$(mode)),--release,)
+    dd conv=notrunc if=$(bin) of=$(img)
 
-# In debug mode, open another terminal with the following command
-# and type `continue` to start the boot process:
-# > gdb target/x86_64-moros/debug/moros -ex "target remote :1234"
+$(img):
+    qemu-img create $(img) 32M
 
 qemu:
-	qemu-system-x86_64 $(qemu-opts)
-
-test:
-	cargo test --release --lib --no-default-features --features serial -- \
-		-m $(memory) -cpu core2duo -display none -serial stdio \
-		-device isa-debug-exit,iobase=0xF4,iosize=0x04
-
-website:
-	cd www && sh build.sh
-
-spell:
-	cd dsk/lib/spell && sh build.sh
-
-pkg:
-	ls -1 dsk/var/pkg | grep -v index.html > dsk/var/pkg/index.html
-
-pkg-kernel:
-	cp $(bin) dsk/ini/kernel.img
-	sh run/deflate.sh dsk/ini/kernel.img
+    qemu-system-x86_64 \
+        -name "MOROS v$(MOROS_VERSION)" \
+        -cpu $(QEMU_CPU) \
+        -m $(memory) \
+        -smp $(smp) \
+        -drive file=$(img),format=raw \
+        -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0 \
+        $(if $(filter serial,$(output)),-display none -serial stdio,) \
+        $(if $(filter debug,$(mode)),-s -S,)
 
 clean:
-	cargo clean
-	rm -f www/*.html www/images/*.png
+    cargo clean
+    rm -f $(img)
+    rm -rf dsk/bin/*
+# =============================================================================
+# MOROS MAKEFILE USAGE GUIDE
+# =============================================================================
+#
+# 1. BASIC COMMANDS:
+#    make setup             - Install Rust tools and bootimage crate.
+#    make image             - Compile the kernel and create 'disk.img'.
+#    make qemu              - Launch the OS in QEMU with default settings.
+#    make clean             - Remove all build artifacts and the disk image.
+#
+# 2. HARDWARE OVERRIDES (Pass as arguments to 'make qemu'):
+#    cpu=...                - Set CPU model (e.g., Skylake-Client, athlon64, pentium4).
+#    memory=...             - Set RAM in MB (default is 512).
+#    smp=...                - Set number of CPU cores (default is 4).
+#    kvm=true               - Enable hardware acceleration (Linux hosts only).
+#
+# 3. OUTPUT & DEBUGGING:
+#    output=serial          - Redirect OS output to the terminal (headless mode).
+#    mode=debug             - Build without optimizations and wait for GDB.
+#
+# 4. USERSPACE DEVELOPMENT:
+#    make user-nasm         - Assemble .s files from 'dsk/src/bin/' to '/bin/'.
+#    make user-rust         - Compile .rs files from 'src/bin/' to '/bin/'.
+#
+# EXAMPLE: make qemu cpu=Skylake-Client memory=1024 smp=4 kvm=true
+# =============================================================================
+
+.PHONY: setup image qemu clean user-nasm user-rust
+.EXPORT_ALL_VARIABLES:
+
+# Default Hardware Settings
+cpu     ?= Skylake-Client
+memory  ?= 512
+smp     ?= 4
+kvm     ?= false
+output  ?= video
+mode    ?= release
+nic     ?= rtl8139
+
+# Internal Paths
+bin = target/x86_64-moros/$(mode)/bootimage-moros.bin
+img = disk.img
+
+# QEMU CPU Configuration
+ifeq ($(kvm),true)
+    QEMU_CPU = host -accel kvm
+else
+    QEMU_CPU = $(cpu)
+endif
+
+# MOROS Environment
+export MOROS_VERSION = $(shell git describe --tags 2>/dev/null || echo "0.0.0")
+export MOROS_KEYBOARD = qwerty
+
+setup:
+    curl https://rustup.rs -sSf | sh -s -- -y --default-toolchain none
+    rustup show
+    cargo install bootimage
+
+user-nasm:
+    @mkdir -p dsk/bin
+    basename -s .s dsk/src/bin/*.s | xargs -I {} \
+        nasm dsk/src/bin/{}.s -o dsk/bin/{}.tmp
+    basename -s .s dsk/src/bin/*.s | xargs -I {} \
+        sh -c "printf '\x7FBIN' | cat - dsk/bin/{}.tmp > dsk/bin/{}"
+    rm -f dsk/bin/*.tmp
+
+user-rust:
+    @mkdir -p dsk/bin
+    basename -s .rs src/bin/*.rs | xargs -I {} \
+        cargo rustc --no-default-features --features userspace --release --bin {} \
+        -- -C linker-flavor=ld -C link-args="-Ttext=0x800000"
+    basename -s .rs src/bin/*.rs | xargs -I {} \
+        cp target/x86_64-moros/release/{} dsk/bin/{}
+
+image: $(img)
+    touch src/lib.rs
+    cargo bootimage --no-default-features --features $(output) --bin moros $(if $(filter release,$(mode)),--release,)
+    dd conv=notrunc if=$(bin) of=$(img)
+
+$(img):
+    qemu-img create $(img) 32M
+
+qemu:
+    qemu-system-x86_64 \
+        -name "MOROS v$(MOROS_VERSION)" \
+        -cpu $(QEMU_CPU) \
+        -m $(memory) \
+        -smp $(smp) \
+        -drive file=$(img),format=raw \
+        -netdev user,id=e0,hostfwd=tcp::8080-:80 -device $(nic),netdev=e0 \
+        $(if $(filter serial,$(output)),-display none -serial stdio,) \
+        $(if $(filter debug,$(mode)),-s -S,)
+
+clean:
+    cargo clean
+    rm -f $(img)
+    rm -rf dsk/bin/*

--- a/doc/syscalls.md
+++ b/doc/syscalls.md
@@ -283,6 +283,29 @@ enum FileType {
     Device = 2,
 }
 ```
+## VERSION (0x13)
+```
+fn get_version() -> usize
+```
+Return a packed version ID.
+
+## CREATE_DIR (0x14)
+
+```
+fn create_dir(path: &str) -> Result<(), ()>
+```
+Create a new directory at the specified path.
+
+The raw syscall takes a pointer to the path string in RDI and its length in RSI. It returns 0 on success and usize::MAX (-1) on failure, for example, if the parent directory does not exist or the path is already taken.
+
+## FILE_LIST (0x15)
+```
+fn file_list(path: &str, buf: *mut u8, max_count: usize) -> usize
+```
+Fill a userspace buffer with a list of file names from the specified directory.
+
+The raw syscall takes a pointer to the directory path string in RDI and its length in RSI. It also takes a pointer to a destination buffer in RDX and the maximum number of entries in R10. Each file name is written as a 64-byte null-terminated string. The syscall returns the number of entries actually written to the buffer.
+
 
 The raw syscall returns a `isize` that will be converted a `FileType` if the
 number is positive.

--- a/src/sys/syscall/codes.rs
+++ b/src/sys/syscall/codes.rs
@@ -21,7 +21,9 @@ pub enum SyscallCode {
     Alloc       = 0x10,
     Free        = 0x11,
     Kind        = 0x12,
-    Version = 0x13
+    Version     = 0x13,
+    CreateDir   = 0x14,
+    FileList    = 0x15,
 }
 
 impl TryFrom<usize> for SyscallCode {

--- a/src/sys/syscall/codes.rs
+++ b/src/sys/syscall/codes.rs
@@ -1,0 +1,36 @@
+use core::convert::TryFrom;
+
+#[repr(usize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SyscallCode {
+    Exit    = 0x1,
+    Spawn   = 0x2,
+    Read    = 0x3,
+    Write   = 0x4,
+    Open    = 0x5,
+    Close   = 0x6,
+    Info    = 0x7,
+    Dup     = 0x8,
+    Delete  = 0x9,
+    Stop    = 0xA,
+    Sleep   = 0xB,
+    Poll    = 0xC,
+    Connect = 0xD,
+    Listen  = 0xE,
+    Accept  = 0xF,
+    Alloc   = 0x10,
+    Free    = 0x11,
+    Kind    = 0x12,
+}
+
+impl TryFrom<usize> for SyscallCode {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value >= 0x1 && value <= 0x12 {
+            Ok(unsafe { core::mem::transmute(value) })
+        } else {
+            Err(())
+        }
+    }
+}

--- a/src/sys/syscall/codes.rs
+++ b/src/sys/syscall/codes.rs
@@ -3,24 +3,25 @@ use core::convert::TryFrom;
 #[repr(usize)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SyscallCode {
-    Exit    = 0x1,
-    Spawn   = 0x2,
-    Read    = 0x3,
-    Write   = 0x4,
-    Open    = 0x5,
-    Close   = 0x6,
-    Info    = 0x7,
-    Dup     = 0x8,
-    Delete  = 0x9,
-    Stop    = 0xA,
-    Sleep   = 0xB,
-    Poll    = 0xC,
-    Connect = 0xD,
-    Listen  = 0xE,
-    Accept  = 0xF,
-    Alloc   = 0x10,
-    Free    = 0x11,
-    Kind    = 0x12,
+    Exit        = 0x1,
+    Spawn       = 0x2,
+    Read        = 0x3,
+    Write       = 0x4,
+    Open        = 0x5,
+    Close       = 0x6,
+    Info        = 0x7,
+    Dup         = 0x8,
+    Delete      = 0x9,
+    Stop        = 0xA,
+    Sleep       = 0xB,
+    Poll        = 0xC,
+    Connect     = 0xD,
+    Listen      = 0xE,
+    Accept      = 0xF,
+    Alloc       = 0x10,
+    Free        = 0x11,
+    Kind        = 0x12,
+    Version = 0x13
 }
 
 impl TryFrom<usize> for SyscallCode {

--- a/src/sys/syscall/mod.rs
+++ b/src/sys/syscall/mod.rs
@@ -155,6 +155,22 @@ pub fn dispatcher(
         SyscallCode::Version => {
             service::get_version()
         }
+        SyscallCode::CreateDir => {
+            let ptr = sys::process::ptr_from_addr(arg1 as u64) as *const u8;
+            let len = arg2;
+            let path = utf8_from_raw_parts(ptr as *mut u8, len);
+            service::create_dir(path) as usize
+        }
+        SyscallCode::FileList => {
+            let path_ptr = sys::process::ptr_from_addr(arg1 as u64) as *const u8;
+            let path_len = arg2;
+            let path = utf8_from_raw_parts(path_ptr as *mut u8, path_len);
+
+            let out_ptr = arg3 as *mut u8; 
+            let max_count = arg4;
+
+            service::file_list(path, out_ptr, max_count)
+        }
     }
 }
 

--- a/src/sys/syscall/mod.rs
+++ b/src/sys/syscall/mod.rs
@@ -1,12 +1,16 @@
-pub mod number;
+pub mod codes;
 pub mod service;
 
 use crate::api::process::ExitCode;
 use crate::sys;
 use crate::sys::fs::FileInfo;
+// use crate::sys::net::usage; Unused import
+use crate::sys::syscall::codes::SyscallCode;
 
+use core::convert::TryFrom;
 use core::arch::asm;
 use core::convert::TryInto;
+use core::usize;
 use smoltcp::wire::IpAddress;
 use smoltcp::wire::Ipv4Address;
 
@@ -18,43 +22,47 @@ fn utf8_from_raw_parts(ptr: *mut u8, len: usize) -> &'static str {
 }
 
 pub fn dispatcher(
-    n: usize,
+    syscall_code: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
     arg4: usize
 ) -> usize {
-    match n {
-        number::EXIT => service::exit(ExitCode::from(arg1)) as usize,
-        number::SLEEP => {
+    let code = match SyscallCode::try_from(syscall_code) {
+        Ok(c) => c,
+        Err(_) => unimplemented!()
+    };
+    match code {
+        SyscallCode::Exit => service::exit(ExitCode::from(arg1)) as usize,
+        SyscallCode::Sleep => {
             service::sleep(f64::from_bits(arg1 as u64));
             0
         }
-        number::DELETE => {
+        SyscallCode::Delete => {
             let ptr = sys::process::ptr_from_addr(arg1 as u64);
             let len = arg2;
             let path = utf8_from_raw_parts(ptr, len);
             service::delete(path) as usize
         }
-        number::INFO => {
+        SyscallCode::Info => {
             let ptr = sys::process::ptr_from_addr(arg1 as u64);
             let len = arg2;
             let path = utf8_from_raw_parts(ptr, len);
             let info = unsafe { &mut *(arg3 as *mut FileInfo) };
             service::info(path, info) as usize
         }
-        number::KIND => {
+        SyscallCode::Kind => {
             let handle = arg1;
             service::kind(handle) as usize
         }
-        number::OPEN => {
+        SyscallCode::Open => {
             let ptr = sys::process::ptr_from_addr(arg1 as u64);
             let len = arg2;
             let path = utf8_from_raw_parts(ptr, len);
             let flags = arg3 as u8;
             service::open(path, flags) as usize
         }
-        number::READ => {
+        SyscallCode::Read => {
             let handle = arg1;
             let ptr = sys::process::ptr_from_addr(arg2 as u64);
             let len = arg3;
@@ -63,7 +71,7 @@ pub fn dispatcher(
             };
             service::read(handle, buf) as usize
         }
-        number::WRITE => {
+        SyscallCode::Write => {
             let handle = arg1;
             let ptr = sys::process::ptr_from_addr(arg2 as u64);
             let len = arg3;
@@ -72,17 +80,17 @@ pub fn dispatcher(
             };
             service::write(handle, buf) as usize
         }
-        number::CLOSE => {
+        SyscallCode::Close => {
             let handle = arg1;
             service::close(handle);
             0
         }
-        number::DUP => {
+        SyscallCode::Dup => {
             let old_handle = arg1;
             let new_handle = arg2;
             service::dup(old_handle, new_handle) as usize
         }
-        number::SPAWN => {
+        SyscallCode::Spawn => {
             let path_ptr = sys::process::ptr_from_addr(arg1 as u64);
             let path_len = arg2;
             let path = utf8_from_raw_parts(path_ptr, path_len);
@@ -90,17 +98,17 @@ pub fn dispatcher(
             let args_len = arg4;
             service::spawn(path, args_ptr, args_len) as usize
         }
-        number::STOP => {
+        SyscallCode::Stop => {
             let code = arg1;
             service::stop(code)
         }
-        number::POLL => {
+        SyscallCode::Poll => {
             let ptr = sys::process::ptr_from_addr(arg1 as u64) as *const _;
             let len = arg2;
             let list = unsafe { core::slice::from_raw_parts(ptr, len) };
             service::poll(list) as usize
         }
-        number::CONNECT => {
+        SyscallCode::Connect => {
             let handle = arg1;
             let ptr = sys::process::ptr_from_addr(arg2 as u64);
             let len = arg3;
@@ -113,12 +121,12 @@ pub fn dispatcher(
                 -1 as isize as usize
             }
         }
-        number::LISTEN => {
+        SyscallCode::Listen => {
             let handle = arg1;
             let port = arg2 as u16;
             service::listen(handle, port) as usize
         }
-        number::ACCEPT => {
+        SyscallCode::Accept => {
             let handle = arg1;
             let ptr = sys::process::ptr_from_addr(arg2 as u64);
             let len = arg3;
@@ -130,12 +138,12 @@ pub fn dispatcher(
                 -1 as isize as usize
             }
         }
-        number::ALLOC => {
+        SyscallCode::Alloc => {
             let size = arg1;
             let align = arg2;
             service::alloc(size, align) as usize
         }
-        number::FREE => {
+        SyscallCode::Free => {
             let ptr = arg1 as *mut u8;
             let size = arg2;
             let align = arg3;
@@ -144,27 +152,24 @@ pub fn dispatcher(
             }
             0
         }
-        _ => {
-            unimplemented!();
-        }
     }
 }
 
 #[doc(hidden)]
-pub unsafe fn syscall0(n: usize) -> usize {
+pub unsafe fn syscall0(syscall_code: usize) -> usize {
     let res: usize;
     asm!(
-        "int 0x80", in("rax") n,
+        "int 0x80", in("rax") syscall_code,
         lateout("rax") res
     );
     res
 }
 
 #[doc(hidden)]
-pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
+pub unsafe fn syscall1(syscall_code: usize, arg1: usize) -> usize {
     let res: usize;
     asm!(
-        "int 0x80", in("rax") n,
+        "int 0x80", in("rax") syscall_code,
         in("rdi") arg1,
         lateout("rax") res
     );
@@ -172,10 +177,10 @@ pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
 }
 
 #[doc(hidden)]
-pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(syscall_code: usize, arg1: usize, arg2: usize) -> usize {
     let res: usize;
     asm!(
-        "int 0x80", in("rax") n,
+        "int 0x80", in("rax") syscall_code,
         in("rdi") arg1, in("rsi") arg2,
         lateout("rax") res
     );

--- a/src/sys/syscall/mod.rs
+++ b/src/sys/syscall/mod.rs
@@ -151,6 +151,9 @@ pub fn dispatcher(
                 service::free(ptr, size, align);
             }
             0
+        },
+        SyscallCode::Version => {
+            service::get_version()
         }
     }
 }

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -204,3 +204,10 @@ pub unsafe fn free(ptr: *mut u8, size: usize, align: usize) {
         sys::process::free(ptr, layout);
     }
 }
+
+pub fn get_version() -> usize {
+    let major = 0; 
+    let minor = 12;
+    let patch = 0;
+    (major << 16) | (minor << 8) | patch
+}

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -1,12 +1,9 @@
 use crate::api::fs::{FileIO, IO};
-use crate::api::process::ExitCode;
-use crate::sys;
-use crate::sys::fs::Device;
-use crate::sys::fs::FileInfo;
-use crate::sys::fs::Resource;
+use crate::api::process::{ExitCode};
 use crate::sys::process::Process;
+use crate::sys::fs::{Device, FileInfo, Resource,Dir ,filename, dirname, realpath};
+use crate::sys;
 
-use alloc::string::ToString;
 use alloc::vec;
 use core::alloc::Layout;
 use smoltcp::wire::IpAddress;
@@ -206,8 +203,47 @@ pub unsafe fn free(ptr: *mut u8, size: usize, align: usize) {
 }
 
 pub fn get_version() -> usize {
-    let major = 0; 
+    let major = 0;
     let minor = 12;
     let patch = 0;
-    (major << 16) | (minor << 8) | patch
+    let mini_patch = 1;
+
+    return (major << 24) | (minor << 16) | (patch << 8) | mini_patch;
+}
+
+pub fn create_dir(path: &str) -> isize {
+    let path = realpath(path);
+    let dirname = dirname(&path.as_str());
+    let filename = filename(&path.as_str());
+
+    if let Some(mut dir) = Dir::open(dirname) {
+        if dir.create_dir(filename).is_some() {
+            return 0;
+        }
+    }
+
+    -1
+}
+
+pub fn file_list(path: &str, out_ptr: *mut u8, max_count: usize) -> usize {
+    let mut count = 0;
+    let entry_size = 64;
+
+    if let Some(dir) = Dir::open(path) {
+        for entry in dir.entries() {
+            if count >= max_count { break; }
+
+            let name = entry.info().name();
+            let name_bytes = name.as_bytes();
+            let len = core::cmp::min(name_bytes.len(), entry_size - 1);
+
+            unsafe {
+                let slot_ptr = out_ptr.add(count * entry_size);
+                core::ptr::write_bytes(slot_ptr, 0, entry_size);
+                core::ptr::copy_nonoverlapping(name_bytes.as_ptr(), slot_ptr, len);
+            }
+            count += 1;
+        }
+    }
+    count
 }

--- a/src/sys/syscall/service.rs
+++ b/src/sys/syscall/service.rs
@@ -6,6 +6,7 @@ use crate::sys::fs::FileInfo;
 use crate::sys::fs::Resource;
 use crate::sys::process::Process;
 
+use alloc::string::ToString;
 use alloc::vec;
 use core::alloc::Layout;
 use smoltcp::wire::IpAddress;
@@ -32,7 +33,7 @@ pub fn info(path: &str, info: &mut FileInfo) -> isize {
         Ok(path) => path,
         Err(_) => return -1,
     };
-    if let Some(res) = sys::fs::info(&path) {
+    if let Some(res) = sys::fs::info(&path.as_str()) {
         *info = res;
         0
     } else {
@@ -53,7 +54,7 @@ pub fn open(path: &str, flags: u8) -> isize {
         Ok(path) => path,
         Err(_) => return -1,
     };
-    if let Some(resource) = sys::fs::open(&path, flags) {
+    if let Some(resource) = sys::fs::open(&path.as_str(), flags) {
         if let Ok(handle) = sys::process::create_handle(resource) {
             return handle as isize;
         }
@@ -101,11 +102,11 @@ pub fn spawn(path: &str, args_ptr: usize, args_len: usize) -> ExitCode {
         Ok(path) => path,
         Err(_) => return ExitCode::OpenError,
     };
-    if let Some(mut file) = sys::fs::File::open(&path) {
-        let mut buf = vec![0; file.size()];
-        if let Ok(bytes) = file.read(&mut buf) {
+    if let Some(mut file) = sys::fs::File::open(&path.as_str()) {
+        let mut buf: vec::Vec<u8> = vec![0; file.size()];
+        if let Ok(bytes) = file.read(&mut buf[..]) {
             buf.resize(bytes, 0);
-            if let Err(code) = Process::spawn(&buf, args_ptr, args_len) {
+            if let Err(code) = Process::spawn(&buf[..], args_ptr, args_len) {
                 code
             } else {
                 unreachable!(); // The kernel switched to the child process


### PR DESCRIPTION
I have performed a small refactoring of the syscall dispatcher by replacing the constants in number.rs with a type-safe 

- SyscallCode enum. I also renamed the variable n to syscall_code for better clarity.
- Added 3 new system calls:
- Version: Returns a packed version ID.
- CreateDir: Creates a directory at the specified path.
- FileList: Populates a provided buffer with the list of file names and returns the number of entries.

This is one of my first Pull Requests to this project. I've also updated the Makefile to allow testing on different CPU architectures and memory configurations.
