### PR TITLE
Add keyboard buffer device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add keyboard buffer device (#864)
 
 ## 0.13.0 (2026-06-21)
 - Fix memory leak during process creation ([#825](https://github.com/vinc/moros/pull/825))

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -182,6 +182,7 @@ fn device_type(name: &str) -> Result<DeviceType, ()> {
         "proc-dir"    => Ok(DeviceType::ProcDir),
         "proc-env"    => Ok(DeviceType::ProcEnv),
         "proc-user"   => Ok(DeviceType::ProcUser),
+        "kbd-buffer"  => Ok(DeviceType::KbdBuffer),
         _             => Err(()),
     }
 }

--- a/src/sys/fs/device.rs
+++ b/src/sys/fs/device.rs
@@ -15,6 +15,7 @@ use crate::sys::net::socket::tcp::TcpSocket;
 use crate::sys::net::socket::udp::UdpSocket;
 use crate::sys::rng::Random;
 use crate::sys::speaker::Speaker;
+use crate::sys::keyboard::KeyboardBuffer;
 use crate::sys::vga::{VgaFont, VgaMode, VgaPalette, VgaBuffer};
 use crate::sys::snd::SoundBuffer;
 use crate::sys::process::{ProcId, ProcDir, ProcEnv, ProcUser};
@@ -52,6 +53,7 @@ pub enum DeviceType {
     ProcDir     = 22,
     ProcEnv     = 23,
     ProcUser    = 24,
+    KbdBuffer   = 25,
 }
 
 impl TryFrom<&[u8]> for DeviceType {
@@ -84,6 +86,7 @@ impl TryFrom<&[u8]> for DeviceType {
             22 => Ok(DeviceType::ProcDir),
             23 => Ok(DeviceType::ProcEnv),
             24 => Ok(DeviceType::ProcUser),
+            25 => Ok(DeviceType::KbdBuffer),
              _ => Err(()),
         }
     }
@@ -115,6 +118,7 @@ impl DeviceType {
             DeviceType::ProcDir     => ProcDir::size(),
             DeviceType::ProcEnv     => ProcEnv::size(),
             DeviceType::ProcUser    => ProcUser::size(),
+            DeviceType::KbdBuffer   => KeyboardBuffer::size(),
             _                       => 1,
         };
         let mut res = vec![0; len];
@@ -150,6 +154,7 @@ pub enum Device {
     ProcDir(ProcDir),
     ProcEnv(ProcEnv),
     ProcUser(ProcUser),
+    KbdBuffer(KeyboardBuffer),
 }
 
 impl TryFrom<&[u8]> for Device {
@@ -181,6 +186,7 @@ impl TryFrom<&[u8]> for Device {
             DeviceType::ProcDir     => Ok(Device::ProcDir(ProcDir::new())),
             DeviceType::ProcEnv     => Ok(Device::ProcEnv(ProcEnv::new())),
             DeviceType::ProcUser    => Ok(Device::ProcUser(ProcUser::new())),
+            DeviceType::KbdBuffer   => Ok(Device::KbdBuffer(KeyboardBuffer::new())),
             DeviceType::Drive if buf.len() > 2 => {
                 let bus = buf[1];
                 let dsk = buf[2];
@@ -255,6 +261,7 @@ impl FileIO for Device {
             Device::ProcDir(io)     => io.read(buf),
             Device::ProcEnv(io)     => io.read(buf),
             Device::ProcUser(io)    => io.read(buf),
+            Device::KbdBuffer(io)   => io.read(buf),
         }
     }
 
@@ -285,6 +292,7 @@ impl FileIO for Device {
             Device::ProcDir(io)     => io.write(buf),
             Device::ProcEnv(io)     => io.write(buf),
             Device::ProcUser(io)    => io.write(buf),
+            Device::KbdBuffer(io)   => io.write(buf),
         }
     }
 
@@ -315,6 +323,7 @@ impl FileIO for Device {
             Device::ProcDir(io)     => io.close(),
             Device::ProcEnv(io)     => io.close(),
             Device::ProcUser(io)    => io.close(),
+            Device::KbdBuffer(io)   => io.close(),
         }
     }
 
@@ -345,6 +354,7 @@ impl FileIO for Device {
             Device::ProcDir(io)     => io.poll(event),
             Device::ProcEnv(io)     => io.poll(event),
             Device::ProcUser(io)    => io.poll(event),
+            Device::KbdBuffer(io)   => io.poll(event),
         }
     }
 }

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -105,7 +105,6 @@ fn send_csi(code: &str) {
 #[derive(Debug, Clone)]
 pub struct KeyboardBuffer;
 
-// Read scancodes from /dev/kbd/buffer
 impl KeyboardBuffer {
     pub fn new() -> Self {
         interrupts::without_interrupts(|| BUF.lock().clear());
@@ -149,11 +148,11 @@ fn interrupt_handler() {
     if let Some(ref mut keyboard) = *KEYBOARD.lock() {
         let scancode = read_scancode();
 
-        let mut kb = BUF.lock();
-        if kb.len() > 256 {
-            kb.pop_front();
+        let mut buf = BUF.lock();
+        if buf.len() > 256 {
+            buf.pop_front();
         }
-        kb.push_back(scancode);
+        buf.push_back(scancode);
 
         if let Ok(Some(event)) = keyboard.add_byte(scancode) {
             let ord = Ordering::Relaxed;

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -1,8 +1,11 @@
 use crate::api;
+use crate::api::fs::{FileIO, IO};
 use crate::sys;
 
+use alloc::collections::vec_deque::VecDeque;
 use alloc::format;
 use core::sync::atomic::{AtomicBool, Ordering};
+use lazy_static::lazy_static;
 use pc_keyboard::{
     layouts, DecodedKey, Error, HandleControl, KeyCode, KeyEvent, KeyState,
     Keyboard, ScancodeSet1,
@@ -10,6 +13,10 @@ use pc_keyboard::{
 use spin::Mutex;
 use x86_64::instructions::interrupts;
 use x86_64::instructions::port::Port;
+
+lazy_static! {
+    pub static ref BUF: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
+}
 
 pub static KEYBOARD: Mutex<Option<KeyboardLayout>> = Mutex::new(None);
 
@@ -95,9 +102,59 @@ fn send_csi(code: &str) {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct KeyboardBuffer;
+
+// Read scancodes from /dev/kbd/buffer
+impl KeyboardBuffer {
+    pub fn new() -> Self {
+        interrupts::without_interrupts(|| BUF.lock().clear());
+        Self {}
+    }
+
+    pub fn size() -> usize {
+        4
+    }
+}
+
+impl FileIO for KeyboardBuffer {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
+        interrupts::without_interrupts(||
+            if let Some(scancode) = BUF.lock().pop_front() {
+                buf[0] = scancode;
+                Ok(1)
+            } else {
+                Ok(0)
+            }
+        )
+    }
+
+    fn write(&mut self, _buf: &[u8]) -> Result<usize, ()> {
+        Err(())
+    }
+
+    fn close(&mut self) {}
+
+    fn poll(&mut self, event: IO) -> bool {
+        interrupts::without_interrupts(||
+            match event {
+                IO::Read => !BUF.lock().is_empty(),
+                IO::Write => false,
+            }
+        )
+    }
+}
+
 fn interrupt_handler() {
     if let Some(ref mut keyboard) = *KEYBOARD.lock() {
         let scancode = read_scancode();
+
+        let mut kb = BUF.lock();
+        if kb.len() > 256 {
+            kb.pop_front();
+        }
+        kb.push_back(scancode);
+
         if let Ok(Some(event)) = keyboard.add_byte(scancode) {
             let ord = Ordering::Relaxed;
             match event.code {

--- a/src/usr/install.rs
+++ b/src/usr/install.rs
@@ -49,6 +49,7 @@ pub fn copy_files(verbose: bool) {
     create_dir("/dev/ata/0", verbose);
     create_dir("/dev/ata/1", verbose);
     create_dir("/dev/clk", verbose); // Clock
+    create_dir("/dev/kbd", verbose); // Keyboard
     create_dir("/dev/net", verbose); // Network
     create_dir("/dev/snd", verbose); // Sound
     create_dir("/dev/vga", verbose);
@@ -62,6 +63,7 @@ pub fn copy_files(verbose: bool) {
     create_dev("/dev/clk/epoch", "clk-epoch", verbose);
     create_dev("/dev/clk/rtc", "clk-rtc", verbose);
     create_dev("/dev/console", "console", verbose);
+    create_dev("/dev/kbd/buffer", "kbd-buffer", verbose);
     create_dev("/dev/net/tcp", "net-tcp", verbose);
     create_dev("/dev/net/udp", "net-udp", verbose);
     create_dev("/dev/net/gw", "net-gw", verbose);


### PR DESCRIPTION
Exposes raw PS/2 keyboard scan codes in `/dev/kbd/buffer`. Required to run DOOM in MOROS.