### PR TITLE
Remove dependency on x86_64::instructions::interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove dependency on x86_64::instructions::interrupts (#878)
 - Remove dependency on x86_64::instructions::hlt (#877)
 - Add DOOM to MOROS (#870)
 - Add ATA read-ahead cache (#871)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,11 +91,8 @@ pub enum QemuExitCode {
 }
 
 pub fn exit_qemu(exit_code: QemuExitCode) {
-    use x86_64::instructions::port::Port;
-
     unsafe {
-        let mut port = Port::new(0xF4);
-        port.write(exit_code as u32);
+        sys::x86::port::outl(0xF4, exit_code as u32);
     }
 }
 

--- a/src/sys/clk/cmos.rs
+++ b/src/sys/clk/cmos.rs
@@ -1,10 +1,10 @@
 use super::rtc::{Interrupt, RTC, Register, RTC_CENTURY};
 
+use crate::sys::x86::interrupts;
 use crate::sys::x86::port::*;
 
 use bit_field::BitField;
 use core::hint::spin_loop;
-use x86_64::instructions::interrupts;
 
 const ADDR_PORT: u16 = 0x70;
 const DATA_PORT: u16 = 0x71;

--- a/src/sys/clk/mod.rs
+++ b/src/sys/clk/mod.rs
@@ -8,7 +8,7 @@ mod timer;
 pub use boot::{boot_time, BootTime};
 pub use epoch::{epoch_time, EpochTime};
 pub use rtc::RTC;
-pub use sync::{halt, sleep, wait};
+pub use sync::{sleep, wait};
 pub use timer::{ticks, pit_frequency, set_pit_frequency};
 
 use crate::api;

--- a/src/sys/clk/sync.rs
+++ b/src/sys/clk/sync.rs
@@ -1,18 +1,7 @@
 use super::boot;
 use super::timer;
 
-use x86_64::instructions::interrupts;
-
-/// Halts the CPU until the next interrupt.
-///
-/// This function preserves interrupt state.
-pub fn halt() {
-    let disabled = !interrupts::are_enabled();
-    interrupts::enable_and_hlt();
-    if disabled {
-        interrupts::disable();
-    }
-}
+use crate::sys;
 
 /// Sleeps for the specified number of seconds.
 ///
@@ -21,7 +10,7 @@ pub fn halt() {
 pub fn sleep(seconds: f64) {
     let start = boot::boot_time();
     while boot::boot_time() - start < seconds {
-        halt();
+        sys::x86::hlt();
     }
 }
 

--- a/src/sys/clk/timer.rs
+++ b/src/sys/clk/timer.rs
@@ -2,10 +2,10 @@ use super::sync;
 use super::cmos::CMOS;
 
 use crate::sys;
+use crate::sys::x86::interrupts;
 use crate::sys::x86::port::*;
 
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use x86_64::instructions::interrupts;
 
 // At boot the PIT starts with a frequency divider of 0 (equivalent to 65536)
 // which will result in about 54.926 ms between ticks.

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -1,11 +1,12 @@
 use crate::api::fs::{FileIO, IO};
 use crate::sys;
+use crate::sys::x86::interrupts;
+
 use alloc::string::String;
 use alloc::string::ToString;
 use core::fmt;
 use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
-use x86_64::instructions::interrupts;
 
 pub static STDIN: Mutex<String> = Mutex::new(String::new());
 pub static ECHO: AtomicBool = AtomicBool::new(true);

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -143,7 +143,7 @@ pub fn read_char() -> char {
     sys::console::disable_echo();
     sys::console::enable_raw();
     loop {
-        sys::clk::halt();
+        sys::x86::hlt();
         let res = interrupts::without_interrupts(|| {
             let mut stdin = STDIN.lock();
             if !stdin.is_empty() {
@@ -162,7 +162,7 @@ pub fn read_char() -> char {
 
 pub fn read_line() -> String {
     loop {
-        sys::clk::halt();
+        sys::x86::hlt();
         let res = interrupts::without_interrupts(|| {
             let mut stdin = STDIN.lock();
             match stdin.chars().next_back() {

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -1,12 +1,12 @@
+use crate::{api, hang, sys};
 use crate::api::process::ExitCode;
 use crate::sys::process::Registers;
+use crate::sys::x86::interrupts;
 use crate::sys::x86::port::*;
-use crate::{api, hang, sys};
 
 use core::arch::{asm, naked_asm};
 use lazy_static::lazy_static;
 use spin::Mutex;
-use x86_64::instructions::interrupts;
 use x86_64::registers::control::Cr2;
 use x86_64::structures::idt::{
     InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -2,6 +2,7 @@ use crate::api;
 use crate::api::fs::{FileIO, IO};
 use crate::sys;
 use crate::sys::x86::port::*;
+use crate::sys::x86::interrupts;
 
 use alloc::collections::vec_deque::VecDeque;
 use alloc::format;
@@ -13,7 +14,6 @@ use pc_keyboard::{
     Keyboard, ScancodeSet1,
 };
 use spin::Mutex;
-use x86_64::instructions::interrupts;
 
 lazy_static! {
     pub static ref BUF: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -1,8 +1,8 @@
 use crate::api;
 use crate::api::fs::{FileIO, IO};
 use crate::sys;
-use crate::sys::x86::port::*;
 use crate::sys::x86::interrupts;
+use crate::sys::x86::port::*;
 
 use alloc::collections::vec_deque::VecDeque;
 use alloc::format;

--- a/src/sys/log.rs
+++ b/src/sys/log.rs
@@ -1,9 +1,10 @@
+use crate::sys::x86::interrupts;
+
 use alloc::string::String;
 use core::fmt;
 use core::fmt::Write;
 use lazy_static::lazy_static;
 use spin::Mutex;
-use x86_64::instructions::interrupts;
 
 lazy_static! {
     static ref LOG: Mutex<LogBuffer> = Mutex::new(LogBuffer::new());

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -49,7 +49,7 @@ pub mod x86 {
     }
 
     pub mod rflags {
-        pub const IF: usize = 1 << 9; // Interrupts Flag
+        pub const IF: usize = 1 << 9; // Interrupt Flag
     }
 
     pub mod interrupts {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -40,8 +40,8 @@ macro_rules! log {
 pub mod x86 {
     use core::arch::asm;
 
-    #[inline]
     /// Halts the CPU until the next interrupt
+    #[inline]
     pub fn hlt() {
         unsafe {
             asm!("hlt", options(nomem, nostack, preserves_flags));

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -41,6 +41,7 @@ pub mod x86 {
     use core::arch::asm;
 
     #[inline]
+    /// Halts the CPU until the next interrupt
     pub fn hlt() {
         unsafe {
             asm!("hlt", options(nomem, nostack, preserves_flags));

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -57,6 +57,13 @@ pub mod x86 {
                 asm!("sti", options(nostack, preserves_flags));
             }
         }
+
+        #[inline]
+        pub fn disable() {
+            unsafe {
+                asm!("cli", options(nostack, preserves_flags));
+            }
+        }
     }
 
     pub mod port {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -48,6 +48,10 @@ pub mod x86 {
         }
     }
 
+    pub mod rflags {
+        pub const IF: usize = 1 << 9; // Interrupts Flag
+    }
+
     pub mod interrupts {
         use core::arch::asm;
 
@@ -63,6 +67,29 @@ pub mod x86 {
             unsafe {
                 asm!("cli", options(nostack, preserves_flags));
             }
+        }
+
+        #[inline]
+        pub fn are_enabled() -> bool {
+            let rflags: usize;
+            unsafe {
+                asm!("pushfq; pop {}", out(reg) rflags,
+                    options(nomem, preserves_flags));
+            }
+            rflags & super::rflags::IF != 0
+        }
+
+        #[inline]
+        pub fn without_interrupts<F, R>(f: F) -> R where F: FnOnce() -> R {
+            let enabled = are_enabled();
+            if enabled {
+                disable();
+            }
+            let res = f();
+            if enabled {
+                enable();
+            }
+            res
         }
     }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -48,6 +48,17 @@ pub mod x86 {
         }
     }
 
+    pub mod interrupts {
+        use core::arch::asm;
+
+        #[inline]
+        pub fn enable() {
+            unsafe {
+                asm!("sti", options(nostack, preserves_flags));
+            }
+        }
+    }
+
     pub mod port {
         use core::arch::asm;
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -57,6 +57,7 @@ pub mod x86 {
 
         #[inline]
         pub fn enable() {
+            // NOTE: interrupts are not enabled until after the next instruction
             unsafe {
                 asm!("sti", options(nostack, preserves_flags));
             }

--- a/src/sys/net/nic/pcnet.rs
+++ b/src/sys/net/nic/pcnet.rs
@@ -211,7 +211,7 @@ impl Device {
 
         // Wait until init is done
         while !self.ports.read_csr_32(0).get_bit(CSR0_IDON) {
-            sys::clk::halt();
+            sys::x86::hlt();
         }
 
         // IDON + INTR + INIT

--- a/src/sys/net/socket/tcp.rs
+++ b/src/sys/net/socket/tcp.rs
@@ -91,7 +91,7 @@ impl TcpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
         }
         Ok(())
@@ -110,7 +110,7 @@ impl TcpSocket {
             if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                 wait(d);
             }
-            sys::clk::halt();
+            sys::x86::hlt();
             Ok(())
         } else {
             Err(())
@@ -136,7 +136,7 @@ impl TcpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
         } else {
             Err(())
@@ -174,7 +174,7 @@ impl FileIO for TcpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
             Ok(bytes)
         } else {
@@ -208,7 +208,7 @@ impl FileIO for TcpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
             Ok(buf.len())
         } else {
@@ -233,7 +233,7 @@ impl FileIO for TcpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
         }
     }

--- a/src/sys/net/socket/udp.rs
+++ b/src/sys/net/socket/udp.rs
@@ -79,7 +79,7 @@ impl UdpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
         }
         self.remote_endpoint = Some(IpEndpoint::new(addr, port));
@@ -122,7 +122,7 @@ impl FileIO for UdpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
             Ok(bytes)
         } else {
@@ -160,7 +160,7 @@ impl FileIO for UdpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
             Ok(buf.len())
         } else {
@@ -185,7 +185,7 @@ impl FileIO for UdpSocket {
                 if let Some(d) = iface.poll_delay(sys::net::time(), &sockets) {
                     wait(d);
                 }
-                sys::clk::halt();
+                sys::x86::hlt();
             }
         }
     }

--- a/src/sys/pic.rs
+++ b/src/sys/pic.rs
@@ -1,3 +1,5 @@
+use crate::sys::x86::interrupts;
+
 use pic8259::ChainedPics;
 use spin::Mutex;
 
@@ -12,5 +14,5 @@ pub fn init() {
     unsafe {
         PICS.lock().initialize();
     }
-    x86_64::instructions::interrupts::enable();
+    interrupts::enable();
 }

--- a/src/sys/process/spawn.rs
+++ b/src/sys/process/spawn.rs
@@ -13,6 +13,7 @@ use super::table::{PROCESS_TABLE, MAX_PROCS};
 use crate::api::process::ExitCode;
 use crate::sys::gdt::GDT;
 use crate::sys::mem;
+use crate::sys::x86::interrupts;
 
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
@@ -152,6 +153,7 @@ fn exec(ctx: ProcessContext, args_ptr: usize, args_len: usize) {
         ctx.allocator.lock().init(heap_addr as *mut u8, heap_size);
     }
 
+    interrupts::disable();
     unsafe {
         asm!(
             "cli",        // Disable interrupts

--- a/src/sys/process/spawn.rs
+++ b/src/sys/process/spawn.rs
@@ -13,8 +13,8 @@ use super::table::{PROCESS_TABLE, MAX_PROCS};
 use crate::api::process::ExitCode;
 use crate::sys::gdt::GDT;
 use crate::sys::mem;
-use crate::sys::x86::rflags;
 use crate::sys::x86::interrupts;
+use crate::sys::x86::rflags;
 
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};

--- a/src/sys/process/spawn.rs
+++ b/src/sys/process/spawn.rs
@@ -159,7 +159,7 @@ fn exec(ctx: ProcessContext, args_ptr: usize, args_len: usize) {
         asm!(
             "push {:r}", // Stack segment (SS)
             "push {:r}", // Stack pointer (RSP)
-            "push {:r}", // RFLAGS
+            "push {:r}", // FLAGS register (RFLAGS)
             "push {:r}", // Code segment (CS)
             "push {:r}", // Instruction pointer (RIP)
             "iretq",

--- a/src/sys/process/spawn.rs
+++ b/src/sys/process/spawn.rs
@@ -13,6 +13,7 @@ use super::table::{PROCESS_TABLE, MAX_PROCS};
 use crate::api::process::ExitCode;
 use crate::sys::gdt::GDT;
 use crate::sys::mem;
+use crate::sys::x86::rflags;
 use crate::sys::x86::interrupts;
 
 use alloc::boxed::Box;
@@ -156,15 +157,15 @@ fn exec(ctx: ProcessContext, args_ptr: usize, args_len: usize) {
     interrupts::disable();
     unsafe {
         asm!(
-            "cli",        // Disable interrupts
-            "push {:r}",  // Stack segment (SS)
-            "push {:r}",  // Stack pointer (RSP)
-            "push 0x200", // RFLAGS with interrupts enabled
-            "push {:r}",  // Code segment (CS)
-            "push {:r}",  // Instruction pointer (RIP)
+            "push {:r}", // Stack segment (SS)
+            "push {:r}", // Stack pointer (RSP)
+            "push {:r}", // RFLAGS
+            "push {:r}", // Code segment (CS)
+            "push {:r}", // Instruction pointer (RIP)
             "iretq",
             in(reg) GDT.1.user_data.0,
             in(reg) ctx.stack_addr,
+            in(reg) rflags::IF,
             in(reg) GDT.1.user_code.0,
             in(reg) ctx.entry_point_addr,
             in("rdi") args_ptr,

--- a/src/sys/serial.rs
+++ b/src/sys/serial.rs
@@ -1,4 +1,5 @@
 use crate::sys;
+use crate::sys::x86::interrupts;
 
 use core::fmt;
 use core::fmt::Write;
@@ -6,7 +7,6 @@ use lazy_static::lazy_static;
 use spin::Mutex;
 use uart_16550::SerialPort;
 use vte::{Params, Parser, Perform};
-use x86_64::instructions::interrupts;
 
 lazy_static! {
     pub static ref SERIAL: Mutex<Serial> = Mutex::new(Serial::new(0x3F8));

--- a/src/sys/snd/mod.rs
+++ b/src/sys/snd/mod.rs
@@ -4,6 +4,7 @@ mod sb16;
 use crate::api::fs::{FileIO, IO};
 use crate::sys::pci::DeviceConfig;
 use crate::sys;
+use crate::sys::x86::interrupts;
 
 use core::cmp;
 use core::convert::TryFrom;
@@ -141,7 +142,7 @@ impl FileIO for SoundBuffer {
     }
 
     fn write(&mut self, buffer: &[u8]) -> Result<usize, ()> {
-        x86_64::instructions::interrupts::without_interrupts(|| {
+        interrupts::without_interrupts(|| {
             if let Some((ref mut device, ref mut config)) = *SND.lock() {
                 if buffer.is_empty() {
                     device.stop();

--- a/src/sys/vga/font.rs
+++ b/src/sys/vga/font.rs
@@ -2,10 +2,10 @@ use super::writer::WRITER;
 
 use crate::api::font::Font;
 use crate::api::fs::{FileIO, IO};
+use crate::sys::x86::interrupts;
 
 use core::convert::TryFrom;
 use spin::Mutex;
-use x86_64::instructions::interrupts;
 
 static FONT: Mutex<Option<Font>> = Mutex::new(None);
 

--- a/src/sys/vga/mod.rs
+++ b/src/sys/vga/mod.rs
@@ -14,6 +14,7 @@ use color::Color;
 use palette::Palette;
 use writer::WRITER;
 
+use crate::sys::x86::interrupts;
 use crate::sys::x86::port::*;
 
 use alloc::string::String;
@@ -22,7 +23,6 @@ use core::cmp;
 use core::fmt;
 use core::fmt::Write;
 use core::num::ParseIntError;
-use x86_64::instructions::interrupts;
 
 const ATTR_ADDR_REG:           u16 = 0x3C0;
 const ATTR_WRITE_REG:          u16 = 0x3C0;


### PR DESCRIPTION
Replaces `x86_64::instructions::interrupts` with a new `sys::x86::interrupts` module in preparation for the i686 port (see #872 and #877).