### PR TITLE
Fix sleep::wait timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix sleep::wait timing (#882)
 - Refactor PIC module (#880)
 - Remove dependency on x86_64::instructions::random (#879)
 - Remove dependency on x86_64::instructions::interrupts (#878)

--- a/src/sys/clk/sync.rs
+++ b/src/sys/clk/sync.rs
@@ -19,7 +19,7 @@ pub fn sleep(seconds: f64) {
 /// This function use a busy-wait loop with the `RDTSC` and `PAUSE`
 /// instructions.
 pub fn wait(nanoseconds: u64) {
-    let delta = nanoseconds * timer::tsc_frequency();
+    let delta = nanoseconds * timer::tsc_frequency() / 1_000_000_000;
     let start = timer::tsc();
     while timer::tsc() - start < delta {
         core::hint::spin_loop();

--- a/src/sys/clk/timer.rs
+++ b/src/sys/clk/timer.rs
@@ -82,9 +82,11 @@ pub fn init() {
     CMOS::new().enable_update_interrupt();
 
     // TSC timmer
-    let calibration_time = 250_000; // 0.25 seconds
+    let d = 250_000;
+    let t = 1_000_000;
     let a = tsc();
-    sync::sleep(calibration_time as f64 / 1e6);
+    sync::sleep(d as f64 / t as f64); // 0.25 seconds
     let b = tsc();
-    TSC_FREQUENCY.store((b - a) / calibration_time, Ordering::Relaxed);
+    let f = (b - a) * t / d;
+    TSC_FREQUENCY.store(f, Ordering::Relaxed);
 }


### PR DESCRIPTION
The `sleep::wait(nanosecs)` function was off by 3 orders of magnitude.