### PR TITLE
Replace x86_64 GDT and TSS structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Replace x86_64 GDT and TSS structures (#897)
 - Add Grub support (#889)
 - Add Limine support (#835)
 - Set VGA Text Mode during init (#888)

--- a/src/sys/boot/multiboot.rs
+++ b/src/sys/boot/multiboot.rs
@@ -42,6 +42,7 @@ pub extern "C" fn start(info: u32, magic: u32) -> ! {
             };
             //let offset = 0;
             //crate::init(&memory_map, offset);
+            crate::sys::gdt::init();
         }
     }
 

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -1,79 +1,81 @@
+use crate::sys::tss;
+use crate::sys::tss::TaskStateSegment;
+use crate::sys::x86;
+use crate::sys::x86::DescriptorTablePointer;
 use crate::sys::x86::reg;
+use crate::sys::x86::seg::SegmentSelector;
 
-use core::ptr::addr_of;
+use bit_field::BitField;
 use lazy_static::lazy_static;
-use x86_64::structures::gdt::{
-    Descriptor, GlobalDescriptorTable, SegmentSelector
-};
-use x86_64::structures::tss::TaskStateSegment;
-use x86_64::VirtAddr;
-
-const STACK_SIZE: usize = 1024 * 8 * 16;
-pub const DOUBLE_FAULT_IST: u16 = 0;
-pub const PAGE_FAULT_IST: u16 = 1;
-pub const GENERAL_PROTECTION_FAULT_IST: u16 = 2;
+use x86_64::structures::gdt::Descriptor;
 
 lazy_static! {
-    static ref TSS: TaskStateSegment = {
-        let mut tss = TaskStateSegment::new();
-        tss.privilege_stack_table[0] = {
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(addr_of!(STACK)) + STACK_SIZE as u64
-        };
-        tss.interrupt_stack_table[DOUBLE_FAULT_IST as usize] = {
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(addr_of!(STACK)) + STACK_SIZE as u64
-        };
-        tss.interrupt_stack_table[PAGE_FAULT_IST as usize] = {
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(addr_of!(STACK)) + STACK_SIZE as u64
-        };
-        tss.interrupt_stack_table[GENERAL_PROTECTION_FAULT_IST as usize] = {
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-            VirtAddr::from_ptr(addr_of!(STACK)) + STACK_SIZE as u64
-        };
-        tss
-    };
+    static ref GDT: GlobalDescriptorTable = GlobalDescriptorTable::new(&tss::TSS);
 }
 
-lazy_static! {
-    pub static ref GDT: (GlobalDescriptorTable, Selectors) = {
-        let mut gdt = GlobalDescriptorTable::new();
+pub const SYS_CODE: SegmentSelector = SegmentSelector::new(1, 0);
+pub const SYS_DATA: SegmentSelector = SegmentSelector::new(2, 0);
+pub const USR_CODE: SegmentSelector = SegmentSelector::new(3, 3);
+pub const USR_DATA: SegmentSelector = SegmentSelector::new(4, 3);
+pub const TSS:      SegmentSelector = SegmentSelector::new(5, 0);
 
-        let tss = gdt.append(Descriptor::tss_segment(&TSS));
-        let code = gdt.append(Descriptor::kernel_code_segment());
-        let data = gdt.append(Descriptor::kernel_data_segment());
-        let user_code = gdt.append(Descriptor::user_code_segment());
-        let user_data = gdt.append(Descriptor::user_data_segment());
-
-        (
-            gdt,
-            Selectors {
-                tss,
-                code,
-                data,
-                user_code,
-                user_data,
-            },
-        )
-    };
+const fn desc(desc: Descriptor) -> u64 {
+    match desc {
+        Descriptor::UserSegment(bits) => bits,
+        Descriptor::SystemSegment(..) => panic!("not a segment descriptor"),
+    }
 }
 
-pub struct Selectors {
-    tss: SegmentSelector,
-    code: SegmentSelector,
-    data: SegmentSelector,
-    pub user_code: SegmentSelector,
-    pub user_data: SegmentSelector,
+const LEN: usize = 7;
+
+struct GlobalDescriptorTable {
+    table: [u64; LEN],
+}
+
+impl GlobalDescriptorTable {
+    fn new(tss: &'static TaskStateSegment) -> Self {
+        let mut table = [0; LEN];
+        table[SYS_CODE.index()] = desc(Descriptor::kernel_code_segment());
+        table[SYS_DATA.index()] = desc(Descriptor::kernel_data_segment());
+        table[USR_CODE.index()] = desc(Descriptor::user_code_segment());
+        table[USR_DATA.index()] = desc(Descriptor::user_data_segment());
+
+        let base = tss as *const _ as u64;
+        let mut low = 1 << 47;
+        low.set_bits(0..16, size_of::<TaskStateSegment>() as u64 - 1);
+        low.set_bits(16..40, base.get_bits(0..24));
+        low.set_bits(40..44, 0b1001);
+        low.set_bits(56..64, base.get_bits(24..32));
+
+        table[TSS.index()] = low;
+        table[TSS.index() + 1] = base.get_bits(32..64);
+
+        Self { table }
+    }
+
+    fn limit(&self) -> u16 {
+        (LEN * size_of::<u64>() - 1) as u16
+    }
+
+    fn pointer(&self) -> DescriptorTablePointer {
+        DescriptorTablePointer {
+            limit: self.limit(),
+            base: self.table.as_ptr() as usize,
+        }
+    }
+
+    pub fn load(&'static self) {
+        unsafe { x86::lgdt(&self.pointer()) }
+    }
 }
 
 pub fn init() {
-    GDT.0.load();
+    GDT.load();
     unsafe {
-        reg::load_cs(GDT.1.code);
-        reg::load_ds(GDT.1.data);
-        reg::load_es(GDT.1.data);
-        reg::load_ss(GDT.1.data);
-        reg::load_tss(GDT.1.tss);
+        reg::load_cs(SYS_CODE);
+        reg::load_ds(SYS_DATA);
+        reg::load_es(SYS_DATA);
+        reg::load_ss(SYS_DATA);
+        reg::load_tss(TSS);
     }
 }

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -55,6 +55,9 @@ impl GlobalDescriptorTable {
     fn new(tss: &'static TaskStateSegment) -> Self {
         let mut table = [0; LEN];
 
+        table[SYS_DATA.index()] = COMMON_DATA | SIZE_32;
+        table[USR_DATA.index()] = COMMON_DATA | SIZE_32 | RING_3;
+
         #[cfg(target_arch = "x86")]
         {
             table[SYS_CODE.index()] = COMMON_CODE | SIZE_32;
@@ -66,9 +69,6 @@ impl GlobalDescriptorTable {
             table[SYS_CODE.index()] = COMMON_CODE | SIZE_64;
             table[USR_CODE.index()] = COMMON_CODE | SIZE_64 | RING_3;
         }
-
-        table[SYS_DATA.index()] = COMMON_DATA | SIZE_32;
-        table[USR_DATA.index()] = COMMON_DATA | SIZE_32 | RING_3;
 
         let base = tss.base() as u64;
         let mut bits = PRESENT;

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -26,6 +26,10 @@ const fn desc(desc: Descriptor) -> u64 {
     }
 }
 
+#[cfg(target_arch = "x86")]
+const LEN: usize = 6;
+
+#[cfg(target_arch = "x86_64")]
 const LEN: usize = 7;
 
 struct GlobalDescriptorTable {
@@ -48,7 +52,11 @@ impl GlobalDescriptorTable {
         low.set_bits(56..64, base.get_bits(24..32));
 
         table[TSS.index()] = low;
-        table[TSS.index() + 1] = base.get_bits(32..64);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            table[TSS.index() + 1] = base.get_bits(32..64);
+        }
 
         Self { table }
     }

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -19,6 +19,12 @@ pub const USR_CODE: SegmentSelector = SegmentSelector::new(3, 3);
 pub const USR_DATA: SegmentSelector = SegmentSelector::new(4, 3);
 pub const TSS:      SegmentSelector = SegmentSelector::new(5, 0);
 
+// Segment descriptor flags (Intel SDM 3.4.5)
+const PRESENT: u64 = 1 << 47;
+
+// System segment type (Intel SDM 3.5)
+const TYPE_TSS: u64 = 0b1001; // 32-bit or 64-bit TSS (Available)
+
 #[cfg(target_arch = "x86")]
 const LEN: usize = 6;
 
@@ -33,29 +39,28 @@ impl GlobalDescriptorTable {
     fn new(tss: &'static TaskStateSegment) -> Self {
         let mut table = [0; LEN];
 
-        #[cfg(target_arch = "x86_64")]
-        {
-            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE64.bits();
-            table[USR_CODE.index()] = DescriptorFlags::USER_CODE64.bits();
-        }
-
         #[cfg(target_arch = "x86")]
         {
             table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE32.bits();
             table[USR_CODE.index()] = DescriptorFlags::USER_CODE32.bits();
         }
 
+        #[cfg(target_arch = "x86_64")]
+        {
+            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE64.bits();
+            table[USR_CODE.index()] = DescriptorFlags::USER_CODE64.bits();
+        }
+
         table[SYS_DATA.index()] = DescriptorFlags::KERNEL_DATA.bits();
         table[USR_DATA.index()] = DescriptorFlags::USER_DATA.bits();
 
-        let base = tss as *const _ as u64;
-        let mut low = 1 << 47;
-        low.set_bits(0..16, size_of::<TaskStateSegment>() as u64 - 1);
-        low.set_bits(16..40, base.get_bits(0..24));
-        low.set_bits(40..44, 0b1001);
-        low.set_bits(56..64, base.get_bits(24..32));
-
-        table[TSS.index()] = low;
+        let base = tss.base() as u64;
+        let mut bits = PRESENT;
+        bits.set_bits(0..16, tss.limit() as u64);
+        bits.set_bits(16..40, base.get_bits(0..24));
+        bits.set_bits(40..44, TYPE_TSS);
+        bits.set_bits(56..64, base.get_bits(24..32));
+        table[TSS.index()] = bits;
 
         #[cfg(target_arch = "x86_64")]
         {

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -7,7 +7,6 @@ use crate::sys::x86::seg::SegmentSelector;
 
 use bit_field::BitField;
 use lazy_static::lazy_static;
-use x86_64::structures::gdt::DescriptorFlags;
 
 lazy_static! {
     static ref GDT: GlobalDescriptorTable = GlobalDescriptorTable::new(&tss::TSS);
@@ -20,7 +19,24 @@ pub const USR_DATA: SegmentSelector = SegmentSelector::new(4, 3);
 pub const TSS:      SegmentSelector = SegmentSelector::new(5, 0);
 
 // Segment descriptor flags (Intel SDM 3.4.5)
-const PRESENT: u64 = 1 << 47;
+const ACCESSED:     u64 = 1 << 40; // Accessed (A)
+const READABLE:     u64 = 1 << 41; // Readable (R)
+const WRITABLE:     u64 = 1 << 41; // Writable (W)
+const EXECUTABLE:   u64 = 1 << 43; // Executable (E)
+const CODE_OR_DATA: u64 = 1 << 44; // Segment (S)
+const RING_3:       u64 = 3 << 45; // Descriptor Privilege-Level (DPL)
+const PRESENT:      u64 = 1 << 47; // Present (P)
+const SIZE_64:      u64 = 1 << 53; // Long (L)
+const SIZE_32:      u64 = 1 << 54; // Default Operand Size (D/B)
+const GRANULARITY:  u64 = 1 << 55; // Granularity (G)
+
+const LIMIT_LO:     u64 = 0xFFFF;
+const LIMIT_HI:     u64 = 0xF << 48;
+const LIMIT:        u64 = LIMIT_LO | LIMIT_HI | GRANULARITY;
+
+const COMMON:       u64 = CODE_OR_DATA | PRESENT | ACCESSED | LIMIT;
+const COMMON_DATA:  u64 = COMMON | WRITABLE;
+const COMMON_CODE:  u64 = COMMON | READABLE | EXECUTABLE;
 
 // System segment type (Intel SDM 3.5)
 const TYPE_TSS: u64 = 0b1001; // 32-bit or 64-bit TSS (Available)
@@ -41,18 +57,18 @@ impl GlobalDescriptorTable {
 
         #[cfg(target_arch = "x86")]
         {
-            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE32.bits();
-            table[USR_CODE.index()] = DescriptorFlags::USER_CODE32.bits();
+            table[SYS_CODE.index()] = COMMON_CODE | SIZE_32;
+            table[USR_CODE.index()] = COMMON_CODE | SIZE_32 | RING_3;
         }
 
         #[cfg(target_arch = "x86_64")]
         {
-            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE64.bits();
-            table[USR_CODE.index()] = DescriptorFlags::USER_CODE64.bits();
+            table[SYS_CODE.index()] = COMMON_CODE | SIZE_64;
+            table[USR_CODE.index()] = COMMON_CODE | SIZE_64 | RING_3;
         }
 
-        table[SYS_DATA.index()] = DescriptorFlags::KERNEL_DATA.bits();
-        table[USR_DATA.index()] = DescriptorFlags::USER_DATA.bits();
+        table[SYS_DATA.index()] = COMMON_DATA | SIZE_32;
+        table[USR_DATA.index()] = COMMON_DATA | SIZE_32 | RING_3;
 
         let base = tss.base() as u64;
         let mut bits = PRESENT;

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -96,3 +96,21 @@ pub fn init() {
         reg::load_tss(TSS);
     }
 }
+
+#[test_case]
+fn test_gdt() {
+    assert_eq!(GDT.table.len(), 7);
+
+    assert_eq!(GDT.table[0], 0); // Null descriptor
+    assert_eq!(GDT.table[1], 0x00AF_9B00_0000_FFFF); // Kernel code segment
+    assert_eq!(GDT.table[2], 0x00CF_9300_0000_FFFF); // Kernel data segment
+    assert_eq!(GDT.table[3], 0x00AF_FB00_0000_FFFF); // User code segment
+    assert_eq!(GDT.table[4], 0x00CF_F300_0000_FFFF); // User data segment
+
+    // Task state segment (TSS)
+    let lo = GDT.table[5];
+    let hi = GDT.table[6];
+    let base = lo.get_bits(16..40) | (lo.get_bits(56..64) << 24) | (hi << 32);
+    assert_eq!(base, tss::TSS.base() as u64);
+    assert_eq!(lo.get_bit(47), true); // Present
+}

--- a/src/sys/gdt.rs
+++ b/src/sys/gdt.rs
@@ -7,7 +7,7 @@ use crate::sys::x86::seg::SegmentSelector;
 
 use bit_field::BitField;
 use lazy_static::lazy_static;
-use x86_64::structures::gdt::Descriptor;
+use x86_64::structures::gdt::DescriptorFlags;
 
 lazy_static! {
     static ref GDT: GlobalDescriptorTable = GlobalDescriptorTable::new(&tss::TSS);
@@ -18,13 +18,6 @@ pub const SYS_DATA: SegmentSelector = SegmentSelector::new(2, 0);
 pub const USR_CODE: SegmentSelector = SegmentSelector::new(3, 3);
 pub const USR_DATA: SegmentSelector = SegmentSelector::new(4, 3);
 pub const TSS:      SegmentSelector = SegmentSelector::new(5, 0);
-
-const fn desc(desc: Descriptor) -> u64 {
-    match desc {
-        Descriptor::UserSegment(bits) => bits,
-        Descriptor::SystemSegment(..) => panic!("not a segment descriptor"),
-    }
-}
 
 #[cfg(target_arch = "x86")]
 const LEN: usize = 6;
@@ -39,10 +32,21 @@ struct GlobalDescriptorTable {
 impl GlobalDescriptorTable {
     fn new(tss: &'static TaskStateSegment) -> Self {
         let mut table = [0; LEN];
-        table[SYS_CODE.index()] = desc(Descriptor::kernel_code_segment());
-        table[SYS_DATA.index()] = desc(Descriptor::kernel_data_segment());
-        table[USR_CODE.index()] = desc(Descriptor::user_code_segment());
-        table[USR_DATA.index()] = desc(Descriptor::user_data_segment());
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE64.bits();
+            table[USR_CODE.index()] = DescriptorFlags::USER_CODE64.bits();
+        }
+
+        #[cfg(target_arch = "x86")]
+        {
+            table[SYS_CODE.index()] = DescriptorFlags::KERNEL_CODE32.bits();
+            table[USR_CODE.index()] = DescriptorFlags::USER_CODE32.bits();
+        }
+
+        table[SYS_DATA.index()] = DescriptorFlags::KERNEL_DATA.bits();
+        table[USR_DATA.index()] = DescriptorFlags::USER_DATA.bits();
 
         let base = tss as *const _ as u64;
         let mut low = 1 << 47;

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -28,13 +28,13 @@ lazy_static! {
         unsafe {
             idt.double_fault.
                 set_handler_fn(double_fault_handler).
-                set_stack_index(sys::gdt::DOUBLE_FAULT_IST);
+                set_stack_index(sys::tss::DOUBLE_FAULT as u16);
             idt.page_fault.
                 set_handler_fn(page_fault_handler).
-                set_stack_index(sys::gdt::PAGE_FAULT_IST);
+                set_stack_index(sys::tss::PAGE_FAULT as u16);
             idt.general_protection_fault.
                 set_handler_fn(general_protection_fault_handler).
-                set_stack_index(sys::gdt::GENERAL_PROTECTION_FAULT_IST);
+                set_stack_index(sys::tss::GENERAL_PROTECTION_FAULT as u16);
 
             let addr = VirtAddr::from_ptr(wrapped_syscall_handler as *const ());
             idt[0x80].

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -58,5 +58,6 @@ pub mod serial;
 #[cfg(target_arch = "x86_64")] pub mod snd;
 #[cfg(target_arch = "x86_64")] pub mod speaker;
 #[cfg(target_arch = "x86_64")] pub mod syscall;
+pub mod tss;
 #[cfg(target_arch = "x86_64")] pub mod vga;
 pub mod x86;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -44,7 +44,7 @@ pub mod boot;
 #[cfg(target_arch = "x86_64")] pub mod console;
 #[cfg(target_arch = "x86_64")] pub mod cpu;
 #[cfg(target_arch = "x86_64")] pub mod fs;
-#[cfg(target_arch = "x86_64")] pub mod gdt;
+pub mod gdt;
 #[cfg(target_arch = "x86_64")] pub mod idt;
 #[cfg(target_arch = "x86_64")] pub mod keyboard;
 #[cfg(target_arch = "x86_64")] pub mod log;

--- a/src/sys/process/spawn.rs
+++ b/src/sys/process/spawn.rs
@@ -11,7 +11,7 @@ use super::free_process;
 use super::table::{PROCESS_TABLE, MAX_PROCS};
 
 use crate::api::process::ExitCode;
-use crate::sys::gdt::GDT;
+use crate::sys::gdt;
 use crate::sys::mem;
 use crate::sys::x86::int;
 use crate::sys::x86::reg::{Cr3, flags};
@@ -163,10 +163,10 @@ fn exec(ctx: ProcessContext, args_ptr: usize, args_len: usize) {
             "push {:r}", // Code segment (CS)
             "push {:r}", // Instruction pointer (RIP)
             "iretq",
-            in(reg) GDT.1.user_data.0,
+            in(reg) gdt::USR_DATA.bits,
             in(reg) ctx.stack_addr,
             in(reg) flags::IF,
-            in(reg) GDT.1.user_code.0,
+            in(reg) gdt::USR_CODE.bits,
             in(reg) ctx.entry_point_addr,
             in("rdi") args_ptr,
             in("rsi") args_len,

--- a/src/sys/tss.rs
+++ b/src/sys/tss.rs
@@ -81,8 +81,20 @@ pub struct TaskStateSegment {
 impl TaskStateSegment {
     pub fn new() -> Self {
         let mut tss = Self::default();
-        tss.iomap_base = size_of::<Self>() as u16;
+        tss.iomap_base = Self::size();
         tss
+    }
+
+    const fn size() -> u16 {
+        size_of::<Self>() as u16
+    }
+
+    pub fn limit(&self) -> u16 {
+        Self::size() - 1
+    }
+
+    pub fn base(&self) -> usize {
+        self as *const _ as usize
     }
 
     #[cfg(target_arch = "x86")]

--- a/src/sys/tss.rs
+++ b/src/sys/tss.rs
@@ -1,0 +1,103 @@
+use core::ptr::addr_of;
+use lazy_static::lazy_static;
+
+const STACK_SIZE: usize = 1024 * 8 * 16;
+pub const DOUBLE_FAULT: usize = 0;
+pub const PAGE_FAULT: usize = 1;
+pub const GENERAL_PROTECTION_FAULT: usize = 2;
+
+lazy_static! {
+    pub static ref TSS: TaskStateSegment = {
+        let mut tss = TaskStateSegment::new();
+
+        let addr = {
+            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+            STACK_SIZE + addr_of!(STACK) as usize
+        };
+        tss.set_kernel_stack(addr);
+
+        #[cfg(target_arch = "x86")]
+        {
+            tss.stack[0].ss = crate::sys::gdt::SYS_DATA.bits;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let addr = {
+                static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+                STACK_SIZE + addr_of!(STACK) as usize
+            };
+            tss.set_interrupt_stack(DOUBLE_FAULT, addr);
+
+            let addr = {
+                static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+                STACK_SIZE + addr_of!(STACK) as usize
+            };
+            tss.set_interrupt_stack(PAGE_FAULT, addr);
+
+            let addr = {
+                static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+                STACK_SIZE + addr_of!(STACK) as usize
+            };
+            tss.set_interrupt_stack(GENERAL_PROTECTION_FAULT, addr);
+        }
+        tss
+    };
+}
+
+#[cfg(target_arch = "x86")]
+#[repr(C)]
+#[derive(Default)]
+pub struct PrivilegeStack {
+    pub esp: u32,
+    pub ss: u16,
+    reserved: u16,
+}
+
+#[cfg(target_arch = "x86")]
+#[repr(C, packed(4))]
+#[derive(Default)]
+pub struct TaskStateSegment {
+    reserved_1: u32,
+    pub stack: [PrivilegeStack; 3],
+    reserved_2: [u32; 18],
+    reserved_3: u16,
+    pub iomap_base: u16,
+}
+
+#[cfg(target_arch = "x86_64")]
+#[derive(Default)]
+#[repr(C, packed(4))]
+pub struct TaskStateSegment {
+    reserved_1: u32,
+    pub stack: [u64; 3],
+    reserved_2: [u32; 2],
+    pub ist: [u64; 7],
+    reserved_3: [u32; 2],
+    reserved_4: u16,
+    pub iomap_base: u16,
+}
+
+impl TaskStateSegment {
+    pub fn new() -> Self {
+        let mut tss = Self::default();
+        tss.iomap_base = size_of::<Self>() as u16;
+        tss
+    }
+
+    #[cfg(target_arch = "x86")]
+    pub fn set_kernel_stack(&mut self, addr: usize) {
+        self.stack[0].esp = addr as u32;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn set_kernel_stack(&mut self, addr: usize) {
+        self.stack[0] = addr as u64;
+    }
+
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn set_interrupt_stack(&mut self, index: usize, addr: usize) {
+        self.ist[index] = addr as u64;
+    }
+}

--- a/src/sys/x86/mod.rs
+++ b/src/sys/x86/mod.rs
@@ -35,6 +35,12 @@ pub struct DescriptorTablePointer {
     pub base: usize,
 }
 
+pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
+    unsafe {
+        asm!("lgdt [{}]", in(reg) gdt, options(readonly, nostack, preserves_flags));
+    }
+}
+
 pub mod port {
     use core::arch::asm;
 

--- a/src/sys/x86/mod.rs
+++ b/src/sys/x86/mod.rs
@@ -29,6 +29,12 @@ pub fn rdrand() -> Option<u64> {
     None
 }
 
+#[repr(C, packed(2))]
+pub struct DescriptorTablePointer {
+    pub limit: u16,
+    pub base: usize,
+}
+
 pub mod port {
     use core::arch::asm;
 

--- a/src/sys/x86/mod.rs
+++ b/src/sys/x86/mod.rs
@@ -1,5 +1,6 @@
 pub mod int;
 pub mod reg;
+pub mod seg;
 
 use core::arch::asm;
 

--- a/src/sys/x86/reg.rs
+++ b/src/sys/x86/reg.rs
@@ -1,7 +1,8 @@
+use super::seg::SegmentSelector;
+
 use core::arch::asm;
 
 use bit_field::BitField;
-use x86_64::structures::gdt::SegmentSelector;
 use x86_64::structures::paging::PhysFrame;
 use x86_64::PhysAddr;
 
@@ -80,29 +81,29 @@ pub unsafe fn load_cs(sel: SegmentSelector) {
         "push {0}", // Return address
         "retfq",
         "2:",
-        inout(reg) usize::from(sel.0) => _,
+        inout(reg) usize::from(sel.bits) => _,
         options(preserves_flags),
     );
 }
 
 #[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
-    asm!("mov ds, {:x}", in(reg) sel.0, options(nostack, preserves_flags));
+    asm!("mov ds, {:x}", in(reg) sel.bits, options(nostack, preserves_flags));
 }
 
 #[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
-    asm!("mov es, {:x}", in(reg) sel.0, options(nostack, preserves_flags));
+    asm!("mov es, {:x}", in(reg) sel.bits, options(nostack, preserves_flags));
 }
 
 #[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
-    asm!("mov ss, {:x}", in(reg) sel.0, options(nostack, preserves_flags));
+    asm!("mov ss, {:x}", in(reg) sel.bits, options(nostack, preserves_flags));
 }
 
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
-    asm!("ltr {:x}", in(reg) sel.0, options(nostack, preserves_flags));
+    asm!("ltr {:x}", in(reg) sel.bits, options(nostack, preserves_flags));
 }
 
 #[test_case]

--- a/src/sys/x86/reg.rs
+++ b/src/sys/x86/reg.rs
@@ -74,7 +74,18 @@ pub mod flags {
 
 #[inline]
 pub unsafe fn load_cs(sel: SegmentSelector) {
-    // See `x86_64` and `x86` crates for reference
+    #[cfg(target_arch = "x86")]
+    asm!(
+        "push {0}", // Selector
+        "lea {0}, [2f]",
+        "push {0}", // Return address
+        "retf",
+        "2:",
+        inout(reg) usize::from(sel.bits) => _,
+        options(preserves_flags),
+    );
+
+    #[cfg(target_arch = "x86_64")]
     asm!(
         "push {0}", // Selector
         "lea {0}, [rip + 2f]",

--- a/src/sys/x86/seg.rs
+++ b/src/sys/x86/seg.rs
@@ -1,0 +1,13 @@
+pub struct SegmentSelector {
+    pub bits: u16,
+}
+
+impl SegmentSelector {
+    pub const fn new(index: usize, ring: usize) -> Self {
+        Self { bits: (index << 3 | ring) as u16 }
+    }
+
+    pub const fn index(&self) -> usize {
+        (self.bits >> 3) as usize
+    }
+}


### PR DESCRIPTION
Another PR removing more usages of the `x86_64` crate for the i686 port.

I'm using the code of both `x86_64` and `x86` crates along with the OSDev wiki as a starting point. The crates must be generic to work for a lot of projects but I just need a subset of the features for MOROS so there's room for simplification.