### PR TITLE
Improve Lisp binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Improve Lisp binding (#848)
 - Add process devices (#836)
 - Improve Lisp user experience (#841)
 - Add assembler written in Lisp (#839)

--- a/doc/lisp-doc.md
+++ b/doc/lisp-doc.md
@@ -108,12 +108,23 @@
 ### quote '
 
     '(1 2 3) # => (1 2 3)
+
 ### quasiquote `
 ### unquote ,
 ### unquote-splice ,@
+
 ### splice @
 
+    ((fun (a b @c) c) '(1 2 (3))) # => (3)
+    ((fun (a b @c) c) '(1 2 ()))  # => ()
+    ((fun (a b @c) c) '(1 2))     # => ()
+
 ## Meta
+
+### apply
+
+    (apply + '(1 2 3)) # => 6
+    (apply + 1 2 '())  # => 3
 
 ### load
 
@@ -333,11 +344,18 @@ Applies the function to the elements of the list.
     (map first '((1 2) (3 4) (5 6))) # => (1 3 5)
     (map (fun (x) (* x 2)) '(1 2 3)) # => (2 4 6)
 
+### fold
+
+    (fold + 0 '(1 2 3)) # => 6
+    (fold + 0 '(1 2 3)) # => -6
+
 ### reduce
 
 Reduces the elements of the list with the function.
 
     (reduce + '(1 2 3)) # => 6
+    (reduce - '(1 2 3)) # => -4
+    (reduce + '())      # => 0
 
 ### filter
 

--- a/doc/lisp.md
+++ b/doc/lisp.md
@@ -30,7 +30,6 @@ Check the [documentation](/lisp-doc.md) for more information.
 - `if`
 - `cond`
 - `case`
-- `while`
 - `mac`
 - `fun`
 - `var`
@@ -39,6 +38,9 @@ Check the [documentation](/lisp-doc.md) for more information.
 - `def` (equivalent to `def-fun`)
 - `def-fun`
 - `def-mac`
+- `apply`
+- `fold`
+- `while`
 - `do`
 - `doc`
 - `eval`
@@ -183,8 +185,10 @@ Would produce the following output:
 ## Changelog
 
 ### Unreleased
+- Allow optional arguments
+- Add `fold` special form
+- Fix double eval issue with `apply`
 - Add `dict/pairs` function
-- Remove `apply` and keep only `reduce`
 - Change `socket/accept` to return `()` instead of an error
 - Replace long names (`string`, `variable`, `define`, ...) by short names (`str`, `var`, `def`, ...)
 - Change `and` and `or` to accept more than 2 args

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -88,8 +88,7 @@
 
 (def (reduce f ls)
   "Reduces the elements of the list with the function"
-  (if (empty? (tail ls)) (head ls)
-    (f (head ls) (reduce f (tail ls)))))
+  (fold f (first ls) (rest ls)))
 
 (def (map f ls)
   "Applies the function to the elements of the list"

--- a/dsk/lib/lisp/core.lsp
+++ b/dsk/lib/lisp/core.lsp
@@ -94,22 +94,22 @@
   "Applies the function to the elements of the list"
   (if (empty? ls) nil
     (cons
-      (f (head ls))
-      (map f (tail ls)))))
+      (f (first ls))
+      (map f (rest ls)))))
 
 (def (filter f ls)
   "Filters the elements of the list with the function"
   (if (empty? ls) nil
-    (if (f (head ls))
-      (cons (head ls) (filter f (tail ls)))
-      (filter f (tail ls)))))
+    (if (f (first ls))
+      (cons (first ls) (filter f (rest ls)))
+      (filter f (rest ls)))))
 
 (def (reject f ls)
   "Rejects the elements of the list with the function"
   (if (empty? ls) nil
-    (if (not (f (head ls)))
-      (cons (head ls) (reject f (tail ls)))
-      (reject f (tail ls)))))
+    (if (not (f (first ls)))
+      (cons (first ls) (reject f (rest ls)))
+      (reject f (rest ls)))))
 
 (def (intersection a b)
   "Returns the elements found in both lists"
@@ -118,7 +118,7 @@
 (def (rev ls)
   "Reverses the list"
   (if (nil? ls) ls
-    (concat (rev (tail ls)) (cons (head ls) '()))))
+    (concat (rev (rest ls)) (cons (first ls) '()))))
 
 (def (range start stop)
   "Returns a list of numbers from start to stop excluded"
@@ -127,11 +127,11 @@
 
 (def (min ls)
   "Returns the minimum element of the list"
-  (head (sort ls)))
+  (first (sort ls)))
 
 (def (max ls)
   "Returns the maximum element of the list"
-  (head (rev (sort ls))))
+  (first (rev (sort ls))))
 
 (def (abs x)
   "Returns the absolute value of the number"

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::f64::consts::PI;
 
-const BUILTINS: [&str; 25] = [
+const BUILTINS: [&str; 26] = [
     "quote",
     "quasiquote",
     "unquote",
@@ -23,7 +23,6 @@ const BUILTINS: [&str; 25] = [
     "if",
     "cond",
     "case",
-    "while",
     "fun",
     "var",
     "var?",
@@ -34,6 +33,8 @@ const BUILTINS: [&str; 25] = [
     "def-mac",
     "eval",
     "expand",
+    "apply",
+    "while",
     "do",
     "load",
     "doc",

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::f64::consts::PI;
 
-const BUILTINS: [&str; 26] = [
+const BUILTINS: [&str; 27] = [
     "quote",
     "quasiquote",
     "unquote",
@@ -34,6 +34,7 @@ const BUILTINS: [&str; 26] = [
     "eval",
     "expand",
     "apply",
+    "fold",
     "while",
     "do",
     "load",

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -371,7 +371,7 @@ pub fn bind(
                         if let Exp::Sym(_) = &l[1] {
                             is_variadic = true;
                             list[n - 1] = l[1].clone();
-                            if n <= m {
+                            if n - 1 <= m {
                                 let rest = args.drain((n - 1)..).collect();
                                 args.push(Exp::List(rest));
                             }
@@ -381,9 +381,10 @@ pub fn bind(
             }
             let m = args.len();
 
-            if n != m {
-                let s = if n != 1 { "s" } else { "" };
-                let a = if is_variadic { "at least " } else { "" };
+            if m != n {
+                let n = if is_variadic { n - 1 } else { n };        // Expect
+                let s = if n != 1 { "s" } else { "" };              // Plural
+                let a = if is_variadic { "at least " } else { "" }; // Prefix
                 return expected!("{}{} argument{}, got {}", a, n, s, m);
             }
             for (exp, arg) in list.iter().zip(args.iter()) {

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -1,4 +1,3 @@
-use super::eval::eval_args;
 use super::primitive;
 use super::FUNCTIONS;
 use super::{Err, Exp, Number};
@@ -348,21 +347,13 @@ pub fn env_set(
     }
 }
 
-enum InnerEnv {
-    Function,
-    Macro,
-}
-
-fn inner_env(
-    kind: InnerEnv,
+/// Bind arg values to param names in the new env returned.
+pub fn bind(
     params: &Exp,
     args: &[Exp],
     outer: &mut Rc<RefCell<Env>>,
 ) -> Result<Rc<RefCell<Env>>, Err> {
-    let mut args = match kind {
-        InnerEnv::Function => eval_args(args, outer)?,
-        InnerEnv::Macro => args.to_vec(),
-    };
+    let mut args = args.to_vec();
     let mut data: BTreeMap<String, Exp> = BTreeMap::new();
     match params {
         Exp::Sym(s) => {
@@ -409,20 +400,4 @@ fn inner_env(
         data,
         outer: Some(outer.clone()),
     })))
-}
-
-pub fn function_env(
-    params: &Exp,
-    args: &[Exp],
-    outer: &mut Rc<RefCell<Env>>,
-) -> Result<Rc<RefCell<Env>>, Err> {
-    inner_env(InnerEnv::Function, params, args, outer)
-}
-
-pub fn macro_env(
-    params: &Exp,
-    args: &[Exp],
-    outer: &mut Rc<RefCell<Env>>,
-) -> Result<Rc<RefCell<Env>>, Err> {
-    inner_env(InnerEnv::Macro, params, args, outer)
 }

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -113,6 +113,21 @@ fn eval_env_args(
     Ok(Exp::List(keys))
 }
 
+fn eval_apply_args(
+    args: &[Exp],
+    env: &mut Rc<RefCell<Env>>
+) -> Result<Exp, Err> {
+    ensure_length_gt!(args, 1);
+    let i = args.len() - 1;
+    let last = args[i].clone();
+    let mut args = eval_args(&args[0..i], env)?;
+    match eval(&last, env)? {
+        Exp::List(rest) => args.extend(rest),
+        _ => return expected!("last argument to be a list"),
+    }
+    apply(&args[0], &args[1..], env)
+}
+
 fn eval_while_args(
     args: &[Exp],
     env: &mut Rc<RefCell<Env>>
@@ -233,6 +248,9 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                     Exp::Sym(s) if s == "env" => {
                         return eval_env_args(args, env);
                     }
+                    Exp::Sym(s) if s == "apply" => {
+                        return eval_apply_args(args, env);
+                    }
                     Exp::Sym(s) if s == "expand" => {
                         ensure_length_eq!(args, 1);
                         return expand(&args[0], env);
@@ -271,9 +289,9 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                         return Ok(exp);
                     }
                     _ => {
-                        let head = eval(&list[0], env)?;
+                        let f = eval(&list[0], env)?;
                         let args = eval_args(args, env)?;
-                        match head {
+                        match f {
                             Exp::Function(f) => {
                                 env_tmp = bind(&f.params, &args, env)?;
                                 exp_tmp = f.body;
@@ -293,6 +311,25 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 }
             }
             _ => return Err(Err::Reason("Unexpected argument".to_string())),
+        }
+    }
+}
+
+fn apply(
+    f: &Exp,
+    args: &[Exp],
+    env: &mut Rc<RefCell<Env>>
+) -> Result<Exp, Err> {
+    match f {
+        Exp::Function(f) => {
+            let mut inner_env = bind(&f.params, &args, env)?;
+            eval(&f.body, &mut inner_env)
+        }
+        Exp::Primitive(f) => {
+            f(&args)
+        }
+        _ => {
+            expected!("first argument to be a function")
         }
     }
 }

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -143,6 +143,24 @@ fn eval_while_args(
     Ok(res)
 }
 
+fn eval_fold_args(
+    args: &[Exp],
+    env: &mut Rc<RefCell<Env>>
+) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 3);
+    let fun = eval(&args[0], env)?;
+    let mut acc = eval(&args[1], env)?;
+    match eval(&args[2], env)? {
+        Exp::List(list) => {
+            for arg in list {
+                acc = apply(&fun, &[acc, arg], env)?;
+            }
+        }
+        _ => return expected!("last argument to be a list"),
+    }
+    Ok(acc)
+}
+
 fn eval_eval_args(
     args: &[Exp],
     env: &mut Rc<RefCell<Env>>
@@ -247,6 +265,9 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                     }
                     Exp::Sym(s) if s == "env" => {
                         return eval_env_args(args, env);
+                    }
+                    Exp::Sym(s) if s == "fold" => {
+                        return eval_fold_args(args, env);
                     }
                     Exp::Sym(s) if s == "apply" => {
                         return eval_apply_args(args, env);

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -1,4 +1,4 @@
-use super::env::{env_get, env_keys, env_set, function_env};
+use super::env::{env_get, env_keys, env_set, bind};
 use super::expand::expand;
 use super::string;
 use super::{exec, Env, Err, Exp, Function};
@@ -272,7 +272,8 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                     }
                     _ => match eval(&list[0], env)? {
                         Exp::Function(f) => {
-                            env_tmp = function_env(&f.params, args, env)?;
+                            let args = eval_args(args, env)?;
+                            env_tmp = bind(&f.params, &args, env)?;
                             exp_tmp = f.body;
                             env = &mut env_tmp;
                             exp = &exp_tmp;

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -270,19 +270,24 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                         };
                         return Ok(exp);
                     }
-                    _ => match eval(&list[0], env)? {
-                        Exp::Function(f) => {
-                            let args = eval_args(args, env)?;
-                            env_tmp = bind(&f.params, &args, env)?;
-                            exp_tmp = f.body;
-                            env = &mut env_tmp;
-                            exp = &exp_tmp;
-                        }
-                        Exp::Primitive(f) => {
-                            return f(&eval_args(args, env)?);
-                        }
-                        _ => {
-                            return expected!("first argument to be a function");
+                    _ => {
+                        let head = eval(&list[0], env)?;
+                        let args = eval_args(args, env)?;
+                        match head {
+                            Exp::Function(f) => {
+                                env_tmp = bind(&f.params, &args, env)?;
+                                exp_tmp = f.body;
+                                env = &mut env_tmp;
+                                exp = &exp_tmp;
+                            }
+                            Exp::Primitive(f) => {
+                                return f(&args);
+                            }
+                            _ => {
+                                return expected!(
+                                    "first argument to be a function"
+                                );
+                            }
                         }
                     },
                 }

--- a/src/usr/lisp/expand.rs
+++ b/src/usr/lisp/expand.rs
@@ -1,4 +1,4 @@
-use super::env::{env_get, macro_env};
+use super::env::{env_get, bind};
 use super::eval::eval;
 use super::{Env, Err, Exp};
 
@@ -165,7 +165,7 @@ pub fn expand(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
             }
             Exp::Sym(s) => {
                 if let Ok(Exp::Macro(m)) = env_get(s, env) {
-                    let mut m_env = macro_env(&m.params, &list[1..], env)?;
+                    let mut m_env = bind(&m.params, &list[1..], env)?;
                     let m_exp = m.body;
                     expand(&eval(&m_exp, &mut m_env)?, env)
                 } else {

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -774,4 +774,11 @@ fn test_lisp() {
     assert_eq!(eval!("(eval 42)"), "42");
     assert_eq!(eval!("(eval \"hello\")"), "\"hello\"");
     assert_eq!(eval!("(eval (dict \"a\" 1))"), "(dict \"a\" 1)");
+
+    // apply
+    assert_eq!(eval!("(apply add '(1 2 3))"), "6");
+    assert_eq!(eval!("(apply add 1 2 '(3))"), "6");
+    assert_eq!(eval!("(apply add 1 2 '())"), "3");
+    assert_eq!(eval!("(apply add '())"), "0");
+    assert_eq!(eval!("(apply (fun (x) x) (list '(1 2))))"), "(1 2)");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -784,4 +784,7 @@ fn test_lisp() {
 
     // fold
     assert_eq!(eval!("(fold sub 0 '(1 2 3))"), "-6");
+    assert_eq!(eval!("(fold sub 0 '(1 2))"), "-3");
+    assert_eq!(eval!("(fold sub 0 '(1))"), "-1");
+    assert_eq!(eval!("(fold sub 0 '())"), "0");
 }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -781,4 +781,7 @@ fn test_lisp() {
     assert_eq!(eval!("(apply add 1 2 '())"), "3");
     assert_eq!(eval!("(apply add '())"), "0");
     assert_eq!(eval!("(apply (fun (x) x) (list '(1 2))))"), "(1 2)");
+
+    // fold
+    assert_eq!(eval!("(fold sub 0 '(1 2 3))"), "-6");
 }

--- a/www/lisp-doc.html
+++ b/www/lisp-doc.html
@@ -142,7 +142,18 @@ foo          # =&gt; 10
 
     <h3>splice @</h3>
 
+    <pre><code>((fun (a b @c) c) &#39;(1 2 (3))) # =&gt; (3)
+((fun (a b @c) c) &#39;(1 2 ()))  # =&gt; ()
+((fun (a b @c) c) &#39;(1 2))     # =&gt; ()
+</code></pre>
+
     <h2>Meta</h2>
+
+    <h3>apply</h3>
+
+    <pre><code>(apply + &#39;(1 2 3)) # =&gt; 6
+(apply + 1 2 &#39;())  # =&gt; 3
+</code></pre>
 
     <h3>load</h3>
 
@@ -395,11 +406,19 @@ foo          # =&gt; 10
 (map (fun (x) (* x 2)) &#39;(1 2 3)) # =&gt; (2 4 6)
 </code></pre>
 
+    <h3>fold</h3>
+
+    <pre><code>(fold + 0 &#39;(1 2 3)) # =&gt; 6
+(fold + 0 &#39;(1 2 3)) # =&gt; -6
+</code></pre>
+
     <h3>reduce</h3>
 
     <p>Reduces the elements of the list with the function.</p>
 
     <pre><code>(reduce + &#39;(1 2 3)) # =&gt; 6
+(reduce - &#39;(1 2 3)) # =&gt; -4
+(reduce + &#39;())      # =&gt; 0
 </code></pre>
 
     <h3>filter</h3>

--- a/www/lisp.html
+++ b/www/lisp.html
@@ -46,7 +46,6 @@ shell.</p>
     <li><code>if</code></li>
     <li><code>cond</code></li>
     <li><code>case</code></li>
-    <li><code>while</code></li>
     <li><code>mac</code></li>
     <li><code>fun</code></li>
     <li><code>var</code></li>
@@ -55,6 +54,9 @@ shell.</p>
     <li><code>def</code> (equivalent to <code>def-fun</code>)</li>
     <li><code>def-fun</code></li>
     <li><code>def-mac</code></li>
+    <li><code>apply</code></li>
+    <li><code>fold</code></li>
+    <li><code>while</code></li>
     <li><code>do</code></li>
     <li><code>doc</code></li>
     <li><code>eval</code></li>
@@ -215,8 +217,10 @@ with the following content:</p>
     <h3>Unreleased</h3>
 
     <ul>
+    <li>Allow optional arguments</li>
+    <li>Add <code>fold</code> special form</li>
+    <li>Fix double eval issue with <code>apply</code></li>
     <li>Add <code>dict/pairs</code> function</li>
-    <li>Remove <code>apply</code> and keep only <code>reduce</code></li>
     <li>Change <code>socket/accept</code> to return <code>()</code> instead of an error</li>
     <li>Replace long names (<code>string</code>, <code>variable</code>, <code>define</code>, ...) by short names (<code>str</code>, <code>var</code>, <code>def</code>, ...)</li>
     <li>Change <code>and</code> and <code>or</code> to accept more than 2 args</li>

--- a/www/manual.html
+++ b/www/manual.html
@@ -182,7 +182,7 @@ Hello, World!
 tilde <code>~</code> means that you are in your home directory:</p>
 
     <pre><code>~
-&gt; print $DIR
+&gt; print $dir
 /usr/vinc
 </code></pre>
 
@@ -192,7 +192,7 @@ tilde <code>~</code> means that you are in your home directory:</p>
 &gt; /tmp
 
 /tmp
-&gt; print $DIR
+&gt; print $dir
 /tmp
 </code></pre>
 
@@ -296,20 +296,20 @@ file:</p>
     <pre><code>&gt; calc &quot;2 * 60 * 60&quot;
 7200
 
-&gt; env TZ 7200
+&gt; set --env TZ 7200
 
 &gt; date
 2023-03-21 12:00:00 +0200
 </code></pre>
 
-    <p>Add <code>env TZ 7200</code> to <code>/ini/boot.sh</code> before <code>shell</code> to save the timezone:</p>
+    <p>Add <code>set --env TZ 7200</code> to <code>/ini/boot.sh</code> before <code>shell</code> to save the timezone:</p>
 
     <pre><code>&gt; read /ini/boot.sh
 shell /ini/palettes/gruvbox-dark.sh
 read /ini/fonts/zap-light-8x16.psf =&gt; /dev/vga/font
 read /ini/banner.txt
 user login
-env TZ 7200
+set --env TZ 7200
 shell
 </code></pre>
 

--- a/www/shell.html
+++ b/www/shell.html
@@ -196,11 +196,11 @@ multiple heads like <code>=&gt;&gt;</code> will append to it.</p>
     <li>Name of the shell or the script: <code>$0</code></li>
     <li>Script arguments: <code>$1</code>, <code>$2</code>, <code>$3</code>, <code>$4</code>, ...</li>
     <li>Exit code: <code>$?</code></li>
-    <li>Process environment variable: <code>$HOME</code>, ...</li>
-    <li>Shell environment variable: <code>$foo</code>, ...</li>
+    <li>Environment variable: <code>$HOME</code>, ...</li>
+    <li>Shell variable: <code>$foo</code>, ...</li>
     </ul>
 
-    <p>Setting a variable in the shell environment is done with the following command:</p>
+    <p>Setting a variable in the shell is done with the following command:</p>
 
     <pre><code>&gt; set foo 42
 
@@ -216,13 +216,22 @@ multiple heads like <code>=&gt;&gt;</code> will append to it.</p>
 Hello Alice and Bob
 </code></pre>
 
-    <p>The process environment is copied to the shell environment when a session is
-started. By convention a process env var should be in uppercase and a shell
-env var should be lowercase.</p>
-
     <p>Unsetting a variable is done like this:</p>
 
     <pre><code>&gt; unset foo
+</code></pre>
+
+    <p>Environment variables are copied to the shell when a session is started.
+By convention an env var should be in uppercase and a shell var should be
+lowercase. They can be changed by using <code>--env</code> or <code>-e</code>.</p>
+
+    <pre><code>&gt; date
+2026-04-21 17:24:06 +0000
+
+&gt; set --env TZ 7200
+
+&gt; date
+2026-04-21 19:24:14 +0200
 </code></pre>
 
     <h2>Globbing</h2>


### PR DESCRIPTION
- [x] Move `eval::eval_args` calls out of `env::inner_env` in interpreter
- [x] Remove `env::function_env` and `env::macro_env` in interpreter
- [x] Rename `env::inner_env` to `env::bind` in interpreter
- [x] Allow optional arguments
- [x] Add `eval::apply` in interpreter
- [x] Add back `apply` special form without double eval bug
- [x] Add `fold` special form
- [x] Update doc