### PR TITLE
Refactor PIC module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Refactor PIC module (#880)
 - Remove dependency on x86_64::instructions::random (#879)
 - Remove dependency on x86_64::instructions::interrupts (#878)
 - Remove dependency on x86_64::instructions::hlt (#877)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,6 @@ dependencies = [
  "object",
  "pbkdf2",
  "pc-keyboard",
- "pic8259",
  "rand",
  "rand_hc",
  "raw-cpuid 11.6.0",
@@ -463,15 +462,6 @@ name = "pc-keyboard"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ca629cbb3f0d5b699c338f0129ff78c9bfd7ea8b1258ad529bff490dc8ed5a"
-
-[[package]]
-name = "pic8259"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d9a86c292b165f757e47e7fd66855def189b2564609bc4203727b27c33db22"
-dependencies = [
- "x86_64",
-]
 
 [[package]]
 name = "proc-macro-error-attr2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ num-traits = { version = "0.2.19", default-features = false }
 object = { version = "0.40.0", default-features = false, features = ["read"] }
 pbkdf2 = { version = "0.12.2", default-features = false, features = ["hmac"] }
 pc-keyboard = "0.8.0"
-pic8259 = "0.11.0"
 rand = { version = "0.9.2", default-features = false }
 rand_hc = "0.4.0"
 raw-cpuid = "11.6.0"

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ be accomplished after completing an OSDev tutorial, while reading the
 
 - External bootloader (using [bootloader][4])
 - AMD64 CPU support (using [x86_64][5])
-- PS/2 keyboard with customizable layout (using [pc-keyboard][7])
+- PS/2 keyboard with customizable layout (using [pc-keyboard][6])
 - VGA text mode and 320x200 graphics buffer (for games and images) with
   customizable font and color palette
-- Serial output (using [uart_16550][8])
-- Heap allocation (using [linked_list_allocator][9])
-- ACPI shutdown (using [acpi][10] and [aml][11])
+- Serial output (using [uart_16550][7])
+- Heap allocation (using [linked_list_allocator][8])
+- ACPI shutdown (using [acpi][9] and [aml][10])
 - RTC clock with userspace NTP synchronization
 - Intel 8259 PIC
 - PCI devices
 - ATA PIO mode
 - Custom [filesystem](doc/filesystem.md) with bitmap allocation, linked blocks,
   block caching, and support for files, directories, and device nodes
-- Random number generator (using [rand_hc][12])
+- Random number generator (using [rand_hc][11])
 - Intel PRO/1000, RTL8139, and AMD PCNET network cards
-- DHCP/IP/TCP/UDP/DNS/HTTP network protocols (using [smoltcp][13])
+- DHCP/IP/TCP/UDP/DNS/HTTP network protocols (using [smoltcp][12])
 - AC97 and SB16 sound cards
 - Paging with bitmap frame allocator
 - Processes with isolated address spaces and demand paging
@@ -111,14 +111,13 @@ MOROS is released under MIT.
 [3]: https://wiki.osdev.org
 [4]: https://github.com/rust-osdev/bootloader
 [5]: https://crates.io/crates/x86_64
-[6]: https://crates.io/crates/pic8259
-[7]: https://crates.io/crates/pc-keyboard
-[8]: https://crates.io/crates/uart_16550
-[9]: https://crates.io/crates/linked_list_allocator
-[10]: https://crates.io/crates/acpi
-[11]: https://crates.io/crates/aml
-[12]: https://crates.io/crates/rand_hc
-[13]: https://crates.io/crates/smoltcp
+[6]: https://crates.io/crates/pc-keyboard
+[7]: https://crates.io/crates/uart_16550
+[8]: https://crates.io/crates/linked_list_allocator
+[9]: https://crates.io/crates/acpi
+[10]: https://crates.io/crates/aml
+[11]: https://crates.io/crates/rand_hc
+[12]: https://crates.io/crates/smoltcp
 
 [s1]: https://img.shields.io/github/actions/workflow/status/vinc/moros/rust.yml
 [s2]: https://img.shields.io/crates/v/moros.svg

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ be accomplished after completing an OSDev tutorial, while reading the
 ## Features
 
 - External bootloader (using [bootloader][4])
-- x86 CPU support (using [x86_64][5])
-- Hardware interrupts (using [pic8259][6])
+- AMD64 CPU support (using [x86_64][5])
 - PS/2 keyboard with customizable layout (using [pc-keyboard][7])
 - VGA text mode and 320x200 graphics buffer (for games and images) with
   customizable font and color palette
@@ -29,6 +28,7 @@ be accomplished after completing an OSDev tutorial, while reading the
 - Heap allocation (using [linked_list_allocator][9])
 - ACPI shutdown (using [acpi][10] and [aml][11])
 - RTC clock with userspace NTP synchronization
+- Intel 8259 PIC
 - PCI devices
 - ATA PIO mode
 - Custom [filesystem](doc/filesystem.md) with bitmap allocation, linked blocks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,10 @@ pub fn init(boot_info: &'static BootInfo) {
     sys::vga::init();
     sys::gdt::init();
     sys::idt::init();
-    sys::pic::init(); // Enable interrupts
+    sys::pic::init();
+
+    sys::x86::interrupts::enable();
+
     sys::serial::init();
     sys::keyboard::init();
     sys::clk::init();

--- a/src/sys/clk/timer.rs
+++ b/src/sys/clk/timer.rs
@@ -75,10 +75,10 @@ pub fn init() {
     let divider = PIT_DIVIDER;
     let channel = 0; // PIC
     set_pit_frequency(divider, channel);
-    sys::idt::set_irq_handler(0, pit_interrupt_handler);
+    sys::idt::set_irq_handler(sys::pic::PIT_IRQ, pit_interrupt_handler);
 
     // RTC timmer
-    sys::idt::set_irq_handler(8, rtc_interrupt_handler);
+    sys::idt::set_irq_handler(sys::pic::RTC_IRQ, rtc_interrupt_handler);
     CMOS::new().enable_update_interrupt();
 
     // TSC timmer

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -1,8 +1,8 @@
 use crate::{api, hang, sys};
 use crate::api::process::ExitCode;
+use crate::sys::pic;
 use crate::sys::process::Registers;
 use crate::sys::x86::interrupts;
-use crate::sys::x86::port::*;
 
 use core::arch::{asm, naked_asm};
 use lazy_static::lazy_static;
@@ -12,11 +12,6 @@ use x86_64::structures::idt::{
     InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode
 };
 use x86_64::VirtAddr;
-
-// Translate IRQ into system interrupt
-fn interrupt_index(irq: u8) -> u8 {
-    sys::pic::PIC_1_OFFSET + irq
-}
 
 fn default_handler() {}
 
@@ -46,22 +41,22 @@ lazy_static! {
                 set_handler_addr(addr).
                 set_privilege_level(x86_64::PrivilegeLevel::Ring3);
         }
-        idt[interrupt_index(0)].set_handler_fn(irq0_handler);
-        idt[interrupt_index(1)].set_handler_fn(irq1_handler);
-        idt[interrupt_index(2)].set_handler_fn(irq2_handler);
-        idt[interrupt_index(3)].set_handler_fn(irq3_handler);
-        idt[interrupt_index(4)].set_handler_fn(irq4_handler);
-        idt[interrupt_index(5)].set_handler_fn(irq5_handler);
-        idt[interrupt_index(6)].set_handler_fn(irq6_handler);
-        idt[interrupt_index(7)].set_handler_fn(irq7_handler);
-        idt[interrupt_index(8)].set_handler_fn(irq8_handler);
-        idt[interrupt_index(9)].set_handler_fn(irq9_handler);
-        idt[interrupt_index(10)].set_handler_fn(irq10_handler);
-        idt[interrupt_index(11)].set_handler_fn(irq11_handler);
-        idt[interrupt_index(12)].set_handler_fn(irq12_handler);
-        idt[interrupt_index(13)].set_handler_fn(irq13_handler);
-        idt[interrupt_index(14)].set_handler_fn(irq14_handler);
-        idt[interrupt_index(15)].set_handler_fn(irq15_handler);
+        idt[pic::vector(0)].set_handler_fn(irq0_handler);
+        idt[pic::vector(1)].set_handler_fn(irq1_handler);
+        idt[pic::vector(2)].set_handler_fn(irq2_handler);
+        idt[pic::vector(3)].set_handler_fn(irq3_handler);
+        idt[pic::vector(4)].set_handler_fn(irq4_handler);
+        idt[pic::vector(5)].set_handler_fn(irq5_handler);
+        idt[pic::vector(6)].set_handler_fn(irq6_handler);
+        idt[pic::vector(7)].set_handler_fn(irq7_handler);
+        idt[pic::vector(8)].set_handler_fn(irq8_handler);
+        idt[pic::vector(9)].set_handler_fn(irq9_handler);
+        idt[pic::vector(10)].set_handler_fn(irq10_handler);
+        idt[pic::vector(11)].set_handler_fn(irq11_handler);
+        idt[pic::vector(12)].set_handler_fn(irq12_handler);
+        idt[pic::vector(13)].set_handler_fn(irq13_handler);
+        idt[pic::vector(14)].set_handler_fn(irq14_handler);
+        idt[pic::vector(15)].set_handler_fn(irq15_handler);
         idt
     };
 }
@@ -71,11 +66,7 @@ macro_rules! irq_handler {
         pub extern "x86-interrupt" fn $handler(_: InterruptStackFrame) {
             let handlers = IRQ_HANDLERS.lock();
             handlers[$irq]();
-            unsafe {
-                sys::pic::PICS.lock().notify_end_of_interrupt(
-                    interrupt_index($irq)
-                );
-            }
+            sys::pic::eoi($irq);
         }
     };
 }
@@ -249,39 +240,12 @@ extern "sysv64" fn syscall_handler(
     regs.rax = res;
 }
 
-const PIC1: u16 = 0x21;
-const PIC2: u16 = 0xA1;
-
-fn irq_port(irq: u8) -> u16 {
-    if irq < 8 { PIC1 } else { PIC2 }
-}
-
-fn irq_line(irq: u8) -> u8 {
-    if irq < 8 { irq } else { irq - 8 }
-}
-
-pub fn set_irq_mask(irq: u8) {
-    let port = irq_port(irq);
-    unsafe {
-        let value = inb(port) | (1 << irq_line(irq));
-        outb(port, value);
-    }
-}
-
-pub fn clear_irq_mask(irq: u8) {
-    let port = irq_port(irq);
-    unsafe {
-        let value = inb(port) & !(1 << irq_line(irq));
-        outb(port, value);
-    }
-}
-
 pub fn set_irq_handler(irq: u8, handler: fn()) {
     interrupts::without_interrupts(|| {
         let mut handlers = IRQ_HANDLERS.lock();
         handlers[irq as usize] = handler;
 
-        clear_irq_mask(irq);
+        pic::unmask(irq);
     });
 }
 

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -66,7 +66,7 @@ macro_rules! irq_handler {
         pub extern "x86-interrupt" fn $handler(_: InterruptStackFrame) {
             let handlers = IRQ_HANDLERS.lock();
             handlers[$irq]();
-            sys::pic::eoi($irq);
+            pic::eoi($irq);
         }
     };
 }

--- a/src/sys/keyboard.rs
+++ b/src/sys/keyboard.rs
@@ -133,11 +133,6 @@ impl FileIO for KeyboardLayout {
     }
 }
 
-pub fn init() {
-    set_keyboard(option_env!("MOROS_KEYBOARD").unwrap_or("qwerty"));
-    sys::idt::set_irq_handler(1, interrupt_handler);
-}
-
 fn read_scancode() -> u8 {
     unsafe { inb(0x60) }
 }
@@ -306,4 +301,9 @@ fn interrupt_handler() {
             }
         }
     }
