### PR TITLE
Add box to VGA palette array

### DIFF
--- a/src/sys/fs/block_device.rs
+++ b/src/sys/fs/block_device.rs
@@ -86,7 +86,7 @@ impl BlockDeviceIO for MemBlockDevice {
 }
 
 pub fn mount_mem() {
-    let mem = sys::mem::memory_free() / 3;
+    let mem = sys::mem::memory_free() / 2;
     let len = mem / super::BLOCK_SIZE; // TODO: take a size argument
     let dev = MemBlockDevice::new(len);
     *BLOCK_DEVICE.lock() = Some(BlockDevice::Mem(dev));

--- a/src/sys/vga/mod.rs
+++ b/src/sys/vga/mod.rs
@@ -132,7 +132,7 @@ pub fn init() {
     set_attr_ctrl_reg(0xE, 0x3E);
     set_attr_ctrl_reg(0xF, 0x3F);
 
-    Palette::default().write();
+    //Palette::default().write();
 
     disable_blinking();
     disable_underline();

--- a/src/sys/vga/palette.rs
+++ b/src/sys/vga/palette.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use crate::api::fs::{FileIO, IO};
 
+use alloc::boxed::Box;
 use core::convert::TryFrom;
 use spin::Mutex;
 
@@ -28,12 +29,12 @@ const DEFAULT_COLORS: [(u8, u8, u8); 16] = [
 
 #[derive(Debug, Clone)]
 pub struct Palette {
-    pub colors: [(u8, u8, u8); 256],
+    pub colors: Box<[(u8, u8, u8); 256]>,
 }
 
 impl Palette {
     pub fn new() -> Self {
-        Self { colors: [(0, 0, 0); 256] }
+        Self { colors: Box::new([(0, 0, 0); 256]) }
     }
 
     pub fn default() -> Self {
@@ -81,7 +82,7 @@ impl TryFrom<&[u8]> for Palette {
         if buf.len() != Palette::size() {
             return Err(());
         }
-        let mut colors = [(0, 0, 0); 256];
+        let mut colors = Box::new([(0, 0, 0); 256]);
         for (i, rgb) in buf.chunks(3).enumerate() {
             colors[i] = (rgb[0], rgb[1], rgb[2])
         }


### PR DESCRIPTION
This PR fixes the following issue:

```
warning: large size difference between variants
   --> src/sys/fs/mod.rs:130:1
    |
130 | / pub enum Resource {
131 | |     Dir(Dir),
    | |     -------- the second-largest variant contains at least 48 bytes
132 | |     File(File),
133 | |     Device(Device),
    | |     -------------- the largest variant contains at least 776 bytes
134 | | }
    | |_^ the entire enum is at least 776 bytes
    |
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> src/sys/fs/mod.rs:133:5
    |
133 |     Device(Device),
    |     ^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
```