### PR TITLE
Remove dependency on x86_64::instructions::port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove dependency on x86_64::instructions::port (#872)
 - Improve process memory isolation (#869)
 - Add realpath to kernel FS module (#866)
 - Add file seek syscall (#863)

--- a/src/sys/acpi.rs
+++ b/src/sys/acpi.rs
@@ -1,4 +1,5 @@
 use crate::sys;
+use crate::sys::port::*;
 
 use acpi::{AcpiHandler, AcpiTables, PhysicalMapping};
 use acpi::platform::{Processor, ProcessorState};
@@ -6,10 +7,9 @@ use alloc::boxed::Box;
 use aml::value::AmlValue;
 use aml::{AmlContext, AmlName, DebugVerbosity, Handler};
 use core::ptr::NonNull;
-use x86_64::instructions::port::Port;
 use x86_64::PhysAddr;
 
-static mut PM1A_CNT_BLK: u32 = 0;
+static mut PM1A_CNT_BLK: u16 = 0;
 static mut SLP_TYPA: u16 = 0;
 static SLP_LEN: u16 = 1 << 13;
 
@@ -27,8 +27,9 @@ pub fn init() {
             }
             if let Ok(fadt) = acpi.find_table::<acpi::fadt::Fadt>() {
                 if let Ok(block) = fadt.pm1a_control_block() {
+                    debug_assert!(block.address <= u16::MAX as u64);
                     unsafe {
-                        PM1A_CNT_BLK = block.address as u32;
+                        PM1A_CNT_BLK = block.address as u16;
                     }
                 }
             }
@@ -73,8 +74,7 @@ pub fn init() {
 pub fn shutdown() {
     log!("ACPI Shutdown");
     unsafe {
-        let mut port: Port<u16> = Port::new(PM1A_CNT_BLK as u16);
-        port.write(SLP_TYPA | SLP_LEN);
+        outw(PM1A_CNT_BLK, SLP_TYPA | SLP_LEN);
     }
 }
 

--- a/src/sys/ata.rs
+++ b/src/sys/ata.rs
@@ -1,5 +1,6 @@
-use crate::sys;
 use crate::api::fs::{FileIO, IO};
+use crate::sys;
+use crate::sys::port::*;
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -9,7 +10,6 @@ use core::fmt;
 use core::hint::spin_loop;
 use lazy_static::lazy_static;
 use spin::Mutex;
-use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
 
 // Information Technology
 // AT Attachment with Packet Interface Extension (ATA/ATAPI-4)
@@ -19,6 +19,19 @@ pub const BLOCK_SIZE: usize = 512;
 
 // Keep track of the last selected bus and drive pair to speed up operations
 pub static LAST_SELECTED: Mutex<Option<(u8, u8)>> = Mutex::new(None);
+
+const DATA_REGISTER:             u16 = 0;
+const ERROR_REGISTER:            u16 = 1;
+const SECTOR_COUNT_REGISTER:     u16 = 2;
+const LBA0_REGISTER:             u16 = 3;
+const LBA1_REGISTER:             u16 = 4;
+const LBA2_REGISTER:             u16 = 5;
+const DRIVE_REGISTER:            u16 = 6;
+const STATUS_REGISTER:           u16 = 7;
+const COMMAND_REGISTER:          u16 = 7;
+
+const ALTERNATE_STATUS_REGISTER: u16 = 0;
+const CONTROL_REGISTER:          u16 = 0;
 
 #[repr(u16)]
 #[derive(Debug, Clone, Copy)]
@@ -54,84 +67,55 @@ enum Status {
 pub struct Bus {
     id: u8,
     irq: u8,
-
-    data_register: Port<u16>,
-    error_register: PortReadOnly<u8>,
-    features_register: PortWriteOnly<u8>,
-    sector_count_register: Port<u8>,
-    lba0_register: Port<u8>,
-    lba1_register: Port<u8>,
-    lba2_register: Port<u8>,
-    drive_register: Port<u8>,
-    status_register: PortReadOnly<u8>,
-    command_register: PortWriteOnly<u8>,
-
-    alternate_status_register: PortReadOnly<u8>,
-    control_register: PortWriteOnly<u8>,
-    drive_blockess_register: PortReadOnly<u8>,
+    io_base: u16,
+    ctrl_base: u16,
 }
 
 impl Bus {
     pub fn new(id: u8, io_base: u16, ctrl_base: u16, irq: u8) -> Self {
-        Self {
-            id,
-            irq,
-            data_register: Port::new(io_base + 0),
-            error_register: PortReadOnly::new(io_base + 1),
-            features_register: PortWriteOnly::new(io_base + 1),
-            sector_count_register: Port::new(io_base + 2),
-            lba0_register: Port::new(io_base + 3),
-            lba1_register: Port::new(io_base + 4),
-            lba2_register: Port::new(io_base + 5),
-            drive_register: Port::new(io_base + 6),
-            status_register: PortReadOnly::new(io_base + 7),
-            command_register: PortWriteOnly::new(io_base + 7),
-            alternate_status_register: PortReadOnly::new(ctrl_base + 0),
-            control_register: PortWriteOnly::new(ctrl_base + 0),
-            drive_blockess_register: PortReadOnly::new(ctrl_base + 1),
-        }
+        Self { id, io_base, ctrl_base, irq }
     }
 
-    fn check_floating_bus(&mut self) -> Result<(), ()> {
+    fn check_floating_bus(&self) -> Result<(), ()> {
         match self.status() {
             0xFF | 0x7F => Err(()),
             _ => Ok(()),
         }
     }
 
-    fn wait(&mut self, ns: u64) {
+    fn wait(&self, ns: u64) {
         sys::clk::wait(ns);
     }
 
-    fn clear_interrupt(&mut self) -> u8 {
-        unsafe { self.status_register.read() }
+    fn clear_interrupt(&self) -> u8 {
+        unsafe { inb(self.io_base + STATUS_REGISTER) }
     }
 
-    fn status(&mut self) -> u8 {
-        unsafe { self.alternate_status_register.read() }
+    fn status(&self) -> u8 {
+        unsafe { inb(self.ctrl_base + ALTERNATE_STATUS_REGISTER) }
     }
 
-    fn lba1(&mut self) -> u8 {
-        unsafe { self.lba1_register.read() }
+    fn lba1(&self) -> u8 {
+        unsafe { inb(self.io_base + LBA1_REGISTER) }
     }
 
-    fn lba2(&mut self) -> u8 {
-        unsafe { self.lba2_register.read() }
+    fn lba2(&self) -> u8 {
+        unsafe { inb(self.io_base + LBA2_REGISTER) }
     }
 
-    fn read_data(&mut self) -> u16 {
-        unsafe { self.data_register.read() }
+    fn read_data(&self) -> u16 {
+        unsafe { inw(self.io_base + DATA_REGISTER) }
     }
 
-    fn write_data(&mut self, data: u16) {
-        unsafe { self.data_register.write(data) }
+    fn write_data(&self, data: u16) {
+        unsafe { outw(self.io_base + DATA_REGISTER, data) }
     }
 
-    fn is_error(&mut self) -> bool {
+    fn is_error(&self) -> bool {
         self.status().get_bit(Status::ERR as usize)
     }
 
-    fn poll(&mut self, bit: Status, val: bool) -> Result<(), ()> {
+    fn poll(&self, bit: Status, val: bool) -> Result<(), ()> {
         let start = sys::clk::boot_time();
         while self.status().get_bit(bit as usize) != val {
             if sys::clk::boot_time() - start > 1.0 {
@@ -147,7 +131,7 @@ impl Bus {
         Ok(())
     }
 
-    fn select_drive(&mut self, drive: u8) -> Result<(), ()> {
+    fn select_drive(&self, drive: u8) -> Result<(), ()> {
         self.poll(Status::BSY, false)?;
         self.poll(Status::DRQ, false)?;
 
@@ -162,7 +146,7 @@ impl Bus {
             // Bit 4 => DEV
             // Bit 5 => 1
             // Bit 7 => 1
-            self.drive_register.write(0xA0 | (drive << 4))
+            outb(self.io_base + DRIVE_REGISTER, 0xA0 | (drive << 4));
         }
         sys::clk::wait(400); // Wait at least 400 ns
         self.poll(Status::BSY, false)?;
@@ -170,11 +154,7 @@ impl Bus {
         Ok(())
     }
 
-    fn write_command_params(
-        &mut self,
-        drive: u8,
-        block: u32
-    ) -> Result<(), ()> {
+    fn write_command_params(&self, drive: u8, block: u32) -> Result<(), ()> {
         let lba = true;
         let mut bytes = block.to_le_bytes();
         bytes[3].set_bit(4, drive > 0);
@@ -182,17 +162,19 @@ impl Bus {
         bytes[3].set_bit(6, lba);
         bytes[3].set_bit(7, true);
         unsafe {
-            self.sector_count_register.write(1);
-            self.lba0_register.write(bytes[0]);
-            self.lba1_register.write(bytes[1]);
-            self.lba2_register.write(bytes[2]);
-            self.drive_register.write(bytes[3]);
+            outb(self.io_base + SECTOR_COUNT_REGISTER, 1);
+            outb(self.io_base + LBA0_REGISTER, bytes[0]);
+            outb(self.io_base + LBA1_REGISTER, bytes[1]);
+            outb(self.io_base + LBA2_REGISTER, bytes[2]);
+            outb(self.io_base + DRIVE_REGISTER, bytes[3]);
         }
         Ok(())
     }
 
-    fn write_command(&mut self, cmd: Command) -> Result<(), ()> {
-        unsafe { self.command_register.write(cmd as u8) }
+    fn write_command(&self, cmd: Command) -> Result<(), ()> {
+        unsafe {
+            outb(self.io_base + COMMAND_REGISTER, cmd as u8);
+        }
         self.wait(400); // Wait at least 400 ns
         self.status(); // Ignore results of first read
         self.clear_interrupt();
@@ -209,18 +191,13 @@ impl Bus {
         Ok(())
     }
 
-    fn setup_pio(&mut self, drive: u8, block: u32) -> Result<(), ()> {
+    fn setup_pio(&self, drive: u8, block: u32) -> Result<(), ()> {
         self.select_drive(drive)?;
         self.write_command_params(drive, block)?;
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        drive: u8,
-        block: u32,
-        buf: &mut [u8]
-    ) -> Result<(), ()> {
+    fn read(&self, drive: u8, block: u32, buf: &mut [u8]) -> Result<(), ()> {
         debug_assert!(buf.len() == BLOCK_SIZE);
         self.setup_pio(drive, block)?;
         self.write_command(Command::Read)?;
@@ -237,7 +214,7 @@ impl Bus {
         }
     }
 
-    fn write(&mut self, drive: u8, block: u32, buf: &[u8]) -> Result<(), ()> {
+    fn write(&self, drive: u8, block: u32, buf: &[u8]) -> Result<(), ()> {
         debug_assert!(buf.len() == BLOCK_SIZE);
         self.setup_pio(drive, block)?;
         self.write_command(Command::Write)?;
@@ -254,7 +231,7 @@ impl Bus {
         }
     }
 
-    fn identify_drive(&mut self, drive: u8) -> Result<IdentifyResponse, ()> {
+    fn identify_drive(&self, drive: u8) -> Result<IdentifyResponse, ()> {
         if self.check_floating_bus().is_err() {
             return Ok(IdentifyResponse::None);
         }
@@ -278,25 +255,25 @@ impl Bus {
     }
 
     #[allow(dead_code)]
-    fn reset(&mut self) {
+    fn reset(&self) {
         unsafe {
-            self.control_register.write(4); // Set SRST bit
+            outb(self.ctrl_base + CONTROL_REGISTER, 4); // Set SRST bit
             self.wait(5); // Wait at least 5 ns
-            self.control_register.write(0); // Then clear it
+            outb(self.ctrl_base + CONTROL_REGISTER, 0); // Then clear it
             self.wait(2000); // Wait at least 2 ms
         }
     }
 
     #[allow(dead_code)]
-    fn debug(&mut self) {
+    fn debug(&self) {
         unsafe {
             debug!(
                 "ATA status register: 0b{:08b} <BSY|DRDY|#|#|DRQ|#|#|ERR>",
-                self.alternate_status_register.read()
+                inb(self.ctrl_base + ALTERNATE_STATUS_REGISTER)
             );
             debug!(
                 "ATA error register:  0b{:08b} <#|#|#|#|#|ABRT|#|#>",
-                self.error_register.read()
+                inb(self.io_base + ERROR_REGISTER)
             );
         }
     }
@@ -334,7 +311,7 @@ impl Drive {
     }
 
     pub fn open(bus: u8, dsk: u8) -> Option<Self> {
-        let mut buses = BUSES.lock();
+        let buses = BUSES.lock();
         let res = buses[bus as usize].identify_drive(dsk);
         if let Ok(IdentifyResponse::Ata(res)) = res {
             let buf = res.map(u16::to_be_bytes).concat();
@@ -445,11 +422,11 @@ pub fn list() -> Vec<Drive> {
 }
 
 pub fn read(bus: u8, drive: u8, block: u32, buf: &mut [u8]) -> Result<(), ()> {
-    let mut buses = BUSES.lock();
+    let buses = BUSES.lock();
     buses[bus as usize].read(drive, block, buf)
 }
 
 pub fn write(bus: u8, drive: u8, block: u32, buf: &[u8]) -> Result<(), ()> {
-    let mut buses = BUSES.lock();
+    let buses = BUSES.lock();
     buses[bus as usize].write(drive, block, buf)
 }

--- a/src/sys/clk/cmos.rs
+++ b/src/sys/clk/cmos.rs
@@ -1,21 +1,19 @@
 use super::rtc::{Interrupt, RTC, Register, RTC_CENTURY};
 
+use crate::sys::port::*;
+
 use bit_field::BitField;
 use core::hint::spin_loop;
 use x86_64::instructions::interrupts;
-use x86_64::instructions::port::Port;
 
-pub struct CMOS {
-    addr: Port<u8>,
-    data: Port<u8>,
-}
+const ADDR_PORT: u16 = 0x70;
+const DATA_PORT: u16 = 0x71;
+
+pub struct CMOS;
 
 impl CMOS {
     pub fn new() -> Self {
-        CMOS {
-            addr: Port::new(0x70),
-            data: Port::new(0x71),
-        }
+        Self
     }
 
     fn rtc_unchecked(&mut self) -> RTC {
@@ -128,10 +126,10 @@ impl CMOS {
         interrupts::without_interrupts(|| {
             self.disable_nmi();
             unsafe {
-                self.addr.write(Register::A as u8);
-                let prev = self.data.read();
-                self.addr.write(Register::A as u8);
-                self.data.write((prev & 0xF0) | rate);
+                outb(ADDR_PORT, Register::A as u8);
+                let prev = inb(DATA_PORT);
+                outb(ADDR_PORT, Register::A as u8);
+                outb(DATA_PORT, (prev & 0xF0) | rate);
             }
             self.enable_nmi();
             self.notify_end_of_interrupt();
@@ -142,10 +140,10 @@ impl CMOS {
         interrupts::without_interrupts(|| {
             self.disable_nmi();
             unsafe {
-                self.addr.write(Register::B as u8);
-                let prev = self.data.read();
-                self.addr.write(Register::B as u8);
-                self.data.write(prev | interrupt as u8);
+                outb(ADDR_PORT, Register::B as u8);
+                let prev = inb(DATA_PORT);
+                outb(ADDR_PORT, Register::B as u8);
+                outb(DATA_PORT, prev | interrupt as u8);
             }
             self.enable_nmi();
             self.notify_end_of_interrupt();
@@ -154,8 +152,8 @@ impl CMOS {
 
     pub fn notify_end_of_interrupt(&mut self) {
         unsafe {
-            self.addr.write(Register::C as u8);
-            self.data.read();
+            outb(ADDR_PORT, Register::C as u8);
+            inb(DATA_PORT);
         }
     }
 
@@ -167,36 +165,36 @@ impl CMOS {
 
     fn is_updating(&mut self) -> bool {
         unsafe {
-            self.addr.write(Register::A as u8);
-            self.data.read().get_bit(7)
+            outb(ADDR_PORT, Register::A as u8);
+            inb(DATA_PORT).get_bit(7)
         }
     }
 
     fn read_register(&mut self, reg: Register) -> u8 {
         unsafe {
-            self.addr.write(reg as u8);
-            self.data.read()
+            outb(ADDR_PORT, reg as u8);
+            inb(DATA_PORT)
         }
     }
 
     fn write_register(&mut self, reg: Register, value: u8) {
         unsafe {
-            self.addr.write(reg as u8);
-            self.data.write(value);
+            outb(ADDR_PORT, reg as u8);
+            outb(DATA_PORT, value);
         }
     }
 
     fn enable_nmi(&mut self) {
         unsafe {
-            let prev = self.addr.read();
-            self.addr.write(prev & 0x7F);
+            let prev = inb(ADDR_PORT);
+            outb(ADDR_PORT, prev & 0x7F);
         }
     }
 
     fn disable_nmi(&mut self) {
         unsafe {
-            let prev = self.addr.read();
-            self.addr.write(prev | 0x80);
+            let prev = inb(ADDR_PORT);
+            outb(ADDR_PORT, prev | 0x80);
         }
     }
 }

--- a/src/sys/clk/timer.rs
+++ b/src/sys/clk/timer.rs
@@ -2,10 +2,10 @@ use super::sync;
 use super::cmos::CMOS;
 
 use crate::sys;
+use crate::sys::port::*;
 
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use x86_64::instructions::interrupts;
-use x86_64::instructions::port::Port;
 
 // At boot the PIT starts with a frequency divider of 0 (equivalent to 65536)
 // which will result in about 54.926 ms between ticks.
@@ -39,14 +39,12 @@ pub fn pit_frequency() -> f64 {
 pub fn set_pit_frequency(divider: u16, channel: u8) {
     interrupts::without_interrupts(|| {
         let bytes = divider.to_le_bytes();
-        let mut cmd: Port<u8> = Port::new(0x43);
-        let mut data: Port<u8> = Port::new(0x40 + channel as u16);
         let operating_mode = 6; // Square wave generator
         let access_mode = 3; // Lobyte + Hibyte
         unsafe {
-            cmd.write((channel << 6) | (access_mode << 4) | operating_mode);
-            data.write(bytes[0]);
-            data.write(bytes[1]);
+            outb(0x43, (channel << 6) | (access_mode << 4) | operating_mode);
+            outb(0x40 + channel as u16, bytes[0]);
+            outb(0x40 + channel as u16, bytes[1]);
         }
     });
 }

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -1,12 +1,12 @@
 use crate::api::process::ExitCode;
 use crate::sys::process::Registers;
+use crate::sys::port::*;
 use crate::{api, hlt_loop, sys};
 
 use core::arch::{asm, naked_asm};
 use lazy_static::lazy_static;
 use spin::Mutex;
 use x86_64::instructions::interrupts;
-use x86_64::instructions::port::Port;
 use x86_64::registers::control::Cr2;
 use x86_64::structures::idt::{
     InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode
@@ -252,9 +252,8 @@ extern "sysv64" fn syscall_handler(
 const PIC1: u16 = 0x21;
 const PIC2: u16 = 0xA1;
 
-fn irq_port(irq: u8) -> Port<u8> {
-    let addr = if irq < 8 { PIC1 } else { PIC2 };
-    Port::new(addr)
+fn irq_port(irq: u8) -> u16 {
+    if irq < 8 { PIC1 } else { PIC2 }
 }
 
 fn irq_line(irq: u8) -> u8 {
@@ -262,18 +261,18 @@ fn irq_line(irq: u8) -> u8 {
 }
 
 pub fn set_irq_mask(irq: u8) {
-    let mut port = irq_port(irq);
+    let port = irq_port(irq);
     unsafe {
-        let value = port.read() | (1 << irq_line(irq));
-        port.write(value);
+        let value = inb(port) | (1 << irq_line(irq));
+        outb(port, value);
     }
 }
 
 pub fn clear_irq_mask(irq: u8) {
-    let mut port = irq_port(irq);
+    let port = irq_port(irq);
     unsafe {
-        let value = port.read() & !(1 << irq_line(irq));
-        port.write(value);
+        let value = inb(port) & !(1 << irq_line(irq));
+        outb(port, value);
     }
 }
 

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -1,6 +1,7 @@
 use crate::api;
 use crate::api::fs::{FileIO, IO};
 use crate::sys;
+use crate::sys::port::*;
 
 use alloc::collections::vec_deque::VecDeque;
 use alloc::format;
@@ -13,7 +14,6 @@ use pc_keyboard::{
 };
 use spin::Mutex;
 use x86_64::instructions::interrupts;
-use x86_64::instructions::port::Port;
 
 lazy_static! {
     pub static ref BUF: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
@@ -139,8 +139,7 @@ pub fn init() {
 }
 
 fn read_scancode() -> u8 {
-    let mut port = Port::new(0x60);
-    unsafe { port.read() }
+    unsafe { inb(0x60) }
 }
 
 fn send_key(c: char) {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -44,7 +44,7 @@ pub mod port {
     pub unsafe fn outb(port: u16, value: u8) {
         asm!(
             "out dx, al", in("dx") port, in("al") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
     }
 
@@ -53,7 +53,7 @@ pub mod port {
         let value: u8;
         asm!(
             "in al, dx", in("dx") port, out("al") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
         value
     }
@@ -62,7 +62,7 @@ pub mod port {
     pub unsafe fn outw(port: u16, value: u16) {
         asm!(
             "out dx, ax", in("dx") port, in("ax") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
     }
 
@@ -71,7 +71,7 @@ pub mod port {
         let value: u16;
         asm!(
             "in ax, dx", in("dx") port, out("ax") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
         value
     }
@@ -80,7 +80,7 @@ pub mod port {
     pub unsafe fn outl(port: u16, value: u32) {
         asm!(
             "out dx, eax", in("dx") port, in("eax") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
     }
 
@@ -89,7 +89,7 @@ pub mod port {
         let value: u32;
         asm!(
             "in eax, dx", in("dx") port, out("eax") value,
-            options(nomem, nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
         value
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -38,48 +38,60 @@ macro_rules! log {
 }
 
 pub mod port {
-    use x86_64::instructions::port::Port;
+    use core::arch::asm;
 
-    pub fn outb(addr: u16, value: u8) {
-        let mut port: Port<u8> = Port::new(addr);
-        unsafe {
-            port.write(value);
-        }
+    /// Write an 8-bit byte to a port
+    pub unsafe fn outb(port: u16, value: u8) {
+        asm!(
+            "out dx, al", in("dx") port, in("al") value,
+            options(nomem, nostack, preserves_flags)
+        );
     }
 
-    pub fn outw(addr: u16, value: u16) {
-        let mut port: Port<u16> = Port::new(addr);
-        unsafe {
-            port.write(value);
-        }
+    /// Read an 8-bit byte from a port
+    pub unsafe fn inb(port: u16) -> u8 {
+        let value: u8;
+        asm!(
+            "in al, dx", in("dx") port, out("al") value,
+            options(nomem, nostack, preserves_flags)
+        );
+        value
     }
 
-    pub fn outl(addr: u16, value: u32) {
-        let mut port: Port<u32> = Port::new(addr);
-        unsafe {
-            port.write(value);
-        }
+    /// Write a 16-bit word to a port
+    pub unsafe fn outw(port: u16, value: u16) {
+        asm!(
+            "out dx, ax", in("dx") port, in("ax") value,
+            options(nomem, nostack, preserves_flags)
+        );
     }
 
-    pub fn inb(addr: u16) -> u8 {
-        let mut port: Port<u8> = Port::new(addr);
-        unsafe {
-            port.read()
-        }
+    /// Read a 16-bit word from a port
+    pub unsafe fn inw(port: u16) -> u16 {
+        let value: u16;
+        asm!(
+            "in ax, dx", in("dx") port, out("ax") value,
+            options(nomem, nostack, preserves_flags)
+        );
+        value
     }
 
-    pub fn inw(addr: u16) -> u16 {
-        let mut port: Port<u16> = Port::new(addr);
-        unsafe {
-            port.read()
-        }
+    /// Write a 32-bit double-word to a port
+    pub unsafe fn outl(port: u16, value: u32) {
+        asm!(
+            "out dx, eax", in("dx") port, in("eax") value,
+            options(nomem, nostack, preserves_flags)
+        );
     }
 
-    pub fn inl(addr: u16) -> u32 {
-        let mut port: Port<u32> = Port::new(addr);
-        unsafe {
-            port.read()
-        }
+    /// Read a 32-bit double-word from a port
+    pub unsafe fn inl(port: u16) -> u32 {
+        let value: u32;
+        asm!(
+            "in eax, dx", in("dx") port, out("eax") value,
+            options(nomem, nostack, preserves_flags)
+        );
+        value
     }
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -40,7 +40,7 @@ macro_rules! log {
 pub mod port {
     use core::arch::asm;
 
-    /// Write an 8-bit byte to a port
+    #[inline]
     pub unsafe fn outb(port: u16, value: u8) {
         asm!(
             "out dx, al", in("dx") port, in("al") value,
@@ -48,7 +48,7 @@ pub mod port {
         );
     }
 
-    /// Read an 8-bit byte from a port
+    #[inline]
     pub unsafe fn inb(port: u16) -> u8 {
         let value: u8;
         asm!(
@@ -58,7 +58,7 @@ pub mod port {
         value
     }
 
-    /// Write a 16-bit word to a port
+    #[inline]
     pub unsafe fn outw(port: u16, value: u16) {
         asm!(
             "out dx, ax", in("dx") port, in("ax") value,
@@ -66,7 +66,7 @@ pub mod port {
         );
     }
 
-    /// Read a 16-bit word from a port
+    #[inline]
     pub unsafe fn inw(port: u16) -> u16 {
         let value: u16;
         asm!(
@@ -76,7 +76,7 @@ pub mod port {
         value
     }
 
-    /// Write a 32-bit double-word to a port
+    #[inline]
     pub unsafe fn outl(port: u16, value: u32) {
         asm!(
             "out dx, eax", in("dx") port, in("eax") value,
@@ -84,7 +84,7 @@ pub mod port {
         );
     }
 
-    /// Read a 32-bit double-word from a port
+    #[inline]
     pub unsafe fn inl(port: u16) -> u32 {
         let value: u32;
         asm!(

--- a/src/sys/net/nic/e1000.rs
+++ b/src/sys/net/nic/e1000.rs
@@ -1,6 +1,7 @@
 use crate::sys;
 use crate::sys::mem::PhysBuf;
 use crate::sys::net::{EthernetDeviceIO, Config, Stats};
+use crate::sys::port::*;
 
 use alloc::slice;
 use alloc::sync::Arc;
@@ -10,7 +11,6 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use smoltcp::wire::EthernetAddress;
 use spin::Mutex;
-use x86_64::instructions::port::Port;
 use x86_64::PhysAddr;
 
 // https://pdos.csail.mit.edu/6.828/2019/readings/hardware/8254x_GBe_SDM.pdf
@@ -299,8 +299,8 @@ impl Device {
                 let addr = sys::mem::phys_to_virt(phys).as_u64() as *mut u32;
                 core::ptr::write_volatile(addr, data);
             } else {
-                Port::new(self.io_base + IO_ADDR).write(addr);
-                Port::new(self.io_base + IO_DATA).write(data);
+                outl(self.io_base + IO_ADDR, addr as u32);
+                outl(self.io_base + IO_DATA, data);
             }
         }
     }
@@ -312,8 +312,8 @@ impl Device {
                 let addr = sys::mem::phys_to_virt(phys).as_u64() as *mut u32;
                 core::ptr::read_volatile(addr)
             } else {
-                Port::new(self.io_base + IO_ADDR).write(addr);
-                Port::new(self.io_base + IO_DATA).read()
+                outl(self.io_base + IO_ADDR, addr as u32);
+                inl(self.io_base + IO_DATA)
             }
         }
     }

--- a/src/sys/net/nic/pcnet.rs
+++ b/src/sys/net/nic/pcnet.rs
@@ -1,13 +1,13 @@
 use crate::sys;
 use crate::sys::mem::PhysBuf;
 use crate::sys::net::{Config, EthernetDeviceIO, Stats};
+use crate::sys::port::*;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use bit_field::BitField;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use smoltcp::wire::EthernetAddress;
-use x86_64::instructions::port::Port;
 
 const CSR0_INIT: usize = 0;
 const CSR0_STRT: usize = 1;
@@ -35,79 +35,66 @@ const DE_STP: usize = 1;
 //const DE_ERR:  usize = 6;
 const DE_OWN: usize = 7;
 
+//const RDP_16: u16 = 0x10;
+//const RAP_16: u16 = 0x12;
+const RST_16: u16 = 0x14;
+//const BDP_16: u16 = 0x16;
+
+const RDP_32: u16 = 0x10;
+const RAP_32: u16 = 0x14;
+const RST_32: u16 = 0x18;
+const BDP_32: u16 = 0x1C;
+
 #[derive(Clone)]
 pub struct Ports {
-    pub mac: [Port<u8>; 6],
-    //pub rdp_16: Port<u16>,
-    //pub rap_16: Port<u16>,
-    pub rst_16: Port<u16>,
-    //pub bdp_16: Port<u16>,
-
-    pub rdp_32: Port<u32>,
-    pub rap_32: Port<u32>,
-    pub rst_32: Port<u32>,
-    pub bdp_32: Port<u32>,
+    io_base: u16,
 }
 
 impl Ports {
     pub fn new(io_base: u16) -> Self {
-        Self {
-            mac: [
-                Port::new(io_base + 0x00),
-                Port::new(io_base + 0x01),
-                Port::new(io_base + 0x02),
-                Port::new(io_base + 0x03),
-                Port::new(io_base + 0x04),
-                Port::new(io_base + 0x05),
-            ],
-
-            //rdp_16: Port::new(io_base + 0x10),
-            //rap_16: Port::new(io_base + 0x12),
-            rst_16: Port::new(io_base + 0x14),
-            //bdp_16: Port::new(io_base + 0x16),
-
-            rdp_32: Port::new(io_base + 0x10),
-            rap_32: Port::new(io_base + 0x14),
-            rst_32: Port::new(io_base + 0x18),
-            bdp_32: Port::new(io_base + 0x1C),
-        }
+        Self { io_base }
     }
 
-    fn write_rap_32(&mut self, val: u32) {
-        unsafe { self.rap_32.write(val) }
+    fn write_rap_32(&self, val: u32) {
+        unsafe { outl(self.io_base + RAP_32, val) }
     }
 
-    fn read_csr_32(&mut self, csr: u32) -> u32 {
+    fn write_rdp_32(&self, val: u32) {
+        unsafe { outl(self.io_base + RDP_32, val) }
+    }
+
+    fn read_csr_32(&self, csr: u32) -> u32 {
         self.write_rap_32(csr);
-        unsafe { self.rdp_32.read() }
+        unsafe { inl(self.io_base + RDP_32) }
     }
 
-    fn write_csr_32(&mut self, csr: u32, val: u32) {
+    fn write_csr_32(&self, csr: u32, val: u32) {
         self.write_rap_32(csr);
-        unsafe { self.rdp_32.write(val) }
+        unsafe { outl(self.io_base + RDP_32, val) }
     }
 
-    fn read_bcr_32(&mut self, bcr: u32) -> u32 {
+    fn read_bcr_32(&self, bcr: u32) -> u32 {
         self.write_rap_32(bcr);
-        unsafe { self.bdp_32.read() }
+        unsafe { inl(self.io_base + BDP_32) }
     }
 
-    fn write_bcr_32(&mut self, bcr: u32, val: u32) {
+    fn write_bcr_32(&self, bcr: u32, val: u32) {
         self.write_rap_32(bcr);
-        unsafe { self.bdp_32.write(val) }
+        unsafe { outl(self.io_base + BDP_32, val) }
     }
 
-    fn mac(&mut self) -> [u8; 6] {
+    fn reset(&self) {
         unsafe {
-            [
-                self.mac[0].read(),
-                self.mac[1].read(),
-                self.mac[2].read(),
-                self.mac[3].read(),
-                self.mac[4].read(),
-                self.mac[5].read(),
-            ]
+            inl(self.io_base + RST_32);
+            inw(self.io_base + RST_16);
         }
+    }
+
+    fn mac(&self) -> [u8; 6] {
+        core::array::from_fn(|i| unsafe {
+            // Read the first 6 bytes of the APROM
+            inb(self.io_base + i as u16)
+        })
     }
 }
 
@@ -163,15 +150,10 @@ impl Device {
         self.config.update_mac(EthernetAddress::from_bytes(&mac));
 
         // Reset to 16-bit access
-        unsafe {
-            self.ports.rst_32.read();
-            self.ports.rst_16.read();
-        }
+        self.ports.reset();
 
         // Switch to 32-bit access
-        unsafe {
-            self.ports.rdp_32.write(0);
-        }
+        self.ports.write_rdp_32(0);
 
         // SWSTYLE
         let mut csr_58 = self.ports.read_csr_32(58);

--- a/src/sys/net/nic/rtl8139.rs
+++ b/src/sys/net/nic/rtl8139.rs
@@ -1,5 +1,6 @@
 use crate::sys::mem::PhysBuf;
 use crate::sys::net::{Config, EthernetDeviceIO, Stats};
+use crate::sys::port::*;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -7,7 +8,6 @@ use core::convert::TryInto;
 use core::hint::spin_loop;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 use smoltcp::wire::EthernetAddress;
-use x86_64::instructions::port::Port;
 
 // 00 = 8K + 16 bytes
 // 01 = 16K + 16 bytes
@@ -71,91 +71,96 @@ const TOK: u32 = 1 << 15; // Transmit OK
                           //const TUN: u32 = 1 << 14; // Transmit FIFO Underrun
 const OWN: u32 = 1 << 13; // DMA operation completed
 
+// Registers
+const TSD0:    u16 = 0x10; // Transmit Status of Descriptors 0
+const TSAD0:   u16 = 0x20; // Transmit Start Address of Descriptor 0
+const RBSTART: u16 = 0x30; // Receive (Rx) Buffer Start Address
+const CR:      u16 = 0x37; // Command Register
+const CAPR:    u16 = 0x38; // Current Address of Packet Read
+const CBA:     u16 = 0x3A; // Current Buffer Address
+//const IMR:     u16 = 0x3C; // Interrupt Mask Register
+//const ISR:     u16 = 0x3E; // Interrupt Status Register
+const TCR:     u16 = 0x40; // Transmit (Tx) Configuration Register
+const RCR:     u16 = 0x44; // Receive (Rx) Configuration Register
+const CONFIG0: u16 = 0x51; // Configuration 0
+
 #[derive(Clone)]
 pub struct Ports {
-    // ID Registers (IDR0 ... IDR5)
-    pub mac: [Port<u8>; 6],
-
-    // Transmit Status of Descriptors (TSD0 .. TSD3)
-    pub tx_cmds: [Port<u32>; TX_BUFFERS_COUNT],
-
-    // Transmit Start Address of Descriptor0 (TSAD0 .. TSAD3)
-    pub tx_addrs: [Port<u32>; TX_BUFFERS_COUNT],
-
-    // Configuration Register 1 (CONFIG1)
-    pub config1: Port<u8>,
-
-    // Receive (Rx) Buffer Start Address (RBSTART)
-    pub rx_addr: Port<u32>,
-
-    // Current Address of Packet Read (CAPR)
-    pub capr: Port<u16>,
-
-    // Current Buffer Address (CBA)
-    pub cba: Port<u16>,
-
-    // Command Register (CR)
-    pub cmd: Port<u8>,
-
-    // Interrupt Mask Register (IMR)
-    //pub imr: Port<u16>,
-
-    // Interrupt Status Register (ISR)
-    //pub isr: Port<u16>,
-
-    // Transmit (Tx) Configuration Register (TCR)
-    pub tx_config: Port<u32>,
-
-    // Receive (Rx) Configuration Register (RCR)
-    pub rx_config: Port<u32>,
+    io_base: u16,
 }
 
 impl Ports {
     pub fn new(io_base: u16) -> Self {
-        Self {
-            mac: [
-                Port::new(io_base + 0x00),
-                Port::new(io_base + 0x01),
-                Port::new(io_base + 0x02),
-                Port::new(io_base + 0x03),
-                Port::new(io_base + 0x04),
-                Port::new(io_base + 0x05),
-            ],
-            tx_cmds: [
-                Port::new(io_base + 0x10),
-                Port::new(io_base + 0x14),
-                Port::new(io_base + 0x18),
-                Port::new(io_base + 0x1C),
-            ],
-            tx_addrs: [
-                Port::new(io_base + 0x20),
-                Port::new(io_base + 0x24),
-                Port::new(io_base + 0x28),
-                Port::new(io_base + 0x2C),
-            ],
-            config1: Port::new(io_base + 0x52),
-            rx_addr: Port::new(io_base + 0x30),
-            capr: Port::new(io_base + 0x38),
-            cba: Port::new(io_base + 0x3A),
-            cmd: Port::new(io_base + 0x37),
-            //imr: Port::new(io_base + 0x3C),
-            //isr: Port::new(io_base + 0x3E),
-            tx_config: Port::new(io_base + 0x40),
-            rx_config: Port::new(io_base + 0x44),
-        }
+        Self { io_base }
     }
 
-    fn mac(&mut self) -> [u8; 6] {
-        unsafe {
-            [
-                self.mac[0].read(),
-                self.mac[1].read(),
-                self.mac[2].read(),
-                self.mac[3].read(),
-                self.mac[4].read(),
-                self.mac[5].read(),
-            ]
-        }
+    fn mac(&self) -> [u8; 6] {
+        // Read the EEPROM EthernetID loaded in the ID Registers
+        core::array::from_fn(|i| unsafe {
+            inb(self.io_base + i as u16)
+        })
+    }
+
+    pub fn read_tsd(&self, i: usize) -> u32 {
+        debug_assert!(i < 4);
+        unsafe { inl(self.io_base + TSD0 + 4 * i as u16) }
+    }
+
+    pub fn write_tsd(&self, i: usize, value: u32) {
+        debug_assert!(i < 4);
+        unsafe { outl(self.io_base + TSD0 + 4 * i as u16, value) }
+    }
+
+    pub fn write_tsad(&self, i: usize, value: u32) {
+        debug_assert!(i < 4);
+        unsafe { outl(self.io_base + TSAD0 + 4 * i as u16, value) }
+    }
+
+    pub fn write_rbstart(&self, value: u32) {
+        unsafe { outl(self.io_base + RBSTART, value) }
+    }
+
+    pub fn read_cr(&self) -> u8 {
+        unsafe { inb(self.io_base + CR) }
+    }
+
+    pub fn write_cr(&self, value: u8) {
+        unsafe { outb(self.io_base + CR, value) }
+    }
+
+    pub fn read_capr(&self) -> u16 {
+        unsafe { inw(self.io_base + CAPR) }
+    }
+
+    pub fn write_capr(&self, value: u16) {
+        unsafe { outw(self.io_base + CAPR, value) }
+    }
+
+    pub fn read_cba(&self) -> u16 {
+        unsafe { inw(self.io_base + CBA) }
+    }
+
+    /*
+    pub fn write_imr(&self, value: u16) {
+        unsafe { outw(self.io_base + IMR, value) }
+    }
+
+    pub fn write_isr(&self, value: u16) {
+        unsafe { outw(self.io_base + ISR, value) }
+    }
+    */
+
+    pub fn write_tcr(&self, value: u32) {
+        unsafe { outl(self.io_base + TCR, value) }
+    }
+
+    pub fn write_rcr(&self, value: u32) {
+        unsafe { outl(self.io_base + RCR, value) }
+    }
+
+    pub fn write_config(&self, i: usize, value: u8) {
+        debug_assert!(i < 2);
+        unsafe { outb(self.io_base + CONFIG0 + i as u16, value) }
     }
 }
 
@@ -205,24 +210,22 @@ impl Device {
 
     fn init(&mut self) {
         // Power on
-        unsafe { self.ports.config1.write(0) }
+        self.ports.write_config(1, 0);
 
         // Software reset
-        unsafe {
-            self.ports.cmd.write(CR_RST);
-            fence(Ordering::SeqCst);
-            while self.ports.cmd.read() & CR_RST != 0 {
-                spin_loop();
-            }
+        self.ports.write_cr(CR_RST);
+        fence(Ordering::SeqCst);
+        while self.ports.read_cr() & CR_RST != 0 {
+            spin_loop();
         }
 
         //self.clear_interrupts();
 
         // Enable interrupts
-        //unsafe { self.ports.imr.write(IMR_TOK | IMR_ROK) }
+        // self.ports.write_imr(IMR_TOK | IMR_ROK);
 
         // Enable receiver and transmitter
-        unsafe { self.ports.cmd.write(CR_RE | CR_TE) }
+        self.ports.write_cr(CR_RE | CR_TE);
 
         // Read MAC addr
         self.config.update_mac(EthernetAddress::from_bytes(&self.ports.mac()));
@@ -231,23 +234,23 @@ impl Device {
         let rx_addr = self.rx_buffer.addr();
 
         // Init Receive buffer
-        unsafe { self.ports.rx_addr.write(rx_addr as u32) }
+        self.ports.write_rbstart(rx_addr as u32);
 
         for i in 0..4 {
             // Get physical address of each tx_buffer
             let tx_addr = self.tx_buffers[i].addr();
 
             // Init Transmit buffer
-            unsafe { self.ports.tx_addrs[i].write(tx_addr as u32) }
+            self.ports.write_tsad(i, tx_addr as u32);
         }
 
         // Configure receive buffer (RCR)
         let flags = RCR_RBLEN | RCR_WRAP | RCR_AB | RCR_AM | RCR_APM | RCR_AAP;
-        unsafe { self.ports.rx_config.write(flags) }
+        self.ports.write_rcr(flags);
 
         // Configure transmit buffer (TCR)
         let flags = TCR_IFG | TCR_MXDMA1 | TCR_MXDMA2;
-        unsafe { self.ports.tx_config.write(flags) }
+        self.ports.write_tcr(flags);
     }
 }
 
@@ -268,15 +271,15 @@ impl EthernetDeviceIO for Device {
     fn receive_packet(&mut self) -> Option<Vec<u8>> {
         //self.clear_interrupts();
 
-        let cmd = unsafe { self.ports.cmd.read() };
+        let cmd = self.ports.read_cr();
         if (cmd & CR_BUFE) == CR_BUFE {
             return None;
         }
 
-        let cba = unsafe { self.ports.cba.read() };
+        let cba = self.ports.read_cba();
 
         // CAPR starts at 65520 and with the pad it overflows to 0
-        let capr = unsafe { self.ports.capr.read() };
+        let capr = self.ports.read_capr();
         let offset = ((capr as usize) + RX_BUFFER_PAD) % (1 << 16);
 
         let header = u16::from_le_bytes(
@@ -285,7 +288,7 @@ impl EthernetDeviceIO for Device {
 
         if header & ROK != ROK {
             let capr = ((cba as usize) % RX_BUFFER_LEN) - RX_BUFFER_PAD;
-            unsafe { self.ports.capr.write(capr as u16) }
+            self.ports.write_capr(capr as u16);
             return None;
         }
 
@@ -296,36 +299,34 @@ impl EthernetDeviceIO for Device {
         // Update buffer read pointer
         self.rx_offset = (offset + n + 4 + 3) & !3;
         let capr = (self.rx_offset % RX_BUFFER_LEN) - RX_BUFFER_PAD;
-        unsafe { self.ports.capr.write(capr as u16) }
+        self.ports.write_capr(capr as u16);
 
         Some(self.rx_buffer[(offset + 4)..(offset + n)].to_vec())
     }
 
     fn transmit_packet(&mut self, len: usize) {
         let tx_id = self.tx_id.load(Ordering::SeqCst);
-        let mut cmd_port = self.ports.tx_cmds[tx_id].clone();
-        unsafe {
-            // RTL8139 will not transmit packets smaller than 64 bits
-            let len = len.max(60); // 60 + 4 bits of CRC
 
-            // Fill in Transmit Status: the size of this packet, the early
-            // transmit threshold, and clear OWN bit in TSD (this starts the
-            // PCI operation).
-            // NOTE: The length of the packet use the first 13 bits (but should
-            // not exceed 1792 bytes), and a value of 0x000000 for the early
-            // transmit threshold means 8 bytes. So we just write the size of
-            // the packet.
-            cmd_port.write(0x1FFF & len as u32);
-            fence(Ordering::SeqCst);
+        // RTL8139 will not transmit packets smaller than 64 bits
+        let len = len.max(60); // 60 + 4 bits of CRC
 
-            while cmd_port.read() & OWN != OWN {
-                spin_loop();
-            }
-            while cmd_port.read() & TOK != TOK {
-                spin_loop();
-            }
+        // Fill in Transmit Status: the size of this packet, the early
+        // transmit threshold, and clear OWN bit in TSD (this starts the
+        // PCI operation).
+        // NOTE: The length of the packet use the first 13 bits (but should
+        // not exceed 1792 bytes), and a value of 0x000000 for the early
+        // transmit threshold means 8 bytes. So we just write the size of
+        // the packet.
+        self.ports.write_tsd(tx_id, 0x1FFF & len as u32);
+        fence(Ordering::SeqCst);
+
+        while self.ports.read_tsd(tx_id) & OWN != OWN {
+            spin_loop();
         }
-        //unsafe { self.ports.isr.write(0x4); }
+        while self.ports.read_tsd(tx_id) & TOK != TOK {
+            spin_loop();
+        }
+        //self.ports.write_isr(0x4);
     }
 
     fn next_tx_buffer(&mut self, len: usize) -> &mut [u8] {
@@ -341,7 +342,7 @@ pub fn interrupt_handler() {
     if let Some(mut guard) = sys::net::IFACE.try_lock() {
         if let Some(ref mut iface) = *guard {
             // Clear the interrupt
-            unsafe { iface.device_mut().ports.isr.write(0xFFFF) }
+            iface.device_mut().ports.write_isr(0xFFFF);
         }
     }
 }

--- a/src/sys/pci.rs
+++ b/src/sys/pci.rs
@@ -1,9 +1,10 @@
+use crate::sys::port::*;
+
 use alloc::vec;
 use alloc::vec::Vec;
 use bit_field::BitField;
 use lazy_static::lazy_static;
 use spin::Mutex;
-use x86_64::instructions::port::Port;
 use x86_64::PhysAddr;
 
 #[derive(Debug, Clone, Copy)]
@@ -192,17 +193,16 @@ fn get_header_type(bus: u8, device: u8, function: u8) -> u8 {
     register.read().get_bits(16..24) as u8
 }
 
+const DATA_PORT: u16 = 0xCFC;
+const ADDR_PORT: u16 = 0xCF8;
+
 struct ConfigRegister {
-    data_port: Port<u32>,
-    addr_port: Port<u32>,
     addr: u32,
 }
 
 impl ConfigRegister {
     pub fn new(bus: u8, device: u8, function: u8, offset: u8) -> Self {
         Self {
-            data_port: Port::new(0xCFC),
-            addr_port: Port::new(0xCF8),
             addr: 0x8000_0000
                 | ((bus as u32) << 16)
                 | ((device as u32) << 11)
@@ -213,15 +213,15 @@ impl ConfigRegister {
 
     pub fn read(&mut self) -> u32 {
         unsafe {
-            self.addr_port.write(self.addr);
-            self.data_port.read()
+            outl(ADDR_PORT, self.addr);
+            inl(DATA_PORT)
         }
     }
 
     pub fn write(&mut self, data: u32) {
         unsafe {
-            self.addr_port.write(self.addr);
-            self.data_port.write(data);
+            outl(ADDR_PORT, self.addr);
+            outl(DATA_PORT, data);
         }
     }
 }

--- a/src/sys/snd/ac97.rs
+++ b/src/sys/snd/ac97.rs
@@ -76,10 +76,12 @@ impl Device {
     }
 
     pub fn init(&mut self) {
-        outl(self.bar1 + GLOB_CNT, CR | GIE); // Cold reset
-        sys::clk::wait(100_000); // TODO: Find proper reset delay
-        outw(self.bar0 + NAM_RR, 1); // Reset all registers
-        outw(self.bar0 + NAM_POV, 0); // Set PCM Out Volume to max
+        unsafe {
+            outl(self.bar1 + GLOB_CNT, CR | GIE); // Cold reset
+            sys::clk::wait(100_000); // TODO: Find proper reset delay
+            outw(self.bar0 + NAM_RR, 1); // Reset all registers
+            outw(self.bar0 + NAM_POV, 0); // Set PCM Out Volume to max
+        }
     }
 
     fn fill_next_block(&mut self) -> usize {
@@ -119,46 +121,48 @@ impl Device {
             return;
         }
 
-        // Set Master Volume to max
-        outw(self.bar0 + NAM_MV, 0);
+        unsafe {
+            // Set Master Volume to max
+            outw(self.bar0 + NAM_MV, 0);
 
-        // Set reset bit of output channel
-        outb(self.bar1 + PO_CR, RR);
-        while inb(self.bar1 + PO_CR) & RR != 0 {
-            // Wait for reset to be completed
-            core::hint::spin_loop();
+            // Set reset bit of output channel
+            outb(self.bar1 + PO_CR, RR);
+            while inb(self.bar1 + PO_CR) & RR != 0 {
+                // Wait for reset to be completed
+                core::hint::spin_loop();
+            }
+            debug_assert_eq!(inb(self.bar1 + PO_CIV), 0);
+            debug_assert_eq!(inb(self.bar1 + PO_LVI), 0);
+            self.index.store(0, Ordering::SeqCst);
+
+            // Set sample rate
+            //debug!("SND AC97 Ext Cap: {:#016b}", inw(self.bar0 + NAM_EAR));
+            //debug!("SND AC97 Sample Rate: {} Hz", inw(self.bar0 + NAM_PFDR));
+            debug_assert_ne!(inw(self.bar0 + NAM_EAR) & 0x01, 0);
+            outw(self.bar0 + NAM_EAC, 1);
+            outw(self.bar0 + NAM_PFDR, config.sample_rate as u16);
+            //debug!("SND AC97 Sample Rate: {} Hz", inw(self.bar0 + NAM_PFDR));
+
+            // Write BDL address to Buffer Descriptor Base Address register
+            let bdl = self.bdl.lock();
+            let addr = sys::mem::phys_addr(bdl.as_ptr() as *const u8);
+            debug_assert!(addr % 8 == 0);
+            outl(self.bar1 + PO_BDBAR, addr as u32);
+            drop(bdl);
+
+            // Load sound data to memory
+            let index = self.fill_next_block();
+            debug_assert_eq!(index, 0);
+
+            // Write BDL index to Last Valid Entry register
+            outb(self.bar1 + PO_LVI, index as u8);
+
+            // Clear any pending status bits before starting
+            outw(self.bar1 + PO_SR, LVBCI | BCIS | FIFOE);
+
+            // Start DMA with interrupts
+            outb(self.bar1 + PO_CR, RPBM | LVBIE | IOCE);
         }
-        debug_assert_eq!(inb(self.bar1 + PO_CIV), 0);
-        debug_assert_eq!(inb(self.bar1 + PO_LVI), 0);
-        self.index.store(0, Ordering::SeqCst);
-
-        // Set sample rate
-        //debug!("SND AC97 Ext Cap: {:#016b}", inw(self.bar0 + NAM_EAR));
-        //debug!("SND AC97 Sample Rate: {} Hz", inw(self.bar0 + NAM_PFDR));
-        debug_assert_ne!(inw(self.bar0 + NAM_EAR) & 0x01, 0);
-        outw(self.bar0 + NAM_EAC, 1);
-        outw(self.bar0 + NAM_PFDR, config.sample_rate as u16);
-        //debug!("SND AC97 Sample Rate: {} Hz", inw(self.bar0 + NAM_PFDR));
-
-        // Write BDL address to Buffer Descriptor Base Address register
-        let bdl = self.bdl.lock();
-        let addr = sys::mem::phys_addr(bdl.as_ptr() as *const u8);
-        debug_assert!(addr % 8 == 0);
-        outl(self.bar1 + PO_BDBAR, addr as u32);
-        drop(bdl);
-
-        // Load sound data to memory
-        let index = self.fill_next_block();
-        debug_assert_eq!(index, 0);
-
-        // Write BDL index to Last Valid Entry register
-        outb(self.bar1 + PO_LVI, index as u8);
-
-        // Clear any pending status bits before starting
-        outw(self.bar1 + PO_SR, LVBCI | BCIS | FIFOE);
-
-        // Start DMA with interrupts
-        outb(self.bar1 + PO_CR, RPBM | LVBIE | IOCE);
 
         self.is_playing = true;
     }
@@ -166,7 +170,9 @@ impl Device {
     pub fn stop(&mut self) {
         if self.is_playing {
             self.is_playing = false;
-            outb(self.bar1 + PO_CR, 0); // Stop DMA
+            unsafe {
+                outb(self.bar1 + PO_CR, 0); // Stop DMA
+            }
             for i in 0..BDL {
                 self.blocks[i].fill(0x00);
             }
@@ -176,14 +182,16 @@ impl Device {
     }
 
     pub fn handle_interrupt(&mut self) {
-        // Clear channel status registers
-        outw(self.bar1 + PO_SR, LVBCI | BCIS | FIFOE);
+        unsafe {
+            // Clear channel status registers
+            outw(self.bar1 + PO_SR, LVBCI | BCIS | FIFOE);
 
-        if self.buffer.is_empty() {
-            self.stop();
-        } else {
-            let index = self.fill_next_block();
-            outb(self.bar1 + PO_LVI, index as u8);
+            if self.buffer.is_empty() {
+                self.stop();
+            } else {
+                let index = self.fill_next_block();
+                outb(self.bar1 + PO_LVI, index as u8);
+            }
         }
     }
 }

--- a/src/sys/snd/sb16.rs
+++ b/src/sys/snd/sb16.rs
@@ -59,44 +59,50 @@ impl Device {
         // Program the DMA controller
         dma(self.block.addr(), self.block.size() - 1);
 
-        // Set the DSP transfer sampling rate
-        let rate = (self.config.sample_rate as u16).to_be_bytes();
-        outb(DSP_WRITE, 0x41); // Output
-        outb(DSP_WRITE, rate[0]); // High byte
-        outb(DSP_WRITE, rate[1]); // Low byte
+        unsafe {
+            // Set the DSP transfer sampling rate
+            let rate = (self.config.sample_rate as u16).to_be_bytes();
+            outb(DSP_WRITE, 0x41); // Output
+            outb(DSP_WRITE, rate[0]); // High byte
+            outb(DSP_WRITE, rate[1]); // Low byte
 
-        // Send an I/O command
-        outb(DSP_WRITE, 0xC6); // 8-bit output
+            // Send an I/O command
+            outb(DSP_WRITE, 0xC6); // 8-bit output
 
-        // Send the transfer mode
-        outb(DSP_WRITE, 0x00); // 8-bit mono unsigned PCM
+            // Send the transfer mode
+            outb(DSP_WRITE, 0x00); // 8-bit mono unsigned PCM
 
-        // Send the DSP block transfer size
-        let bytes = (self.block.size() - 1).to_le_bytes();
-        outb(DSP_WRITE, bytes[0]);
-        outb(DSP_WRITE, bytes[1]);
+            // Send the DSP block transfer size
+            let bytes = (self.block.size() - 1).to_le_bytes();
+            outb(DSP_WRITE, bytes[0]);
+            outb(DSP_WRITE, bytes[1]);
+        }
     }
 
     pub fn stop(&mut self) {
-        self.is_playing = false;
-        outb(DSP_WRITE, 0xD0); // Pause DMA playback
-        let chan = 1;
-        outb(0x0A, 0x04 + chan); // Disable channel
+        unsafe {
+            self.is_playing = false;
+            outb(DSP_WRITE, 0xD0); // Pause DMA playback
+            let chan = 1;
+            outb(0x0A, 0x04 + chan); // Disable channel
+        }
         self.block.fill(0x80);
         self.buffer.clear();
         self.buffer.shrink_to_fit();
     }
 
     pub fn handle_interrupt(&mut self) {
-        if self.buffer.is_empty() {
-            self.is_playing = false;
-            outb(DSP_WRITE, 0xD0); // Pause
-            let chan = 1;
-            outb(0x0A, 0x04 + chan); // Disable channel
-        } else {
-            self.fill_block();
+        unsafe {
+            if self.buffer.is_empty() {
+                self.is_playing = false;
+                outb(DSP_WRITE, 0xD0); // Pause
+                let chan = 1;
+                outb(0x0A, 0x04 + chan); // Disable channel
+            } else {
+                self.fill_block();
+            }
+            let _ = inb(DSP_ACK);
         }
-        let _ = inb(DSP_ACK);
     }
 
     fn fill_block(&mut self) {
@@ -108,31 +114,35 @@ impl Device {
 }
 
 fn reset() -> bool {
-    outb(DSP_RESET, 1);
-    sys::clk::wait(3000); // 3 microseconds
-    outb(DSP_RESET, 0);
-    for _ in 0..100 {
-        sys::clk::wait(1000);
-        if inb(DSP_READ) == 0xAA {
-            return true;
+    unsafe {
+        outb(DSP_RESET, 1);
+        sys::clk::wait(3000); // 3 microseconds
+        outb(DSP_RESET, 0);
+        for _ in 0..100 {
+            sys::clk::wait(1000);
+            if inb(DSP_READ) == 0xAA {
+                return true;
+            }
         }
+        false
     }
-    false
 }
 
 fn dma(addr: u64, size: usize) {
     let addr = addr.to_le_bytes();
     let size = size.to_le_bytes();
     let chan = 1;
-    outb(0x0A, 0x04 + chan); // Disable channel
-    outb(0x0C, 0x01);        // Flip flop
-    outb(0x0B, 0x58 + chan); // Send transfer mode
-    outb(0x83, addr[2]);     // Send page number
-    outb(0x02, addr[0]);     // Send low bits of addr
-    outb(0x02, addr[1]);     // Send high bits of addr
-    outb(0x03, size[0]);     // Send low bits of size
-    outb(0x03, size[1]);     // Send high bits of size
-    outb(0x0A, chan);        // Enable channel
+    unsafe {
+        outb(0x0A, 0x04 + chan); // Disable channel
+        outb(0x0C, 0x01);        // Flip flop
+        outb(0x0B, 0x58 + chan); // Send transfer mode
+        outb(0x83, addr[2]);     // Send page number
+        outb(0x02, addr[0]);     // Send low bits of addr
+        outb(0x02, addr[1]);     // Send high bits of addr
+        outb(0x03, size[0]);     // Send low bits of size
+        outb(0x03, size[1]);     // Send high bits of size
+        outb(0x0A, chan);        // Enable channel
+    }
 }
 
 fn irq(num: u8) -> u8 {
@@ -146,8 +156,10 @@ fn irq(num: u8) -> u8 {
 }
 
 pub fn init() {
-    outb(MIXER_ADDR, 0x80);
-    outb(MIXER_DATA, irq(IRQ));
+    unsafe {
+        outb(MIXER_ADDR, 0x80);
+        outb(MIXER_DATA, irq(IRQ));
+    }
 }
 
 pub fn find() -> Option<Device> {

--- a/src/sys/speaker.rs
+++ b/src/sys/speaker.rs
@@ -1,9 +1,9 @@
 use super::clk;
 
 use crate::api::fs::{FileIO, IO};
+use crate::sys::port::*;
 
 use alloc::string::String;
-use x86_64::instructions::port::Port;
 
 #[derive(Debug, Clone)]
 pub struct Speaker;
@@ -56,13 +56,11 @@ fn start_sound(frequency: f64) {
     let divider = (clk::pit_frequency() / frequency) as u16;
     clk::set_pit_frequency(divider, SPEAKER_CHANNEL);
 
-    let mut speaker: Port<u8> = Port::new(SPEAKER_PORT);
-    let tmp = unsafe { speaker.read() };
-    unsafe { speaker.write(tmp | SPEAKER_ENABLED) };
+    let tmp = unsafe { inb(SPEAKER_PORT) };
+    unsafe { outb(SPEAKER_PORT, tmp | SPEAKER_ENABLED) };
 }
 
 fn stop_sound() {
-    let mut speaker: Port<u8> = Port::new(SPEAKER_PORT);
-    let tmp = unsafe { speaker.read() };
-    unsafe { speaker.write(tmp & SPEAKER_DISABLED) };
+    let tmp = unsafe { inb(SPEAKER_PORT) };
+    unsafe { outb(SPEAKER_PORT, tmp & SPEAKER_DISABLED) };
 }

--- a/src/sys/vga/mod.rs
+++ b/src/sys/vga/mod.rs
@@ -14,6 +14,8 @@ use color::Color;
 use palette::Palette;
 use writer::WRITER;
 
+use crate::sys::port::*;
+
 use alloc::string::String;
 use bit_field::BitField;
 use core::cmp;
@@ -21,7 +23,6 @@ use core::fmt;
 use core::fmt::Write;
 use core::num::ParseIntError;
 use x86_64::instructions::interrupts;
-use x86_64::instructions::port::Port;
 
 const ATTR_ADDR_REG:           u16 = 0x3C0;
 const ATTR_WRITE_REG:          u16 = 0x3C0;
@@ -60,11 +61,9 @@ pub fn is_printable(c: u8) -> bool {
 // 0x1F -> max (invisible)
 fn set_underline_location(location: u8) {
     interrupts::without_interrupts(|| {
-        let mut addr: Port<u8> = Port::new(CRTC_ADDR_REG);
-        let mut data: Port<u8> = Port::new(CRTC_DATA_REG);
         unsafe {
-            addr.write(0x14); // Underline Location Register
-            data.write(location);
+            outb(CRTC_ADDR_REG, 0x14); // Underline Location Register
+            outb(CRTC_DATA_REG, location);
         }
     })
 }
@@ -84,30 +83,25 @@ fn disable_blinking() {
 
 fn set_attr_ctrl_reg(index: u8, value: u8) {
     interrupts::without_interrupts(|| {
-        let mut isr: Port<u8> = Port::new(INPUT_STATUS_REG);
-        let mut addr: Port<u8> = Port::new(ATTR_ADDR_REG);
         unsafe {
-            isr.read(); // Reset to address mode
-            let tmp = addr.read();
-            addr.write(index);
-            addr.write(value);
-            addr.write(tmp);
+            inb(INPUT_STATUS_REG); // Reset to address mode
+            let tmp = inb(ATTR_ADDR_REG);
+            outb(ATTR_ADDR_REG, index);
+            outb(ATTR_ADDR_REG, value);
+            outb(ATTR_ADDR_REG, tmp);
         }
     })
 }
 
 fn get_attr_ctrl_reg(index: u8) -> u8 {
     interrupts::without_interrupts(|| {
-        let mut isr: Port<u8> = Port::new(INPUT_STATUS_REG);
-        let mut addr: Port<u8> = Port::new(ATTR_ADDR_REG);
-        let mut data: Port<u8> = Port::new(ATTR_READ_REG);
         let index = index | 0x20; // Set "Palette Address Source" bit
         unsafe {
-            isr.read(); // Reset to address mode
-            let tmp = addr.read();
-            addr.write(index);
-            let res = data.read();
-            addr.write(tmp);
+            inb(INPUT_STATUS_REG); // Reset to address mode
+            let tmp = inb(ATTR_ADDR_REG);
+            outb(ATTR_ADDR_REG, index);
+            let res = inb(ATTR_READ_REG);
+            outb(ATTR_ADDR_REG, tmp);
             res
         }
     })

--- a/src/sys/vga/screen.rs
+++ b/src/sys/vga/screen.rs
@@ -81,63 +81,52 @@ fn set_mode(mode: ModeName) {
     }.to_vec();
 
     interrupts::without_interrupts(|| {
-        let mut misc_write: Port<u8> = Port::new(MISC_WRITE_REG);
-        let mut crtc_addr: Port<u8> = Port::new(CRTC_ADDR_REG);
-        let mut crtc_data: Port<u8> = Port::new(CRTC_DATA_REG);
-        let mut seq_addr: Port<u8> = Port::new(SEQUENCER_ADDR_REG);
-        let mut seq_data: Port<u8> = Port::new(SEQUENCER_DATA_REG);
-        let mut gc_addr: Port<u8> = Port::new(GRAPHICS_ADDR_REG);
-        let mut gc_data: Port<u8> = Port::new(GRAPHICS_DATA_REG);
-        let mut ac_addr: Port<u8> = Port::new(ATTR_ADDR_REG);
-        let mut ac_write: Port<u8> = Port::new(ATTR_WRITE_REG);
-        let mut instat_read: Port<u8> = Port::new(INSTAT_READ_REG);
-
         let mut i = 0;
 
         unsafe {
-            misc_write.write(regs[i]);
+            outb(MISC_WRITE_REG, regs[i]);
             i += 1;
 
             for j in 0..SEQ_REGS_COUNT {
-                seq_addr.write(j as u8);
-                seq_data.write(regs[i]);
+                outb(SEQUENCER_ADDR_REG, j as u8);
+                outb(SEQUENCER_DATA_REG, regs[i]);
                 i += 1;
             }
 
             // Unlock CRTC regs
-            crtc_addr.write(0x03);
-            let data = crtc_data.read();
-            crtc_data.write(data | 0x80);
-            crtc_addr.write(0x11);
-            let data = crtc_data.read();
-            crtc_data.write(data & !0x80);
+            outb(CRTC_ADDR_REG, 0x03);
+            let data = inb(CRTC_DATA_REG);
+            outb(CRTC_DATA_REG, data | 0x80);
+            outb(CRTC_ADDR_REG, 0x11);
+            let data = inb(CRTC_DATA_REG);
+            outb(CRTC_DATA_REG, data & !0x80);
 
             // Keep them unlocked
             regs[0x03] |= 0x80;
             regs[0x11] &= !0x80;
 
             for j in 0..CRTC_REGS_COUNT {
-                crtc_addr.write(j as u8);
-                crtc_data.write(regs[i]);
+                outb(CRTC_ADDR_REG, j as u8);
+                outb(CRTC_DATA_REG, regs[i]);
                 i += 1;
             }
 
             for j in 0..GC_REGS_COUNT {
-                gc_addr.write(j as u8);
-                gc_data.write(regs[i]);
+                outb(GRAPHICS_ADDR_REG, j as u8);
+                outb(GRAPHICS_DATA_REG, regs[i]);
                 i += 1;
             }
 
             for j in 0..AC_REGS_COUNT {
-                instat_read.read();
-                ac_addr.write(j as u8);
-                ac_write.write(regs[i]);
+                inb(INSTAT_READ_REG);
+                outb(ATTR_ADDR_REG, j as u8);
+                outb(ATTR_WRITE_REG, regs[i]);
                 i += 1;
             }
 
             // Lock 16-color palette and unblank display
-            instat_read.read();
-            ac_addr.write(0x20);
+            inb(INSTAT_READ_REG);
+            outb(ATTR_ADDR_REG, 0x20);
         }
     });
 }

--- a/src/sys/vga/writer.rs
+++ b/src/sys/vga/writer.rs
@@ -122,39 +122,33 @@ impl Writer {
 
     fn write_cursor(&mut self) {
         let pos = self.cursor[0] + self.cursor[1] * SCREEN_WIDTH;
-        let mut addr = Port::new(CRTC_ADDR_REG);
-        let mut data = Port::new(CRTC_DATA_REG);
         unsafe {
-            addr.write(0x0F as u8);
-            data.write((pos & 0xFF) as u8);
-            addr.write(0x0E as u8);
-            data.write(((pos >> 8) & 0xFF) as u8);
+            outb(CRTC_ADDR_REG, 0x0F);
+            outb(CRTC_DATA_REG, (pos & 0xFF) as u8);
+            outb(CRTC_ADDR_REG, 0x0E);
+            outb(CRTC_DATA_REG, ((pos >> 8) & 0xFF) as u8);
         }
     }
 
     // Source: http://www.osdever.net/FreeVGA/vga/crtcreg.htm#0A
     fn disable_cursor(&self) {
-        let mut addr = Port::new(CRTC_ADDR_REG);
-        let mut data = Port::new(CRTC_DATA_REG);
         unsafe {
-            addr.write(0x0A as u8);
-            data.write(0x20 as u8);
+            outb(CRTC_ADDR_REG, 0x0A);
+            outb(CRTC_DATA_REG, 0x20);
         }
     }
 
     fn enable_cursor(&self) {
-        let mut addr: Port<u8> = Port::new(CRTC_ADDR_REG);
-        let mut data: Port<u8> = Port::new(CRTC_DATA_REG);
         let cursor_start = 13; // Starting row
         let cursor_end = 14; // Ending row
         unsafe {
-            addr.write(0x0A); // Cursor Start Register
-            let b = data.read();
-            data.write((b & 0xC0) | cursor_start);
+            outb(CRTC_ADDR_REG, 0x0A); // Cursor Start Register
+            let b = inb(CRTC_DATA_REG);
+            outb(CRTC_DATA_REG, (b & 0xC0) | cursor_start);
 
-            addr.write(0x0B); // Cursor End Register
-            let b = data.read();
-            data.write((b & 0xE0) | cursor_end);
+            outb(CRTC_ADDR_REG, 0x0B); // Cursor End Register
+            let b = inb(CRTC_DATA_REG);
+            outb(CRTC_DATA_REG, (b & 0xE0) | cursor_end);
         }
     }
 
@@ -269,18 +263,16 @@ impl Writer {
 
     // Source: https://slideplayer.com/slide/3888880
     pub fn set_font(&mut self, font: &Font) {
-        let mut sequencer: Port<u16> = Port::new(SEQUENCER_ADDR_REG);
-        let mut graphics: Port<u16> = Port::new(GRAPHICS_ADDR_REG);
         let buffer = Buffer::addr() as *mut u8;
 
         unsafe {
-            sequencer.write(0x0100); // do a sync reset
-            sequencer.write(0x0402); // write plane 2 only
-            sequencer.write(0x0704); // sequetial access
-            sequencer.write(0x0300); // end the reset
-            graphics.write(0x0204); // read plane 2 only
-            graphics.write(0x0005); // disable odd/even
-            graphics.write(0x0006); // VRAM at 0xA0000
+            outw(SEQUENCER_ADDR_REG, 0x0100); // do a sync reset
+            outw(SEQUENCER_ADDR_REG, 0x0402); // write plane 2 only
+            outw(SEQUENCER_ADDR_REG, 0x0704); // sequetial access
+            outw(SEQUENCER_ADDR_REG, 0x0300); // end the reset
+            outw(GRAPHICS_ADDR_REG,  0x0204); // read plane 2 only
+            outw(GRAPHICS_ADDR_REG,  0x0005); // disable odd/even
+            outw(GRAPHICS_ADDR_REG,  0x0006); // VRAM at 0xA0000
 
             for i in 0..font.size as usize {
                 for j in 0..font.height as usize {
@@ -291,35 +283,31 @@ impl Writer {
                 }
             }
 
-            sequencer.write(0x0100); // do a sync reset
-            sequencer.write(0x0302); // write plane 0 & 1
-            sequencer.write(0x0304); // even/odd access
-            sequencer.write(0x0300); // end the reset
-            graphics.write(0x0004); // restore to default
-            graphics.write(0x1005); // resume odd/even
-            graphics.write(0x0E06); // VRAM at 0xB800
+            outw(SEQUENCER_ADDR_REG, 0x0100); // do a sync reset
+            outw(SEQUENCER_ADDR_REG, 0x0302); // write plane 0 & 1
+            outw(SEQUENCER_ADDR_REG, 0x0304); // even/odd access
+            outw(SEQUENCER_ADDR_REG, 0x0300); // end the reset
+            outw(GRAPHICS_ADDR_REG,  0x0004); // restore to default
+            outw(GRAPHICS_ADDR_REG,  0x1005); // resume odd/even
+            outw(GRAPHICS_ADDR_REG,  0x0E06); // VRAM at 0xB800
         }
     }
 
     pub fn set_palette(&mut self, i: usize, r: u8, g: u8, b: u8) {
-        let mut addr: Port<u8> = Port::new(DAC_ADDR_WRITE_MODE_REG);
-        let mut data: Port<u8> = Port::new(DAC_DATA_REG);
         unsafe {
-            addr.write(i as u8);
-            data.write(r >> 2); // Convert 8-bit to 6-bit color
-            data.write(g >> 2);
-            data.write(b >> 2);
+            outb(DAC_ADDR_WRITE_MODE_REG, i as u8);
+            outb(DAC_DATA_REG, r >> 2); // Convert 8-bit to 6-bit color
+            outb(DAC_DATA_REG, g >> 2);
+            outb(DAC_DATA_REG, b >> 2);
         }
     }
 
     pub fn palette(&mut self, i: usize) -> (u8, u8, u8) {
-        let mut addr: Port<u8> = Port::new(DAC_ADDR_READ_MODE_REG);
-        let mut data: Port<u8> = Port::new(DAC_DATA_REG);
         unsafe {
-            addr.write(i as u8);
-            let r = data.read() << 2; // Convert 6-bit to 8-bit color
-            let g = data.read() << 2;
-            let b = data.read() << 2;
+            outb(DAC_ADDR_READ_MODE_REG, i as u8);
+            let r = inb(DAC_DATA_REG) << 2; // Convert 6-bit to 8-bit color
+            let g = inb(DAC_DATA_REG) << 2;
+            let b = inb(DAC_DATA_REG) << 2;
             (r, g, b)
         }
     }


### PR DESCRIPTION
Replace `x86_64::instructions::port` with `crate::sys::port` to help with a future i686 port.