### PR TITLE
Add hex module to api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add hex module to api (#913)
 - Enable more modules on i686 (#911)
 - Enable keyboard on i686 (#910)
 - Enable cpuid on i686 (#909)

--- a/src/api/hex.rs
+++ b/src/api/hex.rs
@@ -1,0 +1,43 @@
+use super::console::Style;
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+pub fn format_hex(buf: &[u8]) -> String {
+    format_hex_at(buf, 0)
+}
+
+pub fn format_hex_at(buf: &[u8], offset: usize) -> String {
+    let null = 0 as char;
+    let cyan = Style::color("aqua");
+    let gray = Style::color("gray");
+    let pink = Style::color("fushia");
+    let reset = Style::reset();
+
+    let mut res = String::new();
+    for (index, chunk) in buf.chunks(16).enumerate() {
+        let addr = offset + index * 16;
+
+        let hex = chunk.chunks(2).map(|pair|
+            pair.iter().map(|byte|
+                format!("{:02X}", byte)
+            ).collect::<Vec<String>>().join("")
+        ).collect::<Vec<String>>().join(" ");
+
+        let ascii: String = chunk.iter().map(|byte|
+            if *byte >= 32 && *byte <= 126 {
+                *byte as char
+            } else {
+                null
+            }
+        ).collect();
+
+        let text = ascii.replace(null, &format!("{}.{}", gray, reset));
+
+        res.push_str(&format!(
+            "{}{:08X}: {}{:40}{}{}\n", cyan, addr, pink, hex, reset, text
+        ));
+    }
+    res
+}

--- a/src/api/hex.rs
+++ b/src/api/hex.rs
@@ -3,41 +3,53 @@ use super::console::Style;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::fmt;
 
-pub fn format_hex(buf: &[u8]) -> String {
+pub struct HexDump<'a> {
+    buf: &'a [u8],
+    offset: usize,
+}
+
+pub fn format_hex(buf: &[u8]) -> HexDump<'_> {
     format_hex_at(buf, 0)
 }
 
-pub fn format_hex_at(buf: &[u8], offset: usize) -> String {
-    let null = 0 as char;
-    let cyan = Style::color("aqua");
-    let gray = Style::color("gray");
-    let pink = Style::color("fushia");
-    let reset = Style::reset();
+pub fn format_hex_at(buf: &[u8], offset: usize) -> HexDump<'_> {
+    HexDump { buf, offset }
+}
 
-    let mut res = String::new();
-    for (index, chunk) in buf.chunks(16).enumerate() {
-        let addr = offset + index * 16;
+impl fmt::Display for HexDump<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let null = 0 as char;
+        let cyan = Style::color("aqua");
+        let gray = Style::color("gray");
+        let pink = Style::color("fushia");
+        let reset = Style::reset();
 
-        let hex = chunk.chunks(2).map(|pair|
-            pair.iter().map(|byte|
-                format!("{:02X}", byte)
-            ).collect::<Vec<String>>().join("")
-        ).collect::<Vec<String>>().join(" ");
+        for (index, chunk) in self.buf.chunks(16).enumerate() {
+            let addr = self.offset + index * 16;
 
-        let ascii: String = chunk.iter().map(|byte|
-            if *byte >= 32 && *byte <= 126 {
-                *byte as char
-            } else {
-                null
-            }
-        ).collect();
+            let hex = chunk.chunks(2).map(|pair|
+                pair.iter().map(|byte|
+                    format!("{:02X}", byte)
+                ).collect::<Vec<String>>().join("")
+            ).collect::<Vec<String>>().join(" ");
 
-        let text = ascii.replace(null, &format!("{}.{}", gray, reset));
+            let ascii: String = chunk.iter().map(|byte|
+                if *byte >= 32 && *byte <= 126 {
+                    *byte as char
+                } else {
+                    null
+                }
+            ).collect();
 
-        res.push_str(&format!(
-            "{}{:08X}: {}{:40}{}{}\n", cyan, addr, pink, hex, reset, text
-        ));
+            let text = ascii.replace(null, &format!("{}.{}", gray, reset));
+            write!(
+                f, "{}{:08X}: {}{:40}{}{}\n",
+                cyan, addr, pink, hex, reset, text
+            )?;
+        }
+
+        Ok(())
     }
-    res
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -94,6 +94,7 @@ pub mod clock;
 pub mod console;
 pub mod font;
 #[cfg(target_arch = "x86_64")] pub mod fs;
+pub mod hex;
 pub mod ini;
 #[cfg(target_arch = "x86_64")] pub mod io;
 #[cfg(target_arch = "x86_64")] pub mod power;

--- a/src/sys/net/mod.rs
+++ b/src/sys/net/mod.rs
@@ -5,7 +5,7 @@ pub mod mac;
 pub mod stat;
 pub mod socket;
 
-use crate::{sys, usr};
+use crate::{api, sys};
 use crate::sys::pci::DeviceConfig;
 
 use alloc::format;
@@ -111,7 +111,7 @@ impl<'a> smoltcp::phy::Device for EthernetDevice {
         if let Some(buffer) = self.receive_packet() {
             if self.config().is_debug_enabled() {
                 debug!("NET Packet Received");
-                usr::hex::print_hex(&buffer);
+                printk!("{}", api::hex::format_hex(&buffer));
             }
             self.stats().rx_add(buffer.len() as u64);
             let rx = RxToken { buffer };
@@ -163,7 +163,7 @@ impl smoltcp::phy::TxToken for TxToken {
         let res = f(buf);
         if config.is_debug_enabled() {
             debug!("NET Packet Transmitted");
-            usr::hex::print_hex(buf);
+            printk!("{}", api::hex::format_hex(buf));
         }
         self.device.transmit_packet(len);
         self.device.stats().tx_add(len as u64);

--- a/src/usr/elf.rs
+++ b/src/usr/elf.rs
@@ -1,8 +1,8 @@
 use crate::api::console::Style;
 use crate::api::fs;
+use crate::api::hex;
 use crate::api::process::ExitCode;
 
-use crate::usr;
 use object::{Object, ObjectSection};
 
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
@@ -36,7 +36,7 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
                         color, name, reset, addr, size, align
                     );
                     if let Ok(data) = section.data() {
-                        usr::hex::print_hex_at(data, addr);
+                        print!("{}", hex::format_hex_at(data, addr));
                     }
                 }
             }

--- a/src/usr/hex.rs
+++ b/src/usr/hex.rs
@@ -1,10 +1,7 @@
 use crate::api::console::Style;
 use crate::api::fs;
+use crate::api::hex;
 use crate::api::process::ExitCode;
-
-use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
 
 // TODO: add `--skip` and `--length` params
 pub fn main(args: &[&str]) -> Result<(), ExitCode> {
@@ -19,46 +16,11 @@ pub fn main(args: &[&str]) -> Result<(), ExitCode> {
     let pathname = args[1];
     if let Ok(buf) = fs::read_to_bytes(pathname) {
         // TODO: read chunks
-        print_hex(&buf);
+        print!("{}", hex::format_hex(&buf));
         Ok(())
     } else {
         error!("Could not read file {:?}", pathname);
         Err(ExitCode::Failure)
-    }
-}
-
-// TODO: move this to api::hex::print_hex
-pub fn print_hex(buf: &[u8]) {
-    print_hex_at(buf, 0)
-}
-
-pub fn print_hex_at(buf: &[u8], offset: usize) {
-    let null = 0 as char;
-    let cyan = Style::color("aqua");
-    let gray = Style::color("gray");
-    let pink = Style::color("fushia");
-    let reset = Style::reset();
-
-    for (index, chunk) in buf.chunks(16).enumerate() {
-        let addr = offset + index * 16;
-
-        let hex = chunk.chunks(2).map(|pair|
-            pair.iter().map(|byte|
-                format!("{:02X}", byte)
-            ).collect::<Vec<String>>().join("")
-        ).collect::<Vec<String>>().join(" ");
-
-        let ascii: String = chunk.iter().map(|byte|
-            if *byte >= 32 && *byte <= 126 {
-                *byte as char
-            } else {
-                null
-            }
-        ).collect();
-
-        let text = ascii.replace(null, &format!("{}.{}", gray, reset));
-
-        println!("{}{:08X}: {}{:40}{}{}", cyan, addr, pink, hex, reset, text);
     }
 }
 

--- a/src/usr/host.rs
+++ b/src/usr/host.rs
@@ -166,7 +166,7 @@ pub fn resolve(name: &str) -> Result<IpAddress, ResponseCode> {
                 let message = Message::from(&data);
                 if message.id() == query.id() && message.is_response() {
                     syscall::close(handle);
-                    //usr::hex::print_hex(&message.datagram);
+                    //print!("{}", api::hex::format_hex(&message.datagram));
                     return match message.code() {
                         ResponseCode::NoError => {
                             // TODO: Parse the datagram instead of extracting


### PR DESCRIPTION
The `sys` module was using `usr::hex::print_hex`, now both will use `api::hex::format_hex`.