### PR TITLE
Add console::Input for i686

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add console::Input for i686 (#905)
 - Add idt::InterruptDescriptorTable (#902)
 - Move syscall handler from idt to syscall module (#900)
 - Set the kernel stack size (#901)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ be accomplished after completing an OSDev tutorial, while reading the
 [![GitHub Actions][s1]](https://github.com/vinc/moros)
 [![Crates.io][s2]](https://crates.io/crates/moros)
 
+> **Note:** the kernel is currently being refactored to support the i686
+> architecture in addition to x86-64.
+
 ## Features
 
 - External bootloader (using [bootloader][4])

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This project started from the [seventh post][1] of the second edition of
 be accomplished after completing an OSDev tutorial, while reading the
 [OSDev wiki][3] along with many open source kernels.
 
-[![GitHub Actions][s1]](https://github.com/vinc/moros)
-[![Crates.io][s2]](https://crates.io/crates/moros)
-
 > **Note:** the kernel is currently being refactored to support the i686
 > architecture in addition to x86-64.
+
+[![GitHub Actions][s1]](https://github.com/vinc/moros)
+[![Crates.io][s2]](https://crates.io/crates/moros)
 
 ## Features
 

--- a/src/sys/boot/multiboot.rs
+++ b/src/sys/boot/multiboot.rs
@@ -16,10 +16,9 @@ static MULTIBOOT_HEADER: [u32; 6] = [
 // TODO: Improve protocol support
 pub extern "C" fn start(info: u32, magic: u32) -> ! {
     crate::sys::vga::init();
-    crate::sys::vga::print_fmt(format_args!("MOROS loading...\n"));
-
     crate::sys::serial::init();
-    crate::sys::serial::print_fmt(format_args!("MOROS loading...\n"));
+
+    printk!("MOROS loading...\n");
 
     if magic == multiboot2::MAGIC {
         let boot_info = unsafe {
@@ -43,8 +42,7 @@ pub extern "C" fn start(info: u32, magic: u32) -> ! {
         }
     }
 
-    crate::sys::serial::print_fmt(format_args!("MOROS loaded successfully!\n"));
-    crate::sys::vga::print_fmt(format_args!("MOROS loaded successfully!\n"));
+    printk!("MOROS loaded successfully!\n");
 
     //crate::exec();
     crate::hang();

--- a/src/sys/boot/multiboot.rs
+++ b/src/sys/boot/multiboot.rs
@@ -16,7 +16,6 @@ static MULTIBOOT_HEADER: [u32; 6] = [
 // TODO: Improve protocol support
 pub extern "C" fn start(info: u32, magic: u32) -> ! {
     crate::sys::vga::init();
-    crate::sys::serial::init();
 
     printk!("MOROS loading...\n");
 
@@ -42,6 +41,7 @@ pub extern "C" fn start(info: u32, magic: u32) -> ! {
             crate::sys::idt::init();
             crate::sys::pic::init();
             crate::sys::x86::int::enable_interrupts();
+            crate::sys::serial::init();
         }
     }
 

--- a/src/sys/boot/multiboot.rs
+++ b/src/sys/boot/multiboot.rs
@@ -39,6 +39,9 @@ pub extern "C" fn start(info: u32, magic: u32) -> ! {
             //let offset = 0;
             //crate::init(&memory_map, offset);
             crate::sys::gdt::init();
+            crate::sys::idt::init();
+            crate::sys::pic::init();
+            crate::sys::x86::int::enable_interrupts();
         }
     }
 

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -21,19 +21,27 @@ pub const EOT_KEY: char = '\x04'; // End of Transmission
 pub const ESC_KEY: char = '\x1B'; // Escape
 pub const ETX_KEY: char = '\x03'; // End of Text
 
-pub const MAX: usize = 1024;
+const MAX_INPUT: usize = 1024;
 
 pub struct Input {
-    buf: [char; MAX],
+    buf: [char; MAX_INPUT],
     len: usize
 }
 
 impl Input {
     pub const fn new() -> Self {
         Self {
-            buf: ['\0'; MAX],
+            buf: ['\0'; MAX_INPUT],
             len: 0
         }
+    }
+
+    pub const fn capacity(&self) -> usize {
+        MAX_INPUT
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
     }
 
     pub fn is_empty(&self) -> bool {
@@ -73,7 +81,7 @@ impl Input {
     }
 
     pub fn push_back(&mut self, c: char) -> Result<(), ()> {
-        if self.len < MAX {
+        if self.len < MAX_INPUT {
             self.buf[self.len] = c;
             self.len += 1;
             Ok(())
@@ -198,6 +206,13 @@ pub fn key_handle(key: char) {
         } else {
             key
         };
+
+        // Reserve the last slot in the buffer for the newline
+        let reserved = (key != '\n') as usize;
+        if stdin.len() + reserved >= stdin.capacity() {
+            return;
+        }
+
         if stdin.push_back(key).is_ok() && is_echo_enabled() {
             match key {
                 ETX_KEY => print_fmt(format_args!("^C")),

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -44,7 +44,7 @@ impl Input {
         self.len = 0;
     }
 
-    pub fn last(&self) -> Option<char> {
+    pub fn back(&self) -> Option<char> {
         if self.len > 0 {
             Some(self.buf[self.len - 1])
         } else {
@@ -52,7 +52,7 @@ impl Input {
         }
     }
 
-    pub fn pop(&mut self) -> Option<char> {
+    pub fn pop_back(&mut self) -> Option<char> {
         if self.len > 0 {
             self.len -= 1;
             Some(self.buf[self.len])
@@ -61,22 +61,22 @@ impl Input {
         }
     }
 
-    pub fn remove(&mut self, i: usize) -> char {
-        if i < self.len {
-            let c = self.buf[i];
+    pub fn pop_front(&mut self) -> Option<char> {
+        if self.len > 0 {
+            let c = self.buf[0];
             self.len -= 1;
-            let mut j = i;
-            while j < self.len {
-                self.buf[j] = self.buf[j + 1];
-                j += 1;
+            let mut i = 0;
+            while i < self.len {
+                self.buf[i] = self.buf[i + 1];
+                i += 1;
             }
-            c
+            Some(c)
         } else {
-            panic!();
+            None
         }
     }
 
-    pub fn push(&mut self, c: char) -> Result<(), ()> {
+    pub fn push_back(&mut self, c: char) -> Result<(), ()> {
         if self.len < MAX {
             self.buf[self.len] = c;
             self.len += 1;
@@ -186,7 +186,7 @@ pub fn key_handle(key: char) {
 
     if key == BS_KEY && !is_raw_enabled() {
         // Avoid printing more backspaces than chars inserted into STDIN
-        if let Some(c) = stdin.pop() {
+        if let Some(c) = stdin.pop_back() {
             if is_echo_enabled() {
                 let n = match c {
                     ETX_KEY | EOT_KEY | ESC_KEY => 2,
@@ -209,7 +209,7 @@ pub fn key_handle(key: char) {
         } else {
             key
         };
-        if stdin.push(key).is_ok() && is_echo_enabled() {
+        if stdin.push_back(key).is_ok() && is_echo_enabled() {
             match key {
                 ETX_KEY => print_fmt(format_args!("^C")),
                 EOT_KEY => print_fmt(format_args!("^D")),
@@ -237,15 +237,7 @@ pub fn read_char() -> char {
     sys::console::enable_raw();
     loop {
         sys::x86::hlt();
-        let res = int::without_interrupts(|| {
-            let mut stdin = STDIN.lock();
-            if !stdin.is_empty() {
-                Some(stdin.remove(0))
-            } else {
-                None
-            }
-        });
-        if let Some(c) = res {
+        if let Some(c) = int::without_interrupts(|| STDIN.lock().pop_front()) {
             sys::console::enable_echo();
             sys::console::disable_raw();
             return c;
@@ -259,7 +251,7 @@ pub fn read_line() -> String {
         sys::x86::hlt();
         let res = int::without_interrupts(|| {
             let mut stdin = STDIN.lock();
-            match stdin.last() {
+            match stdin.back() {
                 Some('\n') => {
                     let line = stdin.to_string();
                     stdin.clear();

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -198,7 +198,7 @@ pub fn key_handle(key: char) {
         // Reserve the last slot in the buffer for the newline
         let reserved = (key != '\n') as usize;
         if stdin.len() + reserved >= stdin.capacity() {
-            return;
+            return; // Keys are dropped when there is no room for them
         }
 
         if stdin.push_back(key).is_ok() && is_echo_enabled() {
@@ -212,10 +212,12 @@ pub fn key_handle(key: char) {
     }
 }
 
+// TODO: Implement proper signals instead of pushing ETX in STDIN
 pub fn end_of_text() -> bool {
     int::without_interrupts(|| STDIN.lock().contains(ETX_KEY))
 }
 
+// TODO: Implement proper end-of-file instead of pushing EOT in STDIN
 pub fn end_of_transmission() -> bool {
     int::without_interrupts(|| STDIN.lock().contains(EOT_KEY))
 }

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -187,13 +187,7 @@ pub fn key_handle(key: char) {
             if is_echo_enabled() {
                 let n = match c {
                     ETX_KEY | EOT_KEY | ESC_KEY => 2,
-                    _ => {
-                        if (c as u32) < 0xFF {
-                            1
-                        } else {
-                            c.len_utf8()
-                        }
-                    }
+                    _ => 1,
                 };
                 for _ in 0..n {
                     print_fmt(format_args!("{}", BS_KEY));
@@ -201,12 +195,6 @@ pub fn key_handle(key: char) {
             }
         }
     } else {
-        let key = if (key as u32) < 0xFF {
-            (key as u8) as char
-        } else {
-            key
-        };
-
         // Reserve the last slot in the buffer for the newline
         let reserved = (key != '\n') as usize;
         if stdin.len() + reserved >= stdin.capacity() {

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -64,12 +64,8 @@ impl Input {
     pub fn pop_front(&mut self) -> Option<char> {
         if self.len > 0 {
             let c = self.buf[0];
+            self.buf.copy_within(1..self.len, 0);
             self.len -= 1;
-            let mut i = 0;
-            while i < self.len {
-                self.buf[i] = self.buf[i + 1];
-                i += 1;
-            }
             Some(c)
         } else {
             None

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -1,14 +1,18 @@
+#[cfg(target_arch = "x86_64")]
 use crate::sys::fs::{FileIO, IO};
+
 use crate::sys;
 use crate::sys::x86::int;
 
-use alloc::string::String;
-use alloc::string::ToString;
+#[cfg(target_arch = "x86_64")]
+use alloc::string::{String, ToString};
+
 use core::fmt;
+use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
 
-pub static STDIN: Mutex<String> = Mutex::new(String::new());
+pub static STDIN: Mutex<Input> = Mutex::new(Input::new());
 pub static ECHO: AtomicBool = AtomicBool::new(true);
 pub static RAW: AtomicBool = AtomicBool::new(false);
 
@@ -16,6 +20,92 @@ pub const BS_KEY: char = '\x08'; // Backspace
 pub const EOT_KEY: char = '\x04'; // End of Transmission
 pub const ESC_KEY: char = '\x1B'; // Escape
 pub const ETX_KEY: char = '\x03'; // End of Text
+
+pub const MAX: usize = 1024;
+
+pub struct Input {
+    buf: [char; MAX],
+    len: usize
+}
+
+impl Input {
+    pub const fn new() -> Self {
+        Self {
+            buf: ['\0'; MAX],
+            len: 0
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn last(&self) -> Option<char> {
+        if self.len > 0 {
+            Some(self.buf[self.len - 1])
+        } else {
+            None
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<char> {
+        if self.len > 0 {
+            self.len -= 1;
+            Some(self.buf[self.len])
+        } else {
+            None
+        }
+    }
+
+    pub fn remove(&mut self, i: usize) -> char {
+        if i < self.len {
+            let c = self.buf[i];
+            self.len -= 1;
+            let mut j = i;
+            while j < self.len {
+                self.buf[j] = self.buf[j + 1];
+                j += 1;
+            }
+            c
+        } else {
+            panic!();
+        }
+    }
+
+    pub fn push(&mut self, c: char) -> Result<(), ()> {
+        if self.len < MAX {
+            self.buf[self.len] = c;
+            self.len += 1;
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn contains(&self, c: char) -> bool {
+        let mut i = 0;
+        while i < self.len {
+            if self.buf[i] == c {
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+}
+
+impl fmt::Display for Input {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for c in &self.buf[0..self.len] {
+            f.write_char(*c)?;
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Console;
@@ -30,6 +120,7 @@ impl Console {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 impl FileIO for Console {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
         let mut s = if buf.len() == 4 {
@@ -107,7 +198,9 @@ pub fn key_handle(key: char) {
                         }
                     }
                 };
-                print_fmt(format_args!("{}", BS_KEY.to_string().repeat(n)));
+                for _ in 0..n {
+                    print_fmt(format_args!("{}", BS_KEY));
+                }
             }
         }
     } else {
@@ -116,8 +209,7 @@ pub fn key_handle(key: char) {
         } else {
             key
         };
-        stdin.push(key);
-        if is_echo_enabled() {
+        if stdin.push(key).is_ok() && is_echo_enabled() {
             match key {
                 ETX_KEY => print_fmt(format_args!("^C")),
                 EOT_KEY => print_fmt(format_args!("^D")),
@@ -161,14 +253,15 @@ pub fn read_char() -> char {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 pub fn read_line() -> String {
     loop {
         sys::x86::hlt();
         let res = int::without_interrupts(|| {
             let mut stdin = STDIN.lock();
-            match stdin.chars().next_back() {
+            match stdin.last() {
                 Some('\n') => {
-                    let line = stdin.clone();
+                    let line = stdin.to_string();
                     stdin.clear();
                     Some(line)
                 }

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -268,3 +268,43 @@ pub fn print_fmt(args: fmt::Arguments) {
         sys::serial::print_fmt(args);
     }
 }
+
+#[test_case]
+fn test_console_with_short_input() {
+    drain();
+    disable_echo();
+    let msg = "Hello, World!\n";
+    for c in msg.chars() {
+        key_handle(c);
+    }
+    enable_echo();
+    assert_eq!(read_line(), msg);
+}
+
+#[test_case]
+fn test_console_with_long_input() {
+    drain();
+    disable_echo();
+    let msg = "h".repeat(MAX_INPUT * 2);
+    for c in msg.chars() {
+        key_handle(c);
+    }
+    key_handle('\n');
+    enable_echo();
+    assert_eq!(STDIN.lock().len(), MAX_INPUT);
+    assert_eq!(STDIN.lock().back(), Some('\n'));
+    assert_eq!(read_line().len(), MAX_INPUT);
+}
+
+#[test_case]
+fn test_console_with_backspace() {
+    drain();
+    disable_echo();
+    for c in "abc".chars() {
+        key_handle(c);
+    }
+    key_handle(BS_KEY);
+    key_handle('\n');
+    enable_echo();
+    assert_eq!(read_line(), "ab\n");
+}

--- a/src/sys/console.rs
+++ b/src/sys/console.rs
@@ -83,14 +83,7 @@ impl Input {
     }
 
     pub fn contains(&self, c: char) -> bool {
-        let mut i = 0;
-        while i < self.len {
-            if self.buf[i] == c {
-                return true;
-            }
-            i += 1;
-        }
-        false
+        self.buf[..self.len].contains(&c)
     }
 }
 

--- a/src/sys/idt.rs
+++ b/src/sys/idt.rs
@@ -1,5 +1,4 @@
-use crate::{api, hang, sys};
-use crate::api::process::ExitCode;
+use crate::{hang, sys};
 use crate::sys::gdt;
 use crate::sys::pic;
 use crate::sys::tss;
@@ -68,8 +67,11 @@ impl InterruptDescriptorTable {
             table[pic::vector(14)].set_handler(irq14_handler as _);
             table[pic::vector(15)].set_handler(irq15_handler as _);
 
-            table[0x80].set_handler(sys::syscall::handler as _);
-            table[0x80].set_privilege_level(3);
+            #[cfg(target_arch = "x86_64")]
+            {
+                table[0x80].set_handler(sys::syscall::handler as _);
+                table[0x80].set_privilege_level(3);
+            }
         }
 
         Self { table }
@@ -191,6 +193,18 @@ extern "x86-interrupt" fn double_fault_handler(
     panic!();
 }
 
+#[cfg(target_arch = "x86")]
+extern "x86-interrupt" fn page_fault_handler(
+    frame: InterruptFrame,
+    error: usize,
+) {
+    debug!("EXCEPTION: PAGE FAULT (#PF)");
+    debug!("Frame: {:#?}", frame);
+    debug!("Error: {:#X}", error);
+    panic!();
+}
+
+#[cfg(target_arch = "x86_64")]
 extern "x86-interrupt" fn page_fault_handler(
     _frame: InterruptFrame,
     error: usize,
@@ -199,6 +213,8 @@ extern "x86-interrupt" fn page_fault_handler(
     //debug!("Frame: {:#?}", frame);
     //debug!("Error: {:#X}", error);
 
+    use crate::api;
+    use crate::api::process::ExitCode;
     let csi_color = api::console::Style::color("red");
     let csi_reset = api::console::Style::reset();
     let addr = Cr2::read() as u64;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -41,7 +41,7 @@ macro_rules! log {
 #[cfg(target_arch = "x86_64")] pub mod ata;
 pub mod boot;
 #[cfg(target_arch = "x86_64")] pub mod clk;
-#[cfg(target_arch = "x86_64")] pub mod console;
+pub mod console;
 #[cfg(target_arch = "x86_64")] pub mod cpu;
 #[cfg(target_arch = "x86_64")] pub mod fs;
 pub mod gdt;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,6 +5,15 @@ macro_rules! printk {
     });
 }
 
+// TODO: Remove this
+#[cfg(target_arch = "x86")]
+macro_rules! debug {
+    ($($arg:tt)*) => ({
+        $crate::sys::console::print_fmt(format_args!($($arg)*));
+    });
+}
+
+#[cfg(target_arch = "x86_64")]
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => ({
@@ -45,7 +54,7 @@ pub mod console;
 #[cfg(target_arch = "x86_64")] pub mod cpu;
 #[cfg(target_arch = "x86_64")] pub mod fs;
 pub mod gdt;
-#[cfg(target_arch = "x86_64")] pub mod idt;
+pub mod idt;
 #[cfg(target_arch = "x86_64")] pub mod keyboard;
 #[cfg(target_arch = "x86_64")] pub mod log;
 #[cfg(target_arch = "x86_64")] pub mod mem;

--- a/src/sys/serial.rs
+++ b/src/sys/serial.rs
@@ -20,7 +20,7 @@ pub struct Serial {
 impl Serial {
     fn new(addr: u16) -> Self {
         Self {
-            port: unsafe { SerialPort::new(addr) },
+            port: unsafe { SerialPort::new(addr) }
         }
     }
 
@@ -51,7 +51,6 @@ impl fmt::Write for Serial {
 // Source: https://vt100.net/emu/dec_ansi_parser
 impl Perform for Serial {
     fn csi_dispatch(&mut self, params: &Params, _: &[u8], _: bool, c: char) {
-        #[cfg(target_arch = "x86_64")]
         match c {
             'h' => { // Enable
                 for param in params.iter() {
@@ -74,7 +73,6 @@ impl Perform for Serial {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
 fn interrupt_handler() {
     let b = SERIAL.lock().read_byte();
     if b == 0xFF { // Ignore invalid bytes

--- a/src/sys/serial.rs
+++ b/src/sys/serial.rs
@@ -88,8 +88,6 @@ fn interrupt_handler() {
 
 pub fn init() {
     SERIAL.lock().init();
-
-    #[cfg(target_arch = "x86_64")]
     sys::idt::set_irq_handler(sys::pic::COM_IRQ, interrupt_handler);
 }
 

--- a/src/sys/vga/writer.rs
+++ b/src/sys/vga/writer.rs
@@ -170,12 +170,10 @@ impl Writer {
     }
 
     fn disable_echo(&self) {
-        #[cfg(target_arch = "x86_64")]
         sys::console::disable_echo();
     }
 
     fn enable_echo(&self) {
-        #[cfg(target_arch = "x86_64")]
         sys::console::enable_echo();
     }
 


### PR DESCRIPTION
A `String` was used for `STDIN` which required an allocator quite early in the boot process, this PR replaces it with a fixed buffer with a special slot at the end for the newline char.