### PR TITLE
Add Grub support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add Grub support (#889)
 - Add Limine support (#835)
 - Set VGA Text Mode during init (#888)
 - Move FileIO from api to sys (#887)

--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,17 @@ limine-image:
 		run/boot -o $(bin)
 	$(limine-dir)/bin/limine bios-install $(bin)
 
+grub-dir = /usr/lib/grub/i386-pc
+grub-modules = multiboot2 $(shell cat $(grub-dir)/partmap.lst)
+
 grub-image: RUSTFLAGS = -C link-arg=-Trun/boot/multiboot.ld -C link-arg=-z -C link-arg=norelro
 grub-image:
 	cargo build $(cargo-opts),multiboot --target $(arch)-moros.json
 	cp target/$(arch)-moros/$(mode)/moros run/boot/kernel.elf
-	grub-mkrescue -d /usr/lib/grub/i386-pc -o $(bin) /boot=run/boot
+	grub-mkrescue -d $(grub-dir) \
+		--install-modules="$(grub-modules)" \
+		--fonts= --locales= --themes= \
+		-o $(bin) /boot=run/boot
 
 website:
 	cd www && sh build.sh

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ kvm = false
 pcap = false
 trace = false# e1000
 monitor = false
-bootloader = rust# rust, limine
+bootloader = rust# rust, limine, grub
 bootloader-proto = limine# limine, multiboot
 
 export MOROS_VERSION = $(shell git describe --tags | sed "s/^v//")
@@ -159,6 +159,12 @@ limine-image:
 		--protective-msdos-label \
 		run/boot -o $(bin)
 	$(limine-dir)/bin/limine bios-install $(bin)
+
+grub-image: RUSTFLAGS = -C link-arg=-Trun/boot/multiboot.ld -C link-arg=-z -C link-arg=norelro
+grub-image:
+	cargo build $(cargo-opts),multiboot --target i686-moros.json
+	cp target/i686-moros/$(mode)/moros run/boot/kernel.elf
+	grub-mkrescue -d /usr/lib/grub/i386-pc -o $(bin) /boot=run/boot
 
 website:
 	cd www && sh build.sh

--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,8 @@ limine-image:
 
 grub-image: RUSTFLAGS = -C link-arg=-Trun/boot/multiboot.ld -C link-arg=-z -C link-arg=norelro
 grub-image:
-	cargo build $(cargo-opts),multiboot --target i686-moros.json
-	cp target/i686-moros/$(mode)/moros run/boot/kernel.elf
+	cargo build $(cargo-opts),multiboot --target $(arch)-moros.json
+	cp target/$(arch)-moros/$(mode)/moros run/boot/kernel.elf
 	grub-mkrescue -d /usr/lib/grub/i386-pc -o $(bin) /boot=run/boot
 
 website:

--- a/run/boot/grub/grub.cfg
+++ b/run/boot/grub/grub.cfg
@@ -1,4 +1,4 @@
-set timeout=5
+set timeout=3
 set default=0
 
 menuentry "MOROS" {

--- a/run/boot/grub/grub.cfg
+++ b/run/boot/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=5
+set default=0
+
+menuentry "MOROS" {
+    multiboot2 /boot/kernel.elf
+    boot
+}

--- a/run/boot/limine/limine.conf
+++ b/run/boot/limine/limine.conf
@@ -1,7 +1,7 @@
 timeout: 0
 graphics: no
 serial: no
-default_entry: limine
+default_entry: multiboot
 /limine
     protocol: limine
     resolution: 640x480x32


### PR DESCRIPTION
This is a continuation of the work done in #835 that added partial Limine support with `limine` and `multiboot2` protocol and the beginning of the i686 port.