+}
+
+pub fn init() {
+    set_keyboard(option_env!("MOROS_KEYBOARD").unwrap_or("qwerty"));
+    sys::idt::set_irq_handler(sys::pic::KBD_IRQ, interrupt_handler);
 }

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -9,14 +9,12 @@ pub use paging::{
 };
 pub use phys::{phys_addr, PhysBuf};
 
-use crate::sys;
+use crate::sys::pic;
 
 use bootloader::bootinfo::{BootInfo, MemoryMap};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Once;
-use x86_64::structures::paging::{
-    OffsetPageTable, Translate,
-};
+use x86_64::structures::paging::{OffsetPageTable, Translate};
 use x86_64::{PhysAddr, VirtAddr};
 
 #[allow(static_mut_refs)]
@@ -30,7 +28,7 @@ pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
     // the keyboard interrupt that would create a panic if a key is pressed
     // during memory allocation otherwise.
-    sys::pic::mask(1);
+    pic::mask(pic::KBD_IRQ);
 
     let mut memory_size = 0;
     let mut last_end_addr = 0;
@@ -77,7 +75,7 @@ pub fn init(boot_info: &'static BootInfo) {
     bitmap::init_frame_allocator(&boot_info.memory_map);
     heap::init_heap().expect("heap initialization failed");
 
-    sys::pic::unmask(1);
+    pic::unmask(pic::KBD_IRQ);
 }
 
 pub fn phys_mem_offset() -> u64 {

--- a/src/sys/mem/mod.rs
+++ b/src/sys/mem/mod.rs
@@ -30,7 +30,7 @@ pub fn init(boot_info: &'static BootInfo) {
     // Keep the timer interrupt to have accurate boot time measurement but mask
     // the keyboard interrupt that would create a panic if a key is pressed
     // during memory allocation otherwise.
-    sys::idt::set_irq_mask(1);
+    sys::pic::mask(1);
 
     let mut memory_size = 0;
     let mut last_end_addr = 0;
@@ -77,7 +77,7 @@ pub fn init(boot_info: &'static BootInfo) {
     bitmap::init_frame_allocator(&boot_info.memory_map);
     heap::init_heap().expect("heap initialization failed");
 
-    sys::idt::clear_irq_mask(1);
+    sys::pic::unmask(1);
 }
 
 pub fn phys_mem_offset() -> u64 {

--- a/src/sys/pic.rs
+++ b/src/sys/pic.rs
@@ -1,18 +1,22 @@
 use crate::sys::x86::port::*;
 
-use pic8259::ChainedPics;
-use spin::Mutex;
-
+// Ports
 const PIC1_CMD: u16 = 0x20;
 const PIC2_CMD: u16 = 0xA0;
 const PIC1_DATA: u16 = PIC1_CMD + 1;
 const PIC2_DATA: u16 = PIC2_CMD + 1;
-const PIC1_OFFSET: u8 = 32;
-const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
 
-static PICS: Mutex<ChainedPics> = Mutex::new(unsafe {
-    ChainedPics::new(PIC1_OFFSET, PIC2_OFFSET)
-});
+// Vector offset
+const PIC_OFFSET: u8 = 0x20;
+
+// Initialization Command Words (ICW)
+const ICW1_INIT: u8 = 0x10; // Init (A0=0, D4=1)
+const ICW1_ICW4: u8 = 0x01; // ICW4 needed (D0=1)
+const ICW4_8086: u8 = 0x01; // 8086 mode (D0=1)
+
+// Operation Command Words (OCW)
+const PIC_EOI: u8 = 0x20; // End-of-interrupt (D5=1)
+
 // IRQ List
 pub const PIT_IRQ: u8 = 0;
 pub const KBD_IRQ: u8 = 1;
@@ -46,18 +50,65 @@ pub fn unmask(irq: u8) {
 }
 
 pub fn vector(irq: u8) -> u8 {
-    PIC1_OFFSET + irq
+    PIC_OFFSET + irq
 }
 
 pub fn eoi(irq: u8) {
-    let i = vector(irq);
     unsafe {
-        PICS.lock().notify_end_of_interrupt(i)
+        if irq >= 8 {
+            outb(PIC2_CMD, PIC_EOI);
+        }
+        outb(PIC1_CMD, PIC_EOI);
+    }
+}
+
+fn wait() {
+    unsafe {
+        outb(0x80, 0);
+    }
+}
+
+fn mask_all() {
+    unsafe {
+        outb(PIC1_DATA, 0xFF);
+        outb(PIC2_DATA, 0xFF);
+    }
+}
+
+fn remap(offset: u8) {
+    unsafe {
+        // Init
+        outb(PIC1_CMD, ICW1_INIT | ICW1_ICW4); // Clears the mask register
+        wait();
+        outb(PIC2_CMD, ICW1_INIT | ICW1_ICW4); // Clears the mask register
+        wait();
+
+        // Vector
+        outb(PIC1_DATA, offset);
+        wait();
+        outb(PIC2_DATA, offset + 8);
+        wait();
+
+        // Cascade
+        outb(PIC1_DATA, 1 << PIC_IRQ);
+        wait();
+        outb(PIC2_DATA, PIC_IRQ);
+        wait();
+
+        // Mode
+        outb(PIC1_DATA, ICW4_8086);
+        wait();
+        outb(PIC2_DATA, ICW4_8086);
     }
 }
 
 pub fn init() {
-    unsafe {
-        PICS.lock().initialize();
-    }
+    // Initially PIC1 has an offset of 0x8 which overlaps with processor
+    // interrupts so we need to map them higher, but below the system call
+    // interrupt at 0x80.
+    remap(PIC_OFFSET);
+
+    // The remapping unmasked everything
+    mask_all();
+    unmask(PIC_IRQ);
 }

--- a/src/sys/pic.rs
+++ b/src/sys/pic.rs
@@ -53,5 +53,4 @@ pub fn init() {
     unsafe {
         PICS.lock().initialize();
     }
-    interrupts::enable();
 }

--- a/src/sys/pic.rs
+++ b/src/sys/pic.rs
@@ -13,6 +13,13 @@ const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
 static PICS: Mutex<ChainedPics> = Mutex::new(unsafe {
     ChainedPics::new(PIC1_OFFSET, PIC2_OFFSET)
 });
+// IRQ List
+pub const PIT_IRQ: u8 = 0;
+pub const KBD_IRQ: u8 = 1;
+pub const PIC_IRQ: u8 = 2;
+pub const COM_IRQ: u8 = 4;
+pub const SND_IRQ: u8 = 5;
+pub const RTC_IRQ: u8 = 8;
 
 fn irq_port(irq: u8) -> u16 {
     if irq < 8 { PIC1_DATA } else { PIC2_DATA }

--- a/src/sys/pic.rs
+++ b/src/sys/pic.rs
@@ -1,14 +1,53 @@
-use crate::sys::x86::interrupts;
+use crate::sys::x86::port::*;
 
 use pic8259::ChainedPics;
 use spin::Mutex;
 
-pub const PIC_1_OFFSET: u8 = 32;
-pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
+const PIC1_CMD: u16 = 0x20;
+const PIC2_CMD: u16 = 0xA0;
+const PIC1_DATA: u16 = PIC1_CMD + 1;
+const PIC2_DATA: u16 = PIC2_CMD + 1;
+const PIC1_OFFSET: u8 = 32;
+const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
 
-pub static PICS: Mutex<ChainedPics> = Mutex::new(unsafe {
-    ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET)
+static PICS: Mutex<ChainedPics> = Mutex::new(unsafe {
+    ChainedPics::new(PIC1_OFFSET, PIC2_OFFSET)
 });
+
+fn irq_port(irq: u8) -> u16 {
+    if irq < 8 { PIC1_DATA } else { PIC2_DATA }
+}
+
+fn irq_line(irq: u8) -> u8 {
+    if irq < 8 { irq } else { irq - 8 }
+}
+
+pub fn mask(irq: u8) {
+    let port = irq_port(irq);
+    unsafe {
+        let value = inb(port) | (1 << irq_line(irq));
+        outb(port, value);
+    }
+}
+
+pub fn unmask(irq: u8) {
+    let port = irq_port(irq);
+    unsafe {
+        let value = inb(port) & !(1 << irq_line(irq));
+        outb(port, value);
+    }
+}
+
+pub fn vector(irq: u8) -> u8 {
+    PIC1_OFFSET + irq
+}
+
+pub fn eoi(irq: u8) {
+    let i = vector(irq);
+    unsafe {
+        PICS.lock().notify_end_of_interrupt(i)
+    }
+}
 
 pub fn init() {
     unsafe {

--- a/src/sys/serial.rs
+++ b/src/sys/serial.rs
@@ -73,18 +73,6 @@ impl Perform for Serial {
     }
 }
 
-#[doc(hidden)]
-pub fn print_fmt(args: fmt::Arguments) {
-    interrupts::without_interrupts(||
-        SERIAL.lock().write_fmt(args).expect("Could not print to serial")
-    )
-}
-
-pub fn init() {
-    SERIAL.lock().init();
-    sys::idt::set_irq_handler(4, interrupt_handler);
-}
-
 fn interrupt_handler() {
     let b = SERIAL.lock().read_byte();
     if b == 0xFF { // Ignore invalid bytes
@@ -96,4 +84,16 @@ fn interrupt_handler() {
         c => c,
     };
     sys::console::key_handle(c);
+}
+
+#[doc(hidden)]
+pub fn print_fmt(args: fmt::Arguments) {
+    interrupts::without_interrupts(||
+        SERIAL.lock().write_fmt(args).expect("Could not print to serial")
+    )
+}
+
+pub fn init() {
+    SERIAL.lock().init();
+    sys::idt::set_irq_handler(sys::pic::COM_IRQ, interrupt_handler);
 }

--- a/src/sys/snd/mod.rs
+++ b/src/sys/snd/mod.rs
@@ -204,9 +204,8 @@ pub fn init() {
     if let Some(device) = sb16::find() {
         *SND.lock() = Some((SoundDevice::SB16(device), config.clone()));
 
-        let irq = sb16::IRQ;
+        let irq = sys::pic::SND_IRQ;
         sys::idt::set_irq_handler(irq, interrupt_handler);
-
         log!("SND DRV SB16 (IRQ {})", irq);
         return;
     }
@@ -222,7 +221,6 @@ pub fn init() {
 
             let irq = pci.interrupt_line;
             sys::idt::set_irq_handler(irq, interrupt_handler);
-
             log!("SND DRV AC97 (IRQ {})", irq);
             return;
         }

--- a/src/sys/snd/sb16.rs
+++ b/src/sys/snd/sb16.rs
@@ -10,8 +10,6 @@ use alloc::vec::Vec;
 // https://wiki.osdev.org/Sound_Blaster_16
 // https://pdos.csail.mit.edu/6.828/2006/readings/hardware/SoundBlaster.pdf
 
-pub const IRQ: u8 = 5;
-
 const MIXER_ADDR: u16 = 0x224;
 const MIXER_DATA: u16 = 0x225;
 const DSP_RESET:  u16 = 0x226;
@@ -158,7 +156,7 @@ fn irq(num: u8) -> u8 {
 pub fn init() {
     unsafe {
         outb(MIXER_ADDR, 0x80);
-        outb(MIXER_DATA, irq(IRQ));
+        outb(MIXER_DATA, irq(sys::pic::SND_IRQ));
     }
 }
 


### PR DESCRIPTION
- [x] Remove dependency on `pic8259` crate
- [x] Centralize IRQ numbers in `pic` module
- [x] Move `idt::set_irq_mask(irq)` to `pic::mask(irq)`
- [x] Move `idt::clear_irq_mask(irq)` to `pic::unmask(irq)`