### PR TITLE
Add realpath to kernel FS module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add realpath to kernel FS module (#866)
 - Add file seek syscall (#863)
 - Add keyboard layout device (#865)
 - Add keyboard buffer device (#864)

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -9,9 +9,9 @@ mod pipe;
 mod read_dir;
 mod super_block;
 
-use crate::sys;
+use crate::sys::process;
 
-pub use crate::api::fs::{dirname, filename, realpath, FileIO, IO};
+pub use crate::api::fs::{dirname, filename, FileIO, IO};
 pub use crate::sys::ata::BLOCK_SIZE;
 pub use bitmap_block::BITMAP_SIZE;
 pub use block_device::{
@@ -25,11 +25,24 @@ pub use file::{File, SeekFrom};
 use dir_entry::DirEntry;
 use super_block::SuperBlock;
 
+use alloc::format;
 use alloc::string::{String, ToString};
 use core::convert::TryFrom;
 use core::ops::BitOr;
 
 pub const VERSION: u8 = 2;
+
+// Duplicate of `api::fs::realpath`, using `process::dir()` from `sys` instead
+// of `api` to bypass syscall overhead.
+pub fn realpath(pathname: &str) -> String {
+    if pathname.starts_with('/') {
+        pathname.into()
+    } else {
+        let dirname = process::dir();
+        let sep = if dirname.ends_with('/') { "" } else { "/" };
+        format!("{}{}{}", dirname, sep, pathname)
+    }
+}
 
 // TODO: Move that to API
 #[derive(Clone, Copy)]
@@ -178,7 +191,7 @@ impl FileIO for Resource {
 }
 
 pub fn canonicalize(path: &str) -> Result<String, ()> {
-    match sys::process::env_var("HOME") {
+    match process::env_var("HOME") {
         Some(home) => {
             if path.starts_with('~') {
                 Ok(path.replace('~', &home))

--- a/src/sys/process/mod.rs
+++ b/src/sys/process/mod.rs
@@ -15,6 +15,7 @@ pub use table::{
     code_addr,
     env_var,
     set_user,
+    dir,
     alloc, free,
     handle, create_handle, update_handle, delete_handle,
     registers, set_registers,
@@ -25,7 +26,7 @@ use table::{
     PROCESS_TABLE,
     current_process,
     id, set_id,
-    dir, set_dir,
+    set_dir,
     env, set_env_var,
     user,
 };


### PR DESCRIPTION
This PR duplicates the `realpath` function inside the kernel FS module to bypass syscall overhead when opening a file, directory, or device from the kernel